### PR TITLE
fix(enricher): Streamline the pipeline to send flows from plugins to enricher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ RETINA_DIR = $(REPO_ROOT)/controller
 KUBECTL_RETINA_BUILD_DIR = $(OUTPUT_DIR)/kubectl-retina
 OPERATOR_DIR=$(REPO_ROOT)/operator
 CAPTURE_WORKLOAD_DIR = $(REPO_ROOT)/captureworkload
+COVER_PKG ?= .
+
 
 KIND = /usr/local/bin/kind
 KIND_CLUSTER = retina-cluster
@@ -329,6 +331,7 @@ manifest:
 # Make sure the layer has only one directory.
 # the test DockerFile needs to build the scratch stage with all the output files 
 # and we will untar the archive and copy the files from scratch stage
+.PHONY: test-image
 test-image: ## build the retina container image for testing.
 	$(MAKE) container-docker \
 			PLATFORM=$(PLATFORM) \
@@ -338,12 +341,12 @@ test-image: ## build the retina container image for testing.
 			CONTEXT_DIR=$(REPO_ROOT) \
 			TAG=$(RETINA_PLATFORM_TAG)
 
-COVER_PKG ?= .
-
+.PHONY: test
 test: $(ENVTEST) # Run unit tests.
 	go build -o test-summary ./test/utsummary/main.go
 	CGO_ENABLED=0 KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use -p path)" go test -tags=unit -skip=TestE2E* -coverprofile=coverage.out -v -json ./... | ./test-summary --progress --verbose
 
+.PHONY: test-e2e
 coverage: # Code coverage.
 #	go generate ./... && go test -tags=unit -coverprofile=coverage.out.tmp ./...
 	cat coverage.out | grep -v "_bpf.go\|_bpfel_x86.go\|_bpfel_arm64.go|_generated.go|mock_" | grep -v mock > coveragenew.out

--- a/Makefile
+++ b/Makefile
@@ -346,7 +346,7 @@ test: $(ENVTEST) # Run unit tests.
 	go build -o test-summary ./test/utsummary/main.go
 	CGO_ENABLED=0 KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use -p path)" go test -tags=unit -skip=TestE2E* -coverprofile=coverage.out -v -json ./... | ./test-summary --progress --verbose
 
-.PHONY: test-e2e
+.PHONY: coverage
 coverage: # Code coverage.
 #	go generate ./... && go test -tags=unit -coverprofile=coverage.out.tmp ./...
 	cat coverage.out | grep -v "_bpf.go\|_bpfel_x86.go\|_bpfel_arm64.go|_generated.go|mock_" | grep -v mock > coveragenew.out

--- a/pkg/managers/controllermanager/controllermanager.go
+++ b/pkg/managers/controllermanager/controllermanager.go
@@ -25,9 +25,10 @@ import (
 )
 
 const (
-	ResyncTime     time.Duration = 5 * time.Minute
-	errFailedTrack               = "Failed to create track instance"
+	ResyncTime time.Duration = 5 * time.Minute
 )
