### PR TITLE
feat: add container cleanup cronjob

### DIFF
--- a/.github/workflows/container-cleanup.yaml
+++ b/.github/workflows/container-cleanup.yaml
@@ -1,0 +1,33 @@
+name: Container Registry Cleanup
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # every day at midnight
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  container-cleanup:
+    name: delete-images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image:
+          - "retina/charts/retina"
+          - "retina/kubectl-retina"
+          - "retina/retina-agent"
+          - "retina/retina-init"
+          - "retina/retina-operator"
+    steps:
+      # This is a fork of the official actions/delete-package-versions which adds GHCR image tag support
+      # https://github.com/actions/delete-package-versions/pull/104
+      - uses: port-of-rotterdam-dtis/delete-package-versions@bf25fb8df311fdcbeac67ba2e5153495d76415a8
+        with:
+          package-name: ${{ matrix.image }}
+          package-type: "container"
+          min-versions-to-keep: 0
+          ignore-versions: "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(\\.*)$"
+          ignore-versions-include-tags: true

--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -2,7 +2,6 @@ name: Release Retina Charts
 
 on:
   push:
-    branches: [main]
     tags: ["v*"]
 
 permissions:
@@ -25,7 +24,7 @@ jobs:
 
       - uses: azure/setup-helm@v4.2.0
         id: install
-      
+
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3.5.0
 
@@ -33,7 +32,7 @@ jobs:
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u $ --password-stdin
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
-      
+
       - name: Build, Push and Sign chart
         id: build_chart
         shell: bash
@@ -45,4 +44,3 @@ jobs:
           helm push retina-$TAG.tgz oci://ghcr.io/${{ github.repository }}/charts >> helm_push_result.txt 2>&1
           cat helm_push_result.txt
           cosign sign --yes ghcr.io/${{ github.repository }}/charts/retina@$(tail -n 1 helm_push_result.txt | awk '{ print $2 }')
-


### PR DESCRIPTION
Prunes any non-release image tags from the container registry daily at 00:00Z.
"non-release" tags include:
- SemVer prelease such as `:v1.2.3-6f5089b0` suffixed tags
- bare commit tags such as `:6f5089b0`

"release" tags include only bare SemVer such as `:v1.2.3`, specifically matching the RegEx `"^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)$"`, and will be skipped