### PR TITLE
feat: cache Go's build artifacts in dockerfiles

### DIFF
--- a/controller/Dockerfile.controller
+++ b/controller/Dockerfile.controller
@@ -35,11 +35,10 @@ ARG VERSION
 # Set this if you want to enable Application Insights telemetry.
 ARG APP_INSIGHTS_ID
 
-RUN go build -v -o /go/bin/retina/controller -ldflags "-X main.version="$VERSION" -X "main.applicationInsightsID"="$APP_INSIGHTS_ID"" controller/main.go 
-RUN go build -v -o /go/bin/retina/captureworkload -ldflags "-X main.version="$VERSION" -X "main.applicationInsightsID"="$APP_INSIGHTS_ID"" captureworkload/main.go
+RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /go/bin/retina/controller -ldflags "-X main.version="$VERSION" -X "main.applicationInsightsID"="$APP_INSIGHTS_ID"" controller/main.go 
+RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /go/bin/retina/captureworkload -ldflags "-X main.version="$VERSION" -X "main.applicationInsightsID"="$APP_INSIGHTS_ID"" captureworkload/main.go
 # We only build initretina for linux.
-RUN go build -v -o /go/bin/retina/initretina -ldflags "-X main.version="$VERSION" -X "main.applicationInsightsID"="$APP_INSIGHTS_ID"" ././init/retina/main_linux.go
-
+RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /go/bin/retina/initretina -ldflags "-X main.version="$VERSION" -X "main.applicationInsightsID"="$APP_INSIGHTS_ID"" ././init/retina/main_linux.go
 
 # ----------------------------------------------------------------------------------- #
 

--- a/controller/Dockerfile.windows-2019
+++ b/controller/Dockerfile.windows-2019
@@ -10,8 +10,8 @@ WORKDIR /usr/src/retina
 # Copy the source
 COPY . .
 
-RUN go build -v -o /usr/bin/controller.exe -ldflags "-X main.version="$VERSION" -X "main.applicationInsightsID"="$APP_INSIGHTS_ID""  ./controller/
-RUN go build -v -o /usr/bin/captureworkload.exe ./captureworkload/
+RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /usr/bin/controller.exe -ldflags "-X main.version="$VERSION" -X "main.applicationInsightsID"="$APP_INSIGHTS_ID""  ./controller/
+RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /usr/bin/captureworkload.exe ./captureworkload/
 
 # Copy into final image
 FROM  mcr.microsoft.com/windows/servercore:ltsc2019

--- a/controller/Dockerfile.windows-2022
+++ b/controller/Dockerfile.windows-2022
@@ -11,8 +11,8 @@ WORKDIR /usr/src/retina
 # Copy the source
 COPY . .
 
-RUN go build -v -o /usr/bin/controller.exe -ldflags "-X main.version="$VERSION" -X "main.applicationInsightsID"="$APP_INSIGHTS_ID"" ./controller/
-RUN go build -v -o /usr/bin/captureworkload.exe ./captureworkload/
+RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /usr/bin/controller.exe -ldflags "-X main.version="$VERSION" -X "main.applicationInsightsID"="$APP_INSIGHTS_ID"" ./controller/
+RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /usr/bin/captureworkload.exe ./captureworkload/
 
 # Copy into final image
 FROM  mcr.microsoft.com/windows/servercore:ltsc2022

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /workspace
 COPY . .
 
 RUN make manifests
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version="$VERSION" -X "main.applicationInsightsID"="$APP_INSIGHTS_ID"" -a -o retina-operator operator/main.go
+RUN --mount=type=cache,target="/root/.cache/go-build" CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-X main.version="$VERSION" -X "main.applicationInsightsID"="$APP_INSIGHTS_ID"" -a -o retina-operator operator/main.go
 
 FROM scratch
 WORKDIR /

--- a/operator/Dockerfile.windows-2019
+++ b/operator/Dockerfile.windows-2019
@@ -11,7 +11,7 @@ WORKDIR /usr/src/retina
 # Copy the source
 COPY . .
 
-RUN go build -v  -ldflags "-X main.version="$VERSION" -X "main.applicationInsightsID"="$APP_INSIGHTS_ID"" -o -o /usr/bin/retina-operator.exe retina-operator operator/main.go
+RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -ldflags "-X main.version="$VERSION" -X "main.applicationInsightsID"="$APP_INSIGHTS_ID"" -o -o /usr/bin/retina-operator.exe retina-operator operator/main.go
 
 # Copy into final image
 FROM  mcr.microsoft.com/windows/nanoserver:ltsc2019

--- a/operator/Dockerfile.windows-2022
+++ b/operator/Dockerfile.windows-2022
@@ -11,7 +11,7 @@ WORKDIR /usr/src/retina
 # Copy the source
 COPY . .
 
-RUN go build -v  -ldflags "-X main.version="$VERSION" -X "main.applicationInsightsID"="$APP_INSIGHTS_ID"" -o -o /usr/bin/retina-operator.exe retina-operator operator/main.go
+RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -ldflags "-X main.version="$VERSION" -X "main.applicationInsightsID"="$APP_INSIGHTS_ID"" -o -o /usr/bin/retina-operator.exe retina-operator operator/main.go
 
 # Copy into final image
 FROM  mcr.microsoft.com/windows/nanoserver:ltsc2022


### PR DESCRIPTION
This update caches Go’s build artifacts, speeding up image builds and avoiding rebuilds for unchanged packages, thus streamlining development.
