### PR TITLE
fix: add new site pages to nav

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ output
 
 dist/
 bin/
+
+image-metadata-*.json

--- a/site/sidebars.js
+++ b/site/sidebars.js
@@ -29,6 +29,7 @@ const sidebars = {
         'installation/grafana',
         'installation/cli',
         'installation/config',
+        'installation/verify-signed-images'
       ],
     },
     {
@@ -80,7 +81,14 @@ const sidebars = {
         'troubleshooting/basic-metrics',
       ],
     },
-    'contributing/readme',
+    {
+      type: 'category',
+      label: 'Contributing',
+      items: [
+        'contributing/readme',
+        'contributing/developing',
+      ],
+    }
   ],
 
 };


### PR DESCRIPTION
# Description

Two new documentation pages were added but aren't in the site nav so are not discoverable. Adds them to the correct sidebar navigation categories. 

Tested locally:
![image](https://github.com/microsoft/retina/assets/2940321/a000f195-91fb-4f46-ab35-97f2d70475b5)
![image](https://github.com/microsoft/retina/assets/2940321/d7109fbe-e66b-4e74-88c2-230db9f7a4d8)
