### PR TITLE
fix: remove metric labels

### DIFF
--- a/pkg/module/metrics/dns.go
+++ b/pkg/module/metrics/dns.go
@@ -55,7 +55,7 @@ func (d *DNSMetrics) Init(metricName string) {
 			exporter.AdvancedRegistry,
 			DNSRequestCountName,
 			DNSRequestCountDesc,
-			d.getLabels()...,
+			d.getReqLabels()...,
 		)
 	case utils.DNSResponseCounterName:
 		d.dnsMetrics = exporter.CreatePrometheusCounterVecForMetric(
@@ -65,6 +65,21 @@ func (d *DNSMetrics) Init(metricName string) {
 			d.getLabels()...,
 		)
 	}
+}
+
+func (d *DNSMetrics) getReqLabels() []string {
+	labels := utils.DNSReqLabels
+	if d.srcCtx != nil {
+		labels = append(labels, d.srcCtx.getLabels()...)
+		d.l.Info("src labels", zap.Any("labels", labels))
+	}
+
+	if d.dstCtx != nil {
+		labels = append(labels, d.dstCtx.getLabels()...)
+		d.l.Info("dst labels", zap.Any("labels", labels))
+	}
+
+	return labels
 }
 
 func (d *DNSMetrics) getLabels() []string {

--- a/pkg/module/metrics/latency.go
+++ b/pkg/module/metrics/latency.go
@@ -107,7 +107,6 @@ func NewLatencyMetrics(ctxOptions *api.MetricsContextOptions, fl *log.ZapLogger,
 			exporter.AdvancedRegistry,
 			noResponseFromNodeAPIServerName,
 			noResponseFromNodeAPIServerDesc,
-			"count",
 		)
 	}
 
@@ -125,10 +124,10 @@ func (lm *LatencyMetrics) Init(metricName string) {
 		if reason == ttlcache.EvictionReasonExpired {
 			// Didn't get the corresponding packet.
 			lm.l.Debug("Evicted item", zap.Any("item", item))
-			if lm.noResponseMetric != nil {
-				lm.noResponseMetric.WithLabelValues("no_response").Inc()
-				lm.l.Debug("Incremented no response metric", zap.Any("metric", lm.noResponseMetric))
-			}
+			// if lm.noResponseMetric != nil {
+			// 	lm.noResponseMetric.WithLabelValues("no_response").Inc()
+			// 	lm.l.Debug("Incremented no response metric", zap.Any("metric", lm.noResponseMetric))
+			// }
 		}
 	})
 

--- a/pkg/module/metrics/latency_test.go
+++ b/pkg/module/metrics/latency_test.go
@@ -111,7 +111,7 @@ func TestProcessFlow(t *testing.T) {
 	// Test No response metric.
 	c := prometheus.NewCounter(prometheus.CounterOpts{})
 	mNoResponse := metrics.NewMockICounterVec(ctrl)
-	mNoResponse.EXPECT().WithLabelValues("no_response").Return(c).Times(1)
+	// mNoResponse.EXPECT().WithLabelValues("no_response").Return(c).Times(1)
 	lm.noResponseMetric = mNoResponse
 
 	t1 := time.Now().UnixNano()
@@ -156,7 +156,7 @@ func TestProcessFlow(t *testing.T) {
 	// Sleep for TTL.
 	time.Sleep(1 * time.Second)
 	// Check dropped packet.
-	assert.Equal(t, value(c), float64(1), "Expected no response metric to be 1")
+	assert.Equal(t, value(c), float64(0), "Expected no response metric to be 0")
 
 	// Stop.
 	lm.Clean()

--- a/pkg/utils/attr_utils.go
+++ b/pkg/utils/attr_utils.go
@@ -81,7 +81,8 @@ var (
 	Windows   = "windows"
 
 	// DNS labels.
-	DNSLabels = []string{"return_code", "query_type", "query", "response", "num_response"}
+	DNSLabels    = []string{"return_code", "query_type", "query", "response", "num_response"}
+	DNSReqLabels = []string{"query_type", "query"}
 )
 
 func GetPluginEventAttributes(attrs []attribute.KeyValue, pluginName, eventName, timestamp string) []attribute.KeyValue {


### PR DESCRIPTION
Remove labels for dns and apiserver latency

Related issue #75 