### PR TITLE
#98 issue: Update latency.go

### DIFF
--- a/pkg/module/metrics/latency.go
+++ b/pkg/module/metrics/latency.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/cilium/cilium/api/v1/flow"
-	v1 "github.com/cilium/cilium/api/v1/flow"
 	ttlcache "github.com/jellydator/ttlcache/v3"
 	api "github.com/microsoft/retina/crd/api/v1alpha1"
 	"github.com/microsoft/retina/pkg/common"


### PR DESCRIPTION
refactor: Removed duplicate import of flow library

This commit removes the duplicate import statement for the flow library from
"retina\pkg\module\metrics\latency.go". Having duplicate imports can lead to
confusion and potential issues with code maintenance. By removing the duplicate
import, we ensure a cleaner and more maintainable codebase.

Signed-off-by: Mitesh Jalan <mjalan269@gmail.com>
