### PR TITLE
fix #239: Include protocol labels in advanced metrics

### DIFF
--- a/pkg/module/metrics/forward.go
+++ b/pkg/module/metrics/forward.go
@@ -67,6 +67,7 @@ func (f *ForwardMetrics) Init(metricName string) {
 func (f *ForwardMetrics) getLabels() []string {
 	labels := []string{
 		utils.Direction,
+		utils.Protocol,
 	}
 
 	if !f.advEnable {
@@ -114,6 +115,7 @@ func (f *ForwardMetrics) ProcessFlow(flow *v1.Flow) {
 
 	labels := []string{
 		flow.TrafficDirection.String(),
+		flow.L4.String(),
 	}
 
 	if !f.advEnable {

--- a/pkg/module/metrics/types.go
+++ b/pkg/module/metrics/types.go
@@ -161,11 +161,9 @@ func (c *ContextOptions) getLabels() []string {
 	if c.Workload {
 		labels = append(labels, prefix+workloadKindCtxOption, prefix+workloadNameCtxOption)
 	}
-
 	if c.Service {
 		labels = append(labels, prefix+serviceCtxOption)
 	}
-
 	if c.Port {
 		labels = append(labels, prefix+portCtxOption)
 	}

--- a/pkg/utils/attr_utils.go
+++ b/pkg/utils/attr_utils.go
@@ -37,6 +37,7 @@ var (
 	Type           = "type"
 	Reason         = "reason"
 	Direction      = "direction"
+	Protocol       = "protocol"
 	SourceNodeName = "source_node_name"
 	TargetNodeName = "target_node_name"
 	State          = "state"


### PR DESCRIPTION
# Description

Allow grouping time series by a complete L4 packet 5-tuple by adding a protocol label to advanced metrics.

## Related Issue

https://github.com/microsoft/retina/issues/239

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
