### PR TITLE
feat: speed up cross-platform workflows (CodeQL, golangci-lint)

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -3,45 +3,48 @@ on:
   merge_group:
   workflow_dispatch:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 jobs:
   analyze:
     name: Analyze
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        goos: [linux, windows]
+        goarch: [amd64, arm64]
         language: [go]
         go-version: ["1.21"]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     env:
       IS_NOT_MERGE_GROUP: ${{ github.event_name != 'merge_group' }}
+      GOOS: ${{ matrix.goos }}
+      GOARCH: ${{ matrix.goarch }}
     timeout-minutes: 90
     permissions:
       actions: read
       contents: read
       security-events: write
     steps:
-    - name: Setup go
-      if: env.IS_NOT_MERGE_GROUP
-      uses: actions/setup-go@v5
-      with:
-        go-version: ${{ matrix.go-version }}
-    - name: Checkout repository
-      if: env.IS_NOT_MERGE_GROUP
-      uses: actions/checkout@v4
-    - name: Initialize CodeQL
-      if: env.IS_NOT_MERGE_GROUP
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-    - name: Autobuild
-      if: env.IS_NOT_MERGE_GROUP
-      uses: github/codeql-action/autobuild@v3
-    - name: Perform CodeQL Analysis
-      if: env.IS_NOT_MERGE_GROUP
-      uses: github/codeql-action/analyze@v3
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Setup go
+        if: env.IS_NOT_MERGE_GROUP
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Checkout repository
+        if: env.IS_NOT_MERGE_GROUP
+        uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        if: env.IS_NOT_MERGE_GROUP
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+      - name: Autobuild
+        if: env.IS_NOT_MERGE_GROUP
+        uses: github/codeql-action/autobuild@v3
+      - name: Perform CodeQL Analysis
+        if: env.IS_NOT_MERGE_GROUP
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -12,11 +12,14 @@ jobs:
       fail-fast: false
       matrix:
         go-version: ["1.21.x"]
-        os: [ubuntu-latest, windows-latest]
+        goos: ["linux", "windows"]
+        goarch: ["amd64", "arm64"]
     name: Lint
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     env:
       IS_NOT_MERGE_GROUP: ${{ github.event_name != 'merge_group' }}
+      GOOS: ${{ matrix.goos }}
+      GOARCH: ${{ matrix.goarch }}
     steps:
       - uses: actions/setup-go@v5
         if: env.IS_NOT_MERGE_GROUP


### PR DESCRIPTION
# Description

Speeds up the cross-platform workflows by running them on the `ubuntu-latest` runner instead of the `windows-latest` runner. Go builds on the Windows runners are extremely slow. Instead of natively building on Windows, the cross-platform workflows will now run on the Linux runner with GOOS/GOARCH environment variables set to cross-compile.

Also brings coverage to these runners for ARM64 which was previously uncovered since GHA runners are AMD64 only for Linux/Windows.

## Related Issue

Fixes #200 