### PR TITLE
feat(helm): Improve resource configuration in chart

### DIFF
--- a/deploy/manifests/controller/helm/retina/templates/daemonset.yaml
+++ b/deploy/manifests/controller/helm/retina/templates/daemonset.yaml
@@ -61,9 +61,7 @@ spec:
           - name: retina
             containerPort: {{ .Values.retinaPort }}
           resources:
-            limits:
-              memory: {{ .Values.resources.limits.memory | quote }}
-              cpu: {{ .Values.resources.limits.cpu | quote }}
+            {{- toYaml .Values.resources | nindent 12 }}
           env:
           - name: POD_NAME
             valueFrom:

--- a/deploy/manifests/controller/helm/retina/templates/operator.yaml
+++ b/deploy/manifests/controller/helm/retina/templates/operator.yaml
@@ -75,12 +75,7 @@ spec:
             initialDelaySeconds: 5
             periodSeconds: 10
           resources:
-            limits:
-              cpu: 500m
-              memory: 128Mi
-            requests:
-              cpu: 10m
-              memory: 64Mi
+            {{- toYaml .Values.operator.resources | nindent 12 }}
       serviceAccountName: retina-operator
       terminationGracePeriodSeconds: 10
       volumes:

--- a/deploy/manifests/controller/helm/retina/values.yaml
+++ b/deploy/manifests/controller/helm/retina/values.yaml
@@ -122,7 +122,7 @@ resources:
     cpu: "500m"
   requests:
     memory: "300Mi"
-    cpu: "100m"
+    cpu: "500m"
 
 ## @param nodeSelector [object] Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/

--- a/deploy/manifests/controller/helm/retina/values.yaml
+++ b/deploy/manifests/controller/helm/retina/values.yaml
@@ -16,6 +16,13 @@ operator:
   capture:
     debug: "true"
     jobNumLimit: 0
+  resources:
+    limits:
+      cpu: 500m
+      memory: 128Mi
+    requests:
+      cpu: 10m
+      memory: 128Mi
 
 image:
   repository: ghcr.io/microsoft/retina/retina-agent
@@ -113,6 +120,9 @@ resources:
   limits:
     memory: "300Mi"
     cpu: "500m"
+  requests:
+    memory: "300Mi"
+    cpu: "100m"
 
 ## @param nodeSelector [object] Node labels for pod assignment
 ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/


### PR DESCRIPTION
# Description

Currently the resources for the retina operator are non-configurable. And the agent only has limits configurable which sets the requests at the same value. With the default cpu limit for the agent being 500m, this seems excessive for request.

I have added what I think are sane defaults, but if you think other values are appropriate let me know.

## Related Issue

N/A

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

N/A

## Additional Notes

N/A

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
