### PR TITLE
chore: update GHA workflows

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,8 +7,8 @@ updates:
     reviewers:
       - "microsoft/retina"
     commit-message:
-      prefix: "ci"
-    labels: [ "ci", "dependencies" ]
+      prefix: "deps"
+    labels: ["area/infra", "area/dependencies"]
     open-pull-requests-limit: 10
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -17,8 +17,8 @@ updates:
     reviewers:
       - "microsoft/retina"
     commit-message:
-      prefix: "ci"
-    labels: [ "ci", "dependencies" ]
+      prefix: "deps"
+    labels: ["area/infra", "area/dependencies"]
     open-pull-requests-limit: 10
   - package-ecosystem: "gomod"
     directory: "/"
@@ -28,6 +28,17 @@ updates:
       - "microsoft/retina"
     commit-message:
       prefix: "deps"
+    labels: ["lang/go", "area/dependencies"]
     ignore:
       - dependency-name: "github.com/inspektor-gadget/inspektor-gadget"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "gomod"
+    directory: "/hack/tools"
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "microsoft/retina"
+    commit-message:
+      prefix: "deps"
+    labels: ["lang/go", "area/infra", "area/dependencies"]
     open-pull-requests-limit: 10

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,8 +1,8 @@
-name: 'Stale PR and Issue Handler'
+name: "Stale PR and Issue Handler"
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
 
 jobs:
   stale:
@@ -16,14 +16,15 @@ jobs:
         id: stale
         with:
           ascending: true
-          close-issue-message: 'Issue closed due to inactivity.'
-          close-pr-message: 'Pull request closed due to inactivity.'
+          close-issue-message: "Issue closed due to inactivity."
+          close-pr-message: "Pull request closed due to inactivity."
           days-before-close: 7
-          days-before-stale: 14
+          days-before-stale: 7
           delete-branch: true
-          exempt-issue-labels: 'exempt-stale'
+          stale-issue-label: "meta/waiting-for-author"
+          stale-pr-labels: "meta/waiting-for-author"
           operations-per-run: 100
-          stale-issue-message: 'This issue is stale because it has been open for 2 weeks with no activity. Remove stale label or comment or this will be closed in 7 days'
-          stale-pr-message: 'This pull request is stale because it has been open for 2 weeks with no activity. Remove stale label or comment or this will be closed in 7 days'
+          stale-issue-message: "This issue is stale because it has been open for 7 days with no activity. Remove stale label or comment or this will be closed in 7 days"
+          stale-pr-message: "This pull request is stale because it has been open for 7 days with no activity. Remove stale label or comment or this will be closed in 7 days"
       - name: Print outputs
         run: echo ${{ join(steps.stale.outputs.*, ',') }}


### PR DESCRIPTION
- updates dependabot to use new labels and adds the tools submodule to its tracking
- updates stale workflow to use new labels and shortens the stale timer to 7 days, with 7 additional days to close