### PR TITLE
fix: enricher.Instance() returns nil instead of e if e is not initialized

### DIFF
--- a/pkg/enricher/enricher.go
+++ b/pkg/enricher/enricher.go
@@ -18,8 +18,9 @@ import (
 )
 
 var (
-	e    *Enricher
-	once sync.Once
+	e           *Enricher
+	once        sync.Once
+	initialized bool
 )
 
 type Enricher struct {
@@ -50,7 +51,7 @@ func New(ctx context.Context, cache cache.CacheInterface) *Enricher {
 			Reader:     container.NewRingReader(ir, ir.OldestWrite()),
 			outputRing: container.NewRing(container.Capacity1023),
 		}
-		e.init()
+		initialized = true
 	})
 
 	return e
@@ -60,8 +61,8 @@ func Instance() *Enricher {
 	return e
 }
 
-func (e *Enricher) init() {
-	// todo
+func IsInitialized() bool {
+	return initialized
 }
 
 func (e *Enricher) Run() {

--- a/pkg/plugin/dns/dns_linux.go
+++ b/pkg/plugin/dns/dns_linux.go
@@ -67,9 +67,10 @@ func (d *dns) Init() error {
 
 func (d *dns) Start(ctx context.Context) error {
 	if d.cfg.EnablePodLevel {
-		d.enricher = enricher.Instance()
-		if d.enricher == nil {
-			d.l.Warn("Failed to get enricher instance")
+		if enricher.IsInitialized() {
+			d.enricher = enricher.Instance()
+		} else {
+			d.l.Warn("retina enricher is not initialized")
 		}
 	}
 	if err := d.tracer.Attach(d.pid); err != nil {

--- a/pkg/plugin/dropreason/dropreason_linux.go
+++ b/pkg/plugin/dropreason/dropreason_linux.go
@@ -250,10 +250,11 @@ func (dr *dropReason) Start(ctx context.Context) error {
 		dr.recordsChannel = make(chan perf.Record, buffer)
 
 		dr.l.Info("setting up enricher since pod level is enabled")
-		// Setup enricher.
-		dr.enricher = enricher.Instance()
-		if dr.enricher == nil {
-			dr.l.Warn("Retina enricher is nil")
+		// Set up enricher.
+		if enricher.IsInitialized() {
+			dr.enricher = enricher.Instance()
+		} else {
+			dr.l.Warn("retina enricher is not initialized")
 		}
 	} else {
 		dr.l.Info("will not set up enricher since pod level is disabled")

--- a/pkg/plugin/packetparser/packetparser_linux.go
+++ b/pkg/plugin/packetparser/packetparser_linux.go
@@ -190,11 +190,11 @@ func (p *packetParser) Start(ctx context.Context) error {
 	p.l.Info("Starting packet parser")
 
 	p.l.Info("setting up enricher since pod level is enabled")
-	// Setup enricher.
-	p.enricher = enricher.Instance()
-	if p.enricher == nil {
-		p.l.Warn("Retina enricher is nil")
-		// return errors.New("enricher is nil")
+	// Set up enricher.
+	if enricher.IsInitialized() {
+		p.enricher = enricher.Instance()
+	} else {
+		p.l.Warn("retina enricher is not initialized")
 	}
 
 	// Get Pubsub instance.

--- a/pkg/plugin/tcpretrans/tcpretrans_linux.go
+++ b/pkg/plugin/tcpretrans/tcpretrans_linux.go
@@ -19,7 +19,6 @@ import (
 	"github.com/microsoft/retina/pkg/log"
 	"github.com/microsoft/retina/pkg/plugin/api"
 	"github.com/microsoft/retina/pkg/utils"
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
 )
@@ -66,10 +65,12 @@ func (t *tcpretrans) Start(ctx context.Context) error {
 		t.l.Warn("tcpretrans will not start because pod level is disabled")
 		return nil
 	}
-	t.enricher = enricher.Instance()
-	if t.enricher == nil {
-		t.l.Error("Failed to get enricher instance")
-		return errors.New("failed to get enricher instance")
+	// Set up enricher
+	if enricher.IsInitialized() {
+		t.enricher = enricher.Instance()
+	} else {
+		t.l.Error(errEnricherNotInitialized.Error())
+		return errEnricherNotInitialized
 	}
 	t.gadgetCtx = gadgetcontext.New(ctx, "tcpretrans", nil, nil, nil, nil, nil, nil, nil, nil, 0, nil)
 

--- a/pkg/plugin/tcpretrans/types_linux.go
+++ b/pkg/plugin/tcpretrans/types_linux.go
@@ -3,6 +3,8 @@
 package tcpretrans
 
 import (
+	"errors"
+
 	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/tcpretrans/tracer"
 	kcfg "github.com/microsoft/retina/pkg/config"
@@ -22,3 +24,5 @@ type tcpretrans struct {
 	gadgetCtx *gadgetcontext.GadgetContext
 	enricher  enricher.EnricherInterface
 }
+
+var errEnricherNotInitialized = errors.New("enricher not initialized")


### PR DESCRIPTION
Even if the enricher is not intialized, assigning `enricher.Instance() = nil` to the plugin's enricher interface will not result in `p.enricher == nil` equals to true. This is because in Go, an interface holding a nil value is not nil [ref ](https://glucn.medium.com/golang-an-interface-holding-a-nil-value-is-not-nil-bb151f472cc7#:~:text=Under%20the%20hood%2C%20an%20interface,type%20and%20value%20are%20nil.&text=This%20code%20will%20always%20print%20%E2%80%9CERROR%E2%80%9D.). We should not be checking for nil interface with this method.