### PR TITLE
feat(helm): add podmonitor

### DIFF
--- a/deploy/manifests/controller/helm/retina/templates/daemonset.yaml
+++ b/deploy/manifests/controller/helm/retina/templates/daemonset.yaml
@@ -58,7 +58,8 @@ spec:
           {{- end}}
           {{- end}}
           ports:
-          - containerPort: {{ .Values.retinaPort }}
+          - name: retina
+            containerPort: {{ .Values.retinaPort }}
           resources:
             limits:
               memory: {{ .Values.resources.limits.memory | quote }}
@@ -152,7 +153,8 @@ spec:
         - name: retinawin
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           ports:
-            - containerPort: {{ .Values.retinaPort }}
+          - name: retina
+            containerPort: {{ .Values.retinaPort }}
           command:
             - powershell.exe
             - -command

--- a/deploy/manifests/controller/helm/retina/templates/podmonitor.yaml
+++ b/deploy/manifests/controller/helm/retina/templates/podmonitor.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.metrics.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ include "retina.fullname" . }}
+  namespace: {{ ternary .Values.metrics.podMonitor.namespace .Values.namespace (not (empty .Values.metrics.podMonitor.namespace)) }}
+  labels:
+    k8s-app: {{ include "retina.name" . }}
+    {{- if .Values.metrics.podMonitor.additionalLabels }}
+    {{- .Values.metrics.podMonitor.additionalLabels | nindent 4 }}
+    {{- end }}
+spec:
+  podMetricsEndpoints:
+    - port: retina
+      path: /metrics
+      {{- if .Values.metrics.podMonitor.interval }}
+      interval: {{ .Values.metrics.podMonitor.interval }}
+      {{- end }}
+      {{- if .Values.metrics.podMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ .Values.metrics.podMonitor.scrapeTimeout }}
+      {{- end }}
+      {{- if .Values.metrics.podMonitor.scheme }}
+      scheme: {{ .Values.metrics.podMonitor.scheme }}
+      {{- end }}
+      {{- if .Values.metrics.podMonitor.tlsConfig }}
+      tlsConfig: {{- .Values.metrics.podMonitor.tlsConfig | nindent 8 }}
+      {{- end }}
+      {{- if .Values.metrics.podMonitor.relabelings }}
+      relabelings: 
+      {{- .Values.metrics.podMonitor.relabelings | nindent 8 }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Values.namespace }}
+  selector:
+    matchLabels:
+      app: {{ include "retina.name" . }}
+{{- end }}

--- a/deploy/manifests/controller/helm/retina/values.yaml
+++ b/deploy/manifests/controller/helm/retina/values.yaml
@@ -122,3 +122,40 @@ nodeSelector: {}
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
 tolerations: []
+
+metrics:
+  ## Prometheus Service Monitor
+  ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
+  ##
+  podMonitor:
+    ## @param metrics.podMonitor.enabled Create PodMonitor Resource for scraping metrics using PrometheusOperator
+    ##
+    enabled: false
+    ## @param metrics.podMonitor.namespace Namespace in which the PodMonitor should be created
+    ##
+    namespace: ~
+    ## @param metrics.podMonitor.interval Specify the interval at which metrics should be scraped
+    ##
+    interval: 30s
+    ## @param metrics.podMonitor.scrapeTimeout Specify the timeout after which the scrape is ended
+    ##
+    scrapeTimeout: 30s
+    ## @param metrics.podMonitor.additionalLabels [object] Additional labels that can be used so PodMonitors will be discovered by Prometheus
+    ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+    ##
+    additionalLabels: {}
+    ## @param metrics.podMonitor.scheme Scheme to use for scraping
+    ##
+    scheme: http
+    ## @param metrics.podMonitor.tlsConfig [object] TLS configuration used for scrape endpoints used by Prometheus
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#tlsconfig
+    ## e.g:
+    ## tlsConfig:
+    ##   ca:
+    ##     secret:
+    ##       name: existingSecretName
+    ##
+    tlsConfig: {}
+    ## @param metrics.podMonitor.relabelings [array] Prometheus relabeling rules
+    ##
+    relabelings: []


### PR DESCRIPTION
Add support for podMonitor in helm chart.

Testing done:
- podmonitor generated
![image](https://github.com/microsoft/retina/assets/8191198/357892cb-79eb-4355-80a8-06fb57c20d8a)

- prometheus discovered it
![image](https://github.com/microsoft/retina/assets/8191198/94f99bab-fd1f-45f2-8c2c-13aa2ba25a57)
