### PR TITLE
fix: drop dependency on remove kubectl-retina job

### DIFF
--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -2,8 +2,8 @@ name: Release Retina Container Images
 
 on:
   push:
-    branches: [ main ]
-    tags: [ "v*" ]
+    branches: [main]
+    tags: ["v*"]
 
 permissions:
   contents: read
@@ -64,7 +64,7 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-        
+
       - name: Log in to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
 
@@ -98,7 +98,7 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-        
+
       - name: Log in to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
 
@@ -115,11 +115,11 @@ jobs:
   manifests:
     name: Generate Manifests
     runs-on: ubuntu-latest
-    needs: [retina-images, retina-win-images, operator-images, kubectl-retina-images]
+    needs: [retina-images, retina-win-images, operator-images]
 
     strategy:
       matrix:
-        component: ["retina", "operator", "kubectl-retina"]
+        component: ["retina", "operator"]
 
     steps:
       - name: Checkout code
@@ -127,7 +127,7 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-        
+
       - name: Log in to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
 


### PR DESCRIPTION
The kubectl-retina job was removed in #112. Remove the dependency on it from the manifests job so that images may be published.