### PR TITLE
chore: package kubectl retina as tar.gz (zip for windows) via goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,8 +26,7 @@ builds:
     main: cli/main.go
 
 archives:
-  - format: tar.gz
-    name_template: "{{ .Binary }}_{{ .Version }}"
+  - name_template: "{{ .Binary }}-v{{ .Version }}"
     wrap_in_directory: false
     format_overrides:
     - goos: windows

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,9 +26,12 @@ builds:
     main: cli/main.go
 
 archives:
-  - format: binary
+  - format: tar.gz
     name_template: "{{ .Binary }}_{{ .Version }}"
     wrap_in_directory: false
+    format_overrides:
+    - goos: windows
+      format: zip
 
 changelog:
   sort: asc


### PR DESCRIPTION
Publishing plugins to Krew requires the plugins to be packaged as `.zip` or `.tar.gz` archives. 

Sample release: https://github.com/nddq/retina/releases/tag/v0.0.3