### PR TITLE
fix(helm): remove duplicate nodeSelector

### DIFF
--- a/deploy/manifests/controller/helm/retina/templates/daemonset.yaml
+++ b/deploy/manifests/controller/helm/retina/templates/daemonset.yaml
@@ -109,8 +109,6 @@ spec:
           path: {{ $hostPath }}
       {{ end }}
       {{- end }}
-      nodeSelector:
-        kubernetes.io/os: linux
 {{- end }}
 ---
 {{- if .Values.os.windows}}


### PR DESCRIPTION
This duplicate will lead to problems using automated CD tools like fluxCD:

`2024-03-27T14:57:44.805Z error HelmRelease/retina.retina - Reconciler error Helm install failed: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:
  line 119: mapping key "nodeSelector" already defined at line 27`