### PR TITLE
fix: metrics module repeats unnecessary reconciliation (#233)

### DIFF
--- a/pkg/controllers/cache/cache.go
+++ b/pkg/controllers/cache/cache.go
@@ -5,6 +5,7 @@ package cache
 import (
 	"fmt"
 	"net"
+	"sort"
 	"sync"
 
 	"github.com/microsoft/retina/pkg/common"
@@ -483,5 +484,6 @@ func (c *Cache) GetAnnotatedNamespaces() []string {
 	for k := range c.nsAnnotated {
 		ns = append(ns, k)
 	}
+	sort.Strings(ns)
 	return ns
 }


### PR DESCRIPTION
# Description

Prevent namespace controller from causing unnecessary reconciliation.

## Related Issue

Namespace controller causes unnecessary reconciliation of metrics module (#233)

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Additional Notes

The elements of the namespace array returned by GetAnnotatedNamespaces() are in random order, so
If there are more than one annotated namespace, the namespace controller may call Reconcile() with a different spec than before.
