### PR TITLE
fix: fix cross-platform build image dependency package architecture i…

### DIFF
--- a/controller/Dockerfile.controller
+++ b/controller/Dockerfile.controller
@@ -2,7 +2,7 @@ ARG builderImage="ghcr.io/microsoft/retina/retina-builder:0.0.1"
 ARG toolsImage="ghcr.io/microsoft/retina/retina-tools:0.0.1"
 
 # Stage: Build binary
-FROM --platform=$TARGETPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.21 AS builder
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.21 AS builder
 LABEL Name=retina-builder Version=0.0.1
 
 RUN apt-get update &&\
@@ -44,16 +44,14 @@ RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /go/bin/ret
 
 # Stage: Prepare clang and tools
 # Bullseye -> debian11
-FROM  --platform=$TARGETPLATFORM mcr.microsoft.com/mirror/docker/library/debian:bullseye@sha256:a648e10e02af129706b1fb89e1ac9694ae3db7f2b8439aa906321e68cc281bc0 AS tools
+FROM  --platform=$BUILDPLATFORM mcr.microsoft.com/mirror/docker/library/debian:bullseye@sha256:a648e10e02af129706b1fb89e1ac9694ae3db7f2b8439aa906321e68cc281bc0 AS tools
 
 LABEL Name=retina-tools Version=0.0.1
 
 WORKDIR /tmp
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    curl xz-utils binutils wget gnupg2
-RUN apt-get install -y --no-install-recommends \
-    ca-certificates tcpdump iproute2 iptables
+    curl xz-utils binutils wget gnupg2 ca-certificates
 
 RUN mkdir -p /usr/local
 
@@ -69,16 +67,21 @@ RUN if [ "$GOARCH" = "amd64" ] ; then \
     gpg2 --verify clang+llvm.tar.xz.sig clang+llvm.tar.xz; \
     tar -C /usr/local -xJf ./clang+llvm.tar.xz --no-same-owner; \
     mv /usr/local/clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04 /usr/local/clang+llvm; \
+    dpkg --add-architecture amd64; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends tcpdump:amd64 iproute2:amd64 iptables:amd64; \
     else \
     # GOARCH=Arm64.
     # Download clang and llvm.
     # Need more dependencies for Arm64.
+    dpkg --add-architecture arm64; \
     apt-get update; \
-    apt-get install -y --no-install-recommends libc6 zlib1g libncurses5; \
+    apt-get install -y --no-install-recommends libc6:arm64 zlib1g:arm64 libncurses5:arm64; \
     apt-get install -y --no-install-recommends apt-file; \
     apt-file update; \
     apt-file find libstdc++.so.6; \
-    apt-get install -y --no-install-recommends libstdc++6; \
+    apt-get install -y --no-install-recommends libstdc++6:arm64; \
+    apt-get install -y --no-install-recommends tcpdump:arm64 iproute2:arm64 iptables:arm64; \
     # Download clang and llvm.
     wget -O clang+llvm.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.0/clang+llvm-14.0.0-aarch64-linux-gnu.tar.xz; \
     tar -C /usr/local -xJf ./clang+llvm.tar.xz --no-same-owner; \

--- a/controller/Dockerfile.controller
+++ b/controller/Dockerfile.controller
@@ -2,7 +2,7 @@ ARG builderImage="ghcr.io/microsoft/retina/retina-builder:0.0.1"
 ARG toolsImage="ghcr.io/microsoft/retina/retina-tools:0.0.1"
 
 # Stage: Build binary
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.21 AS builder
+FROM --platform=$TARGETPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.21 AS builder
 LABEL Name=retina-builder Version=0.0.1
 
 RUN apt-get update &&\
@@ -44,14 +44,16 @@ RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /go/bin/ret
 
 # Stage: Prepare clang and tools
 # Bullseye -> debian11
-FROM  --platform=$BUILDPLATFORM mcr.microsoft.com/mirror/docker/library/debian:bullseye@sha256:a648e10e02af129706b1fb89e1ac9694ae3db7f2b8439aa906321e68cc281bc0 AS tools
+FROM  --platform=$TARGETPLATFORM mcr.microsoft.com/mirror/docker/library/debian:bullseye@sha256:a648e10e02af129706b1fb89e1ac9694ae3db7f2b8439aa906321e68cc281bc0 AS tools
 
 LABEL Name=retina-tools Version=0.0.1
 
 WORKDIR /tmp
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    curl xz-utils binutils wget gnupg2 ca-certificates
+    curl xz-utils binutils wget gnupg2
+RUN apt-get install -y --no-install-recommends \
+    ca-certificates tcpdump iproute2 iptables
 
 RUN mkdir -p /usr/local
 
@@ -67,21 +69,15 @@ RUN if [ "$GOARCH" = "amd64" ] ; then \
     gpg2 --verify clang+llvm.tar.xz.sig clang+llvm.tar.xz; \
     tar -C /usr/local -xJf ./clang+llvm.tar.xz --no-same-owner; \
     mv /usr/local/clang+llvm-14.0.0-x86_64-linux-gnu-ubuntu-18.04 /usr/local/clang+llvm; \
