### PR TITLE
fix(#237): Use Prometheus type Counter instead of Gauge for forward module's packet and byte counters

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -30,12 +30,12 @@ func InitializeMetrics() {
 		dropBytesTotalDescription,
 		utils.Reason,
 		utils.Direction)
-	ForwardCounter = exporter.CreatePrometheusGaugeVecForMetric(
+	ForwardCounter = exporter.CreatePrometheusCounterVecForMetric(
 		exporter.DefaultRegistry,
 		utils.ForwardCountTotalName,
 		forwardCountTotalDescription,
 		utils.Direction)
-	ForwardBytesCounter = exporter.CreatePrometheusGaugeVecForMetric(
+	ForwardBytesCounter = exporter.CreatePrometheusCounterVecForMetric(
 		exporter.DefaultRegistry,
 		utils.ForwardBytesTotalName,
 		forwardBytesTotalDescription,

--- a/pkg/metrics/types.go
+++ b/pkg/metrics/types.go
@@ -53,8 +53,8 @@ var (
 	// Common counters across os distributions
 	DropCounter         IGaugeVec
 	DropBytesCounter    IGaugeVec
-	ForwardCounter      IGaugeVec
-	ForwardBytesCounter IGaugeVec
+	ForwardCounter      ICounterVec
+	ForwardBytesCounter ICounterVec
 
 	WindowsCounter IGaugeVec
 

--- a/pkg/module/metrics/forward.go
+++ b/pkg/module/metrics/forward.go
@@ -27,7 +27,7 @@ const (
 
 type ForwardMetrics struct {
 	baseMetricObject
-	forwardMetric metricsinit.IGaugeVec
+	forwardMetric metricsinit.ICounterVec
 	// bytesMetric metricsinit.IGaugeVec
 	metricName string
 }
@@ -47,13 +47,13 @@ func NewForwardCountMetrics(ctxOptions *api.MetricsContextOptions, fl *log.ZapLo
 func (f *ForwardMetrics) Init(metricName string) {
 	switch metricName {
 	case utils.ForwardCountTotalName:
-		f.forwardMetric = exporter.CreatePrometheusGaugeVecForMetric(
+		f.forwardMetric = exporter.CreatePrometheusCounterVecForMetric(
 			exporter.AdvancedRegistry,
 			TotalCountName,
 			TotalCountDesc,
 			f.getLabels()...)
 	case utils.ForwardBytesTotalName:
-		f.forwardMetric = exporter.CreatePrometheusGaugeVecForMetric(
+		f.forwardMetric = exporter.CreatePrometheusCounterVecForMetric(
 			exporter.AdvancedRegistry,
 			TotalBytesName,
 			TotalBytesDesc,

--- a/pkg/module/metrics/forward_test.go
+++ b/pkg/module/metrics/forward_test.go
@@ -290,7 +290,7 @@ func TestNewForward(t *testing.T) {
 				assert.NotNil(t, f, "forward metrics should not be nil Test Name: %s", tc.name)
 			}
 
-			forwardMock := metricsinit.NewMockIGaugeVec(ctrl) //nolint:typecheck
+			forwardMock := metricsinit.NewMockICounterVec(ctrl) //nolint:typecheck
 
 			f.forwardMetric = forwardMock
 


### PR DESCRIPTION
# Description

Replace gauges used for the forward module with counters.

## Related Issue

https://github.com/microsoft/retina/issues/237

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
