### PR TITLE
fix: removes duplicated windows metrics (#92)

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -40,12 +40,6 @@ func InitializeMetrics() {
 		utils.ForwardBytesTotalName,
 		forwardBytesTotalDescription,
 		utils.Direction)
-	WindowsCounter = exporter.CreatePrometheusGaugeVecForMetric(
-		exporter.DefaultRegistry,
-		hnsStats,
-		hnsStatsDescription,
-		utils.Direction,
-	)
 	NodeConnectivityStatusGauge = exporter.CreatePrometheusGaugeVecForMetric(
 		exporter.DefaultRegistry,
 		utils.NodeConnectivityStatusName,

--- a/pkg/metrics/types.go
+++ b/pkg/metrics/types.go
@@ -13,10 +13,6 @@ const (
 	pluginManagerFailedToReconcileCounterName = "plugin_manager_failed_to_reconcile"
 	lostEventsCounterName                     = "lost_events_counter"
 
-	// Windows
-	hnsStats            = "windows_hns_stats"
-	hnsStatsDescription = "Include many different metrics from packets sent/received to closed connections"
-
 	// Linux only metrics (for now).
 	nodeApiServerHandshakeLatencyHistName = "node_apiserver_handshake_latency_ms"
 
@@ -54,8 +50,6 @@ var (
 	DropBytesCounter    IGaugeVec
 	ForwardCounter      IGaugeVec
 	ForwardBytesCounter IGaugeVec
-
-	WindowsCounter IGaugeVec
 
 	// Common gauges across os distributions
 	NodeConnectivityStatusGauge  IGaugeVec

--- a/pkg/plugin/windows/hnsstats/hnsstats_windows.go
+++ b/pkg/plugin/windows/hnsstats/hnsstats_windows.go
@@ -159,9 +159,6 @@ func notifyHnsStats(h *hnsstats, stats *HnsStatsData) {
 	metrics.ForwardBytesCounter.WithLabelValues(ingressLabel).Set(float64(stats.hnscounters.BytesReceived))
 	h.l.Debug("emitting bytes received count metric", zap.Uint64(BytesReceived, stats.hnscounters.BytesReceived))
 
-	metrics.WindowsCounter.WithLabelValues(PacketsReceived).Set(float64(stats.hnscounters.PacketsReceived))
-	metrics.WindowsCounter.WithLabelValues(PacketsSent).Set(float64(stats.hnscounters.PacketsSent))
-
 	metrics.DropCounter.WithLabelValues(utils.Endpoint, egressLabel).Set(float64(stats.hnscounters.DroppedPacketsOutgoing))
 	metrics.DropCounter.WithLabelValues(utils.Endpoint, ingressLabel).Set(float64(stats.hnscounters.DroppedPacketsIncoming))
 


### PR DESCRIPTION
# Description

Removed the `windows_hns_stats` because they are already counted in the `forward` count.

There is no reference to the windows hns stats in the prod grafana dashboards.

## Related Issue

#92 

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`)
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