-    dpkg --add-architecture amd64; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends tcpdump:amd64 iproute2:amd64 iptables:amd64; \
     else \
     # GOARCH=Arm64.
     # Download clang and llvm.
     # Need more dependencies for Arm64.
-    dpkg --add-architecture arm64; \
-    apt-get update; \
-    apt-get install -y --no-install-recommends libc6:arm64 zlib1g:arm64 libncurses5:arm64; \
+    apt-get install -y --no-install-recommends libc6 zlib1g libncurses5; \
     apt-get install -y --no-install-recommends apt-file; \
     apt-file update; \
     apt-file find libstdc++.so.6; \
-    apt-get install -y --no-install-recommends libstdc++6:arm64; \
-    apt-get install -y --no-install-recommends tcpdump:arm64 iproute2:arm64 iptables:arm64; \
+    apt-get install -y --no-install-recommends libstdc++6; \
     # Download clang and llvm.
     wget -O clang+llvm.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.0/clang+llvm-14.0.0-aarch64-linux-gnu.tar.xz; \
     tar -C /usr/local -xJf ./clang+llvm.tar.xz --no-same-owner; \

--- a/controller/Dockerfile.controller
+++ b/controller/Dockerfile.controller
@@ -2,7 +2,7 @@ ARG builderImage="ghcr.io/microsoft/retina/retina-builder:0.0.1"
 ARG toolsImage="ghcr.io/microsoft/retina/retina-tools:0.0.1"
 
 # Stage: Build binary
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.21 AS builder
+FROM --platform=$TARGETPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.21 AS builder
 LABEL Name=retina-builder Version=0.0.1
 
 RUN apt-get update &&\
@@ -44,7 +44,7 @@ RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /go/bin/ret
 
 # Stage: Prepare clang and tools
 # Bullseye -> debian11
-FROM  --platform=$BUILDPLATFORM mcr.microsoft.com/mirror/docker/library/debian:bullseye@sha256:a648e10e02af129706b1fb89e1ac9694ae3db7f2b8439aa906321e68cc281bc0 AS tools
+FROM  --platform=$TARGETPLATFORM mcr.microsoft.com/mirror/docker/library/debian:bullseye@sha256:a648e10e02af129706b1fb89e1ac9694ae3db7f2b8439aa906321e68cc281bc0 AS tools
 
 LABEL Name=retina-tools Version=0.0.1
 
@@ -73,13 +73,12 @@ RUN if [ "$GOARCH" = "amd64" ] ; then \
     # GOARCH=Arm64.
     # Download clang and llvm.
     # Need more dependencies for Arm64.
-    dpkg --add-architecture arm64; \
     apt-get update; \
-    apt-get install -y --no-install-recommends libc6:arm64 zlib1g:arm64 libncurses5:arm64; \
+    apt-get install -y --no-install-recommends libc6 zlib1g libncurses5; \
     apt-get install -y --no-install-recommends apt-file; \
     apt-file update; \
     apt-file find libstdc++.so.6; \
-    apt-get install -y --no-install-recommends libstdc++6:arm64; \
+    apt-get install -y --no-install-recommends libstdc++6; \
     # Download clang and llvm.
     wget -O clang+llvm.tar.xz https://github.com/llvm/llvm-project/releases/download/llvmorg-14.0.0/clang+llvm-14.0.0-aarch64-linux-gnu.tar.xz; \
     tar -C /usr/local -xJf ./clang+llvm.tar.xz --no-same-owner; \
@@ -98,7 +97,7 @@ RUN arr="tcpdump ip ss iptables-legacy iptables-legacy-save iptables-nft iptable
 # ----------------------------------------------------------------------------------- #
 
 # Stage: Base distroless init image
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/mirror/gcr/distroless/cc-debian11:latest@sha256:b53fbf5f81f4a120a489fedff2092e6fcbeacf7863fce3e45d99cc58dc230ccc as init
+FROM --platform=$TARGETPLATFORM mcr.microsoft.com/mirror/gcr/distroless/cc-debian11:latest@sha256:b53fbf5f81f4a120a489fedff2092e6fcbeacf7863fce3e45d99cc58dc230ccc as init
 LABEL Name=retina-init Version=0.0.1
 
 COPY --from=builder /go/bin/retina/initretina /retina/initretina
@@ -113,7 +112,7 @@ ENTRYPOINT ["./retina/initretina"]
 # ----------------------------------------------------------------------------------- #
 
 # Stage: Base distroless image
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/mirror/gcr/distroless/cc-debian11:latest@sha256:b53fbf5f81f4a120a489fedff2092e6fcbeacf7863fce3e45d99cc58dc230ccc as agent
+FROM --platform=$TARGETPLATFORM mcr.microsoft.com/mirror/gcr/distroless/cc-debian11:latest@sha256:b53fbf5f81f4a120a489fedff2092e6fcbeacf7863fce3e45d99cc58dc230ccc as agent
 
 LABEL Name=retina-controller Version=0.0.1
 


### PR DESCRIPTION
# Description
Fixed the issues of retina-controller startup failure caused by abnormal cross-platform build image dependency package architecture.


## Related Issue

fixes #130 

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

# Testing Done
Built amd64 and arm64 image and deployed amd64 image in K8s cluster nodes
agent pod is up and running in the nodes