+
+var errFailedTrack = errors.New("failed to create track instance")
 
 type Controller struct {
 	l             *log.ZapLogger
@@ -99,7 +100,7 @@ func (m *Controller) Init(ctx context.Context) error {
 		// create track instance
 		m.t = track.New()
 		if m.t == nil {
-			return errors.New(errFailedTrack)
+			return errFailedTrack
 		}
 		// Setup with plugins.
 		m.pluginManager.SetupChannel(m.t.Channel())

--- a/pkg/plugin/dns/dns_linux.go
+++ b/pkg/plugin/dns/dns_linux.go
@@ -17,7 +17,6 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/dns/types"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/utils/host"
 	kcfg "github.com/microsoft/retina/pkg/config"
-	"github.com/microsoft/retina/pkg/enricher"
 	"github.com/microsoft/retina/pkg/log"
 	"github.com/microsoft/retina/pkg/metrics"
 	"github.com/microsoft/retina/pkg/plugin/api"
@@ -66,13 +65,6 @@ func (d *dns) Init() error {
 }
 
 func (d *dns) Start(ctx context.Context) error {
-	if d.cfg.EnablePodLevel {
-		if enricher.IsInitialized() {
-			d.enricher = enricher.Instance()
-		} else {
-			d.l.Warn("retina enricher is not initialized")
-		}
-	}
 	if err := d.tracer.Attach(d.pid); err != nil {
 		d.l.Error("Failed to attach tracer", zap.Error(err))
 		return err
@@ -139,9 +131,6 @@ func (d *dns) eventHandler(event *types.Event) {
 		Event:     f,
 		Timestamp: f.Time,
 	})
-	if d.enricher != nil {
-		d.enricher.Write(ev)
-	}
 
 	// Send event to external channel.
 	if d.externalChannel != nil {

--- a/pkg/plugin/dns/dns_linux_test.go
+++ b/pkg/plugin/dns/dns_linux_test.go
@@ -204,7 +204,6 @@ func TestResponseEventHandler(t *testing.T) {
 	case <-time.After(3 * time.Second):
 		t.Fatal("Timeout waiting for event")
 	}
-
 }
 
 func value(c prometheus.Counter) float64 {

--- a/pkg/plugin/dns/types_linux.go
+++ b/pkg/plugin/dns/types_linux.go
@@ -5,7 +5,6 @@ package dns
 import (
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 	kcfg "github.com/microsoft/retina/pkg/config"
-	"github.com/microsoft/retina/pkg/enricher"
 	"github.com/microsoft/retina/pkg/log"
 	"github.com/microsoft/retina/pkg/metrics"
 	"github.com/microsoft/retina/pkg/plugin/api"
@@ -23,6 +22,5 @@ type dns struct {
 	l               *log.ZapLogger
 	tracer          common.ITracer
 	pid             uint32
-	enricher        enricher.EnricherInterface
 	externalChannel chan *v1.Event
 }

--- a/pkg/plugin/dropreason/dropreason_linux_test.go
+++ b/pkg/plugin/dropreason/dropreason_linux_test.go
@@ -304,18 +304,25 @@ func TestDropReasonReadData_WithEmptyPerfArray(t *testing.T) {
 		reader:         mockedPerfReader,
 	}
 
-	// Create a context with a short timeout for testing purposes
-	_, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	// Create a context for testing purposes.
+	deadline, _ := t.Deadline()
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
 	defer cancel()
 
+	done := make(chan struct{})
 	// Start the drop reason routine in a goroutine
 	go func() {
 		err := dr.readEventArrayData()
 		assert.Nil(t, err, "Expected error but got nil")
+		done <- struct{}{}
 	}()
 
 	// Wait for a short period of time for the routine to start
-	time.Sleep(2 * time.Second)
+	select {
+	case <-ctx.Done():
+		t.Fatalf("Timed out waiting for test to finish")
+	case <-done:
+	}
 }
 
 func TestDropReasonReadData_WithPerfArrayLostSamples(t *testing.T) {
@@ -344,18 +351,26 @@ func TestDropReasonReadData_WithPerfArrayLostSamples(t *testing.T) {
 
 	metrics.InitializeMetrics()
 
-	// Create a  with a short timeout for testing purposes
-	_, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	// Create a context for testing purposes.
+	deadline, _ := t.Deadline()
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
 	defer cancel()
 
+	done := make(chan struct{})
 	// Start the drop reason routine in a goroutine
 	go func() {
 		err := dr.readEventArrayData()
 		assert.Nil(t, err, "Expected error but got nil")
+		done <- struct{}{}
 	}()
 
 	// Wait for a short period of time for the routine to start
-	time.Sleep(2 * time.Second)
+	select {
+	case <-ctx.Done():
+		t.Fatalf("Timed out waiting for test to finish")
+	case <-done:
+	}
+
 }
 
 func TestDropReasonReadData_WithUnknownError(t *testing.T) {
@@ -388,14 +403,23 @@ func TestDropReasonReadData_WithUnknownError(t *testing.T) {
 
 	metrics.InitializeMetrics()
 
+	deadline, _ := t.Deadline()
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	defer cancel()
+
+	done := make(chan struct{})
 	// Start the drop reason routine in a goroutine
 	go func() {
 		err := dr.readEventArrayData()
 		assert.NotNil(t, err, "Expected error but got nil")
+		done <- struct{}{}
 	}()
 
-	// Wait for a short period of time for the routine to start
-	time.Sleep(2 * time.Second)
+	select {
+	case <-ctx.Done():
+		t.Fatalf("Timed out waiting for test to finish")
+	case <-done:
+	}
 }
 
 func TestDropReasonGenerate(t *testing.T) {

--- a/pkg/plugin/dropreason/dropreason_linux_test.go
+++ b/pkg/plugin/dropreason/dropreason_linux_test.go
@@ -370,7 +370,6 @@ func TestDropReasonReadData_WithPerfArrayLostSamples(t *testing.T) {
 		t.Fatalf("Timed out waiting for test to finish")
 	case <-done:
 	}
-
 }
 
 func TestDropReasonReadData_WithUnknownError(t *testing.T) {

--- a/pkg/plugin/dropreason/types_linux.go
+++ b/pkg/plugin/dropreason/types_linux.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/perf"
 	kcfg "github.com/microsoft/retina/pkg/config"
-	"github.com/microsoft/retina/pkg/enricher"
 	"github.com/microsoft/retina/pkg/log"
 	"github.com/microsoft/retina/pkg/metrics"
 	"github.com/microsoft/retina/pkg/plugin/api"
@@ -45,7 +44,6 @@ type dropReason struct {
 	metricsMapData         IMap
 	isRunning              bool
 	reader                 IPerfReader
-	enricher               enricher.EnricherInterface
 	recordsChannel         chan perf.Record
 	wg                     sync.WaitGroup
 	externalChannel        chan *hubblev1.Event

--- a/pkg/plugin/packetparser/packetparser_linux.go
+++ b/pkg/plugin/packetparser/packetparser_linux.go
@@ -23,7 +23,6 @@ import (
 	helper "github.com/florianl/go-tc/core"
 	"github.com/microsoft/retina/pkg/common"
 	kcfg "github.com/microsoft/retina/pkg/config"
-	"github.com/microsoft/retina/pkg/enricher"
 	"github.com/microsoft/retina/pkg/loader"
 	"github.com/microsoft/retina/pkg/log"
 	"github.com/microsoft/retina/pkg/metrics"
@@ -188,14 +187,6 @@ func (p *packetParser) Start(ctx context.Context) error {
 	}
 
 	p.l.Info("Starting packet parser")
-
-	p.l.Info("setting up enricher since pod level is enabled")
-	// Set up enricher.
-	if enricher.IsInitialized() {
-		p.enricher = enricher.Instance()
-	} else {
-		p.l.Warn("retina enricher is not initialized")
-	}
 
 	// Get Pubsub instance.
 	ps := pubsub.New()
@@ -563,13 +554,9 @@ func (p *packetParser) processRecord(ctx context.Context, id int) {
 
 			p.l.Debug("Received packet", zap.Any("flow", fl))
 
-			// Write the event to the enricher.
 			ev := &v1.Event{
 				Event:     fl,
 				Timestamp: fl.Time,
-			}
-			if p.enricher != nil {
-				p.enricher.Write(ev)
 			}
 
 			// Write the event to the external channel.

--- a/pkg/plugin/packetparser/packetparser_linux_test.go
+++ b/pkg/plugin/packetparser/packetparser_linux_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/florianl/go-tc"
 	"github.com/golang/mock/gomock"
 	kcfg "github.com/microsoft/retina/pkg/config"
-	"github.com/microsoft/retina/pkg/enricher"
 	"github.com/microsoft/retina/pkg/log"
 	"github.com/microsoft/retina/pkg/metrics"
 	"github.com/microsoft/retina/pkg/plugin/packetparser/mocks"
@@ -277,9 +276,6 @@ func TestReadData_Error(t *testing.T) {
 	mperf := mocks.NewMockIPerf(ctrl)
 	mperf.EXPECT().Read().Return(perf.Record{}, errors.New("error")).AnyTimes()
 
-	menricher := enricher.NewMockEnricherInterface(ctrl) //nolint:typecheck
-	menricher.EXPECT().Write(gomock.Any()).Times(0)
-
 	p := &packetParser{
 		cfg:    cfgPodLevelEnabled,
 		l:      log.Logger().Named("test"),
@@ -316,14 +312,10 @@ func TestReadDataPodLevelEnabled(t *testing.T) {
 	mperf := mocks.NewMockIPerf(ctrl)
 	mperf.EXPECT().Read().Return(record, nil).MinTimes(1)
 
-	menricher := enricher.NewMockEnricherInterface(ctrl) //nolint:typecheck
-	menricher.EXPECT().Write(gomock.Any()).MinTimes(1)
-
 	p := &packetParser{
 		cfg:            cfgPodLevelEnabled,
 		l:              log.Logger().Named("test"),
 		reader:         mperf,
-		enricher:       menricher,
 		recordsChannel: make(chan perf.Record, buffer),
 	}
 

--- a/pkg/plugin/packetparser/types_linux.go
+++ b/pkg/plugin/packetparser/types_linux.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/perf"
 	tc "github.com/florianl/go-tc"
-	"github.com/microsoft/retina/pkg/enricher"
 	"github.com/microsoft/retina/pkg/log"
 	"github.com/microsoft/retina/pkg/plugin/api"
 	"github.com/vishvananda/netlink"
@@ -92,9 +91,8 @@ type packetParser struct {
 	callbackID string
 	objs       *packetparserObjects //nolint:typecheck
 	// tcMap is a map of key to *val.
-	tcMap    *sync.Map
-	reader   IPerf
-	enricher enricher.EnricherInterface
+	tcMap  *sync.Map
+	reader IPerf
 	// interfaceLockMap is a map of key to *sync.Mutex.
 	interfaceLockMap    *sync.Map
 	endpointIngressInfo *ebpf.ProgramInfo

--- a/pkg/plugin/tcpretrans/tcpretrans_linux.go
+++ b/pkg/plugin/tcpretrans/tcpretrans_linux.go
@@ -15,7 +15,6 @@ import (
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/tcpretrans/tracer"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/tcpretrans/types"
 	kcfg "github.com/microsoft/retina/pkg/config"
-	"github.com/microsoft/retina/pkg/enricher"
 	"github.com/microsoft/retina/pkg/log"
 	"github.com/microsoft/retina/pkg/plugin/api"
 	"github.com/microsoft/retina/pkg/utils"
@@ -64,13 +63,6 @@ func (t *tcpretrans) Start(ctx context.Context) error {
 	if !t.cfg.EnablePodLevel {
 		t.l.Warn("tcpretrans will not start because pod level is disabled")
 		return nil
-	}
-	// Set up enricher
-	if enricher.IsInitialized() {
-		t.enricher = enricher.Instance()
-	} else {
-		t.l.Error(errEnricherNotInitialized.Error())
-		return errEnricherNotInitialized
 	}
 	t.gadgetCtx = gadgetcontext.New(ctx, "tcpretrans", nil, nil, nil, nil, nil, nil, nil, nil, 0, nil)
 
@@ -133,12 +125,6 @@ func (t *tcpretrans) eventHandler(event *types.Event) {
 	// This is only for development purposes.
 	// Removing this makes logs way too chatter-y.
 	// dr.l.Debug("DropReason Packet Received", zap.Any("flow", fl), zap.Any("Raw Bpf Event", bpfEvent), zap.Uint32("drop type", bpfEvent.Key.DropType))
-
-	// Write the event to the enricher.
-	t.enricher.Write(&v1.Event{
-		Event:     fl,
-		Timestamp: fl.Time,
-	})
 }
 
 func getTcpFlags(flags string) (syn, ack, fin, rst, psh, urg uint16) {

--- a/pkg/plugin/tcpretrans/types_linux.go
+++ b/pkg/plugin/tcpretrans/types_linux.go
@@ -8,7 +8,6 @@ import (
 	gadgetcontext "github.com/inspektor-gadget/inspektor-gadget/pkg/gadget-context"
 	"github.com/inspektor-gadget/inspektor-gadget/pkg/gadgets/trace/tcpretrans/tracer"
 	kcfg "github.com/microsoft/retina/pkg/config"
-	"github.com/microsoft/retina/pkg/enricher"
 	"github.com/microsoft/retina/pkg/log"
 	"github.com/microsoft/retina/pkg/plugin/api"
 )
@@ -22,7 +21,6 @@ type tcpretrans struct {
 	l         *log.ZapLogger
 	tracer    *tracer.Tracer
 	gadgetCtx *gadgetcontext.GadgetContext
-	enricher  enricher.EnricherInterface
 }
 
 var errEnricherNotInitialized = errors.New("enricher not initialized")

--- a/pkg/track/events.go
+++ b/pkg/track/events.go
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package track
+
+import (
+	"context"
+	"sync"
+
+	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
+	"github.com/microsoft/retina/pkg/enricher"
+	"github.com/microsoft/retina/pkg/log"
+)
+
+type Track struct {
+	ctx             context.Context
+	cancel          context.CancelFunc
+	externalChannel chan *v1.Event
+	l               *log.ZapLogger
+	eh              enricher.EnricherInterface
+}
+
+const (
+	DefaultExternalChannelSize = 1000
+)
+
+var (
+	once sync.Once
+	t    *Track
+)
+
+func New() *Track {
+	once.Do(func() {
+		var e *enricher.Enricher
+		if e = enricher.Instance(); e == nil {
+			// Should never happen, but log it just in case.
+			t.l.Error("enricher instance not found, track is useless")
+			return
+		}
+
+		t = &Track{
+			externalChannel: make(chan *v1.Event, DefaultExternalChannelSize),
+			l:               log.Logger().Named("track-events"),
+			eh:              e,
+		}
+	})
+	return t
+}
+
+// Allow invoker to connect the channel to a source of events.
+func (t *Track) Channel() chan *v1.Event {
+	return t.externalChannel
+}
+
+// Start is a blocking function that listens for events on the external channel.
+func (t *Track) Start(ctx context.Context) {
+	t.l.Info("Started tracking events")
+	t.ctx, t.cancel = context.WithCancel(ctx)
+	for {
+		select {
+		case <-t.ctx.Done():
+			t.l.Info("context cancelled, stopping track")
+			return
+		case ev := <-t.externalChannel:
+			t.eh.Write(ev) // Write to the enricher's input ring.
+		}
+	}
+}
+
+func (t *Track) Stop() {
+	t.cancel()
+	close(t.externalChannel)
+	t.l.Info("Stopped tracking events")
+}

--- a/pkg/track/events.go
+++ b/pkg/track/events.go
@@ -12,8 +12,9 @@ import (
 	"github.com/microsoft/retina/pkg/log"
 )
 
+// Track is a singleton that listens for events on an external channel and writes them to the enricher.
+// There could be more actions, besides writing to the enricher, that could be added in the future.
 type Track struct {
-	ctx             context.Context
 	cancel          context.CancelFunc
 	externalChannel chan *v1.Event
 	l               *log.ZapLogger
@@ -55,10 +56,10 @@ func (t *Track) Channel() chan *v1.Event {
 // Start is a blocking function that listens for events on the external channel.
 func (t *Track) Start(ctx context.Context) {
 	t.l.Info("Started tracking events")
-	t.ctx, t.cancel = context.WithCancel(ctx)
+	_, t.cancel = context.WithCancel(ctx)
 	for {
 		select {
-		case <-t.ctx.Done():
+		case <-ctx.Done():
 			t.l.Info("context cancelled, stopping track")
 			return
 		case ev := <-t.externalChannel:


### PR DESCRIPTION
## Description

Currently we have to many ways to extract out the events from plugins, and each plugin is responsible to init/check/send the data to enricher. Instead, setup a tracker module to "track" events generated and decide what to do with it. Currently, we simply forward to enricher.

## Testing done:

- Enabled in local context mode
- Can observe TCP, DNS and Drop advanced metrics
-  Basic mode works as expected
- Unit tests passing