### PR TITLE
chore: package kubectl retina as tar.gz (zip for windows) via goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,9 +26,11 @@ builds:
     main: cli/main.go
 
 archives:
-  - format: binary
-    name_template: "{{ .Binary }}_{{ .Version }}"
+  - name_template: "{{ .Binary }}-v{{ .Version }}"
     wrap_in_directory: false
+    format_overrides:
+    - goos: windows
+      format: zip
 
 changelog:
   sort: asc


### PR DESCRIPTION
Publishing plugins to Krew requires the plugins to be packaged as .zip or .tar.gz archives.