### PR TITLE
feat: publish charts as OCI artifacts to GHCR

### DIFF
--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -1,0 +1,33 @@
+name: Release Retina Charts
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  push-retina-charts:
+    name: Publish Retina Helm Charts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v4.1.0
+        id: install
+
+      - name: Log in to registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u $ --password-stdin
+
+      - name: Build/Push Chart
+        shell: bash
+        run: |
+          set -euo pipefail
+          export TAG=$(make version)
+          helm package ./deploy/manifests/controller/helm/retina --version $TAG
+          helm push retina-*.tgz oci://ghcr.io/${{ github.repository }}/charts

--- a/deploy/manifests/controller/helm/retina/Chart.yaml
+++ b/deploy/manifests/controller/helm/retina/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: retina
-description: A Helm chart for retina Kubernetes with dependencies
+description: A Helm chart for microsoft/retina
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.0"
+appVersion: "0.0.1"

--- a/deploy/manifests/controller/helm/retina/values.yaml
+++ b/deploy/manifests/controller/helm/retina/values.yaml
@@ -10,7 +10,7 @@ os:
 operator:
   enabled: false
   repository: ghcr.io/microsoft/retina/retina-operator
-  tag: "v0.0.1-pre.1"
+  tag: "v0.0.1"
   installCRDs: true
   enableRetinaEndpoint: false
   capture:
@@ -22,7 +22,7 @@ image:
   initRepository: ghcr.io/microsoft/retina/retina-init
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.0.1-pre.1"
+  tag: "v0.0.1"
 
 enablePodLevel: false
 remoteContext: false


### PR DESCRIPTION
Publishes the helm chart to `ghcr.io/<repo>/charts/<chart>:<tag>` on tag.

Sample run: https://github.com/rbtr/retina/actions/runs/8396910644/job/22999286123#step:5:9
Published artifact: https://github.com/rbtr/retina/pkgs/container/retina%2Fcharts%2Fretina/194747724?tag=v0.0.2

fixes #107