### PR TITLE
tool(grafana): test/tooling to ensure dashboards are simplified/importable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -325,7 +325,7 @@ COVER_PKG ?= .
 
 test: $(ENVTEST) # Run unit tests.
 	go build -o test-summary ./test/utsummary/main.go
-	CGO_ENABLED=0 KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use -p path)" go test -tags=unit -skip=TestE2E* -coverprofile=coverage.out -v -json ./... | ./test-summary --progress --verbose
+	CGO_ENABLED=0 KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use -p path)" go test -tags=unit,dashboard -skip=TestE2E* -coverprofile=coverage.out -v -json ./... | ./test-summary --progress --verbose
 
 coverage: # Code coverage.
 #	go generate ./... && go test -tags=unit -coverprofile=coverage.out.tmp ./...
@@ -437,3 +437,7 @@ quick-build:
 .PHONY: quick-deploy
 quick-deploy:
 	$(MAKE) helm-install-advanced-local-context HELM_IMAGE_TAG=$(TAG)-linux-amd64
+
+.PHONY: simplify-dashboards
+simplify-dashboards:
+	cd deploy/grafana/dashboards/ && go test . -tags=dashboard,simplifydashboard -v

--- a/deploy/grafana/dashboards/clusters.json
+++ b/deploy/grafana/dashboards/clusters.json
@@ -1,41 +1,41 @@
 {
-  "__inputs": [],
   "__elements": {},
+  "__inputs": [],
   "__requires": [
     {
-      "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
+      "type": "grafana",
       "version": "9.5.16"
     },
     {
-      "type": "datasource",
       "id": "prometheus",
       "name": "Prometheus",
+      "type": "datasource",
       "version": "1.0.0"
     },
     {
-      "type": "panel",
       "id": "stat",
       "name": "Stat",
+      "type": "panel",
       "version": ""
     },
     {
-      "type": "panel",
       "id": "table",
       "name": "Table",
+      "type": "panel",
       "version": ""
     },
     {
-      "type": "panel",
       "id": "text",
       "name": "Text",
+      "type": "panel",
       "version": ""
     },
     {
-      "type": "panel",
       "id": "timeseries",
       "name": "Time series",
+      "type": "panel",
       "version": ""
     }
   ],

--- a/deploy/grafana/dashboards/dns.json
+++ b/deploy/grafana/dashboards/dns.json
@@ -1,29 +1,29 @@
 {
-  "__inputs": [],
   "__elements": {},
+  "__inputs": [],
   "__requires": [
     {
-      "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
+      "type": "grafana",
       "version": "9.5.15"
     },
     {
-      "type": "datasource",
       "id": "prometheus",
       "name": "Prometheus",
+      "type": "datasource",
       "version": "1.0.0"
     },
     {
-      "type": "panel",
       "id": "table",
       "name": "Table",
+      "type": "panel",
       "version": ""
     },
     {
-      "type": "panel",
       "id": "timeseries",
       "name": "Time series",
+      "type": "panel",
       "version": ""
     }
   ],

--- a/deploy/grafana/dashboards/pod-level.json
+++ b/deploy/grafana/dashboards/pod-level.json
@@ -1,29 +1,29 @@
 {
-  "__inputs": [],
   "__elements": {},
+  "__inputs": [],
   "__requires": [
     {
-      "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
+      "type": "grafana",
       "version": "9.5.6"
     },
     {
-      "type": "panel",
       "id": "heatmap",
       "name": "Heatmap",
+      "type": "panel",
       "version": ""
     },
     {
-      "type": "datasource",
       "id": "prometheus",
       "name": "Prometheus",
+      "type": "datasource",
       "version": "1.0.0"
     },
     {
-      "type": "panel",
       "id": "timeseries",
       "name": "Time series",
+      "type": "panel",
       "version": ""
     }
   ],

--- a/deploy/grafana/dashboards/simplify-grafana-overwrite_test.go
+++ b/deploy/grafana/dashboards/simplify-grafana-overwrite_test.go
@@ -1,0 +1,28 @@
+//go:build dashboard && simplifydashboard
+
+package dashboard
+
+import (
+	"testing"
+
+	"io/ioutil"
+	"path/filepath"
+)
+
+// TestOverwriteDashboards simplifies and overwrites Grafana dashboards in this folder.
+func TestOverwriteDashboards(t *testing.T) {
+	// get all json's in this folder
+	files, err := ioutil.ReadDir("./")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, file := range files {
+		if filepath.Ext(file.Name()) == ".json" {
+			t.Logf("simplifying/overwriting dashboard: %s", file.Name())
+
+			sourcePath := file.Name()
+			_ = SimplifyGrafana(sourcePath, true)
+		}
+	}
+}

--- a/deploy/grafana/dashboards/simplify-grafana.go
+++ b/deploy/grafana/dashboards/simplify-grafana.go
@@ -1,0 +1,126 @@
+//go:build dashboard
+
+package dashboard
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"os"
+)
+
+// SimplifyGrafana parses a json file representing a Grafana dashboard and overwrites it with a simplified version.
+// It removes some unnecessary fields and changes some values so that the dashboard can be used by anyone.
+func SimplifyGrafana(filename string, overwrite bool) map[string]interface{} {
+	dashboard := ParseDashboard(filename)
+
+	// remove unnecessary top-level fields
+	delete(dashboard, "weekStart")
+	delete(dashboard, "fiscalYearStartMonth")
+	delete(dashboard, "graphTooltip")
+	delete(dashboard, "annotations")
+
+	// set empty __inputs
+	if _, ok := dashboard["__inputs"]; ok {
+		dashboard["__inputs"] = []interface{}{}
+	}
+
+	// set current variables to be empty
+	if _, ok := dashboard["templating"]; ok {
+		templating := dashboard["templating"].(map[string]interface{})
+		if _, ok := templating["list"]; ok {
+			list := templating["list"].([]interface{})
+			for _, item := range list {
+				if item, ok := item.(map[string]interface{}); ok {
+					item["current"] = map[string]interface{}{}
+				}
+			}
+		}
+	}
+
+	// remove any pluginVersion
+	removeFieldAnywhere(dashboard, "pluginVersion")
+
+	// change all datasource.uid to "${datasource}"
+	replaceDatasource(dashboard)
+
+	if !overwrite {
+		return dashboard
+	}
+
+	// overwrite the file with the simplified version
+	simplifiedData, err := JSONMarhsalIndent(dashboard, "", "  ")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = os.WriteFile(filename, simplifiedData, 0644)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return dashboard
+}
+
+func ParseDashboard(filename string) map[string]interface{} {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var dashboard map[string]interface{}
+	err = json.Unmarshal(data, &dashboard)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return dashboard
+}
+
+func removeFieldAnywhere(data map[string]interface{}, field string) {
+	if _, ok := data[field]; ok {
+		delete(data, field)
+	}
+
+	for _, value := range data {
+		if m, ok := value.(map[string]interface{}); ok {
+			removeFieldAnywhere(m, field)
+		} else if l, ok := value.([]interface{}); ok {
+			for _, item := range l {
+				if m, ok := item.(map[string]interface{}); ok {
+					removeFieldAnywhere(m, field)
+				}
+			}
+		}
+	}
+}
+
+func replaceDatasource(data map[string]interface{}) {
+	if datasource, ok := data["datasource"].(map[string]interface{}); ok {
+		if _, ok := datasource["uid"].(string); ok {
+			datasource["uid"] = "${datasource}"
+		}
+	}
+
+	for _, value := range data {
+		if m, ok := value.(map[string]interface{}); ok {
+			replaceDatasource(m)
+		} else if l, ok := value.([]interface{}); ok {
+			for _, item := range l {
+				if m, ok := item.(map[string]interface{}); ok {
+					replaceDatasource(m)
+				}
+			}
+		}
+	}
+}
+
+// JSONMarhsalIndent is json.MarshalIndent without HTML escaping (e.g. converting > to \u003e)
+func JSONMarhsalIndent(t interface{}, prefix, indent string) ([]byte, error) {
+	buffer := &bytes.Buffer{}
+	encoder := json.NewEncoder(buffer)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent(prefix, indent)
+	err := encoder.Encode(t)
+	return buffer.Bytes(), err
+}

--- a/deploy/grafana/dashboards/simplify-grafana_test.go
+++ b/deploy/grafana/dashboards/simplify-grafana_test.go
@@ -1,0 +1,35 @@
+//go:build dashboard && !simplifydashboard
+
+package dashboard
+
+import (
+	"testing"
+
+	"io/ioutil"
+	"path/filepath"
+
+	"reflect"
+)
+
+// TestDashboardsAreSimplified ensures that all dashboards are simplified
+func TestDashboardsAreSimplified(t *testing.T) {
+	// get all json's in this folder
+	files, err := ioutil.ReadDir("./")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, file := range files {
+		if filepath.Ext(file.Name()) == ".json" {
+			t.Logf("verifying that dashboard is simplified: %s", file.Name())
+
+			sourcePath := file.Name()
+			simplified := SimplifyGrafana(sourcePath, false)
+			original := ParseDashboard(sourcePath)
+
+			if !reflect.DeepEqual(simplified, original) {
+				t.Errorf("ERROR: dashboard has not been simplified. Please run: make simplify-dashboards")
+			}
+		}
+	}
+}


### PR DESCRIPTION
# Description

When it comes to JSON for Grafana dashboards, it seems best practice to remove a bunch of unnecessary pieces like the name of your personal datasource, current variable selection, etc. This PR:
1. Introduces `make simplify-dashboards` to automate this tedious process.
2. Adds a unit test to ensure authors run this command.

## Related Issue

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

### `make simplify-dashboards`
```bash
$ make simplify-dashboards 
cd deploy/grafana/dashboards/ && go test . -tags=dashboard,simplifydashboard -v
=== RUN   TestOverwriteDashboards
    simplify-grafana-overwrite_test.go:22: simplifying/overwriting dashboard: clusters.json
    simplify-grafana-overwrite_test.go:22: simplifying/overwriting dashboard: dns.json
    simplify-grafana-overwrite_test.go:22: simplifying/overwriting dashboard: pod-level.json
--- PASS: TestOverwriteDashboards (0.02s)
PASS
ok      github.com/microsoft/retina/deploy/grafana/dashboards   0.019s
```

### Unit Test to Ensure Simplification
```bash
go test . -tags=dashboard -v
=== RUN   TestDashboardsAreSimplified
    simplify-grafana_test.go:24: verifying that dashboard is simplified: clusters.json
    simplify-grafana_test.go:31: ERROR: dashboard has not been simplified. Please run: make simplify-dashboards
    simplify-grafana_test.go:24: verifying that dashboard is simplified: dns.json
    simplify-grafana_test.go:24: verifying that dashboard is simplified: pod-level.json
--- FAIL: TestDashboardsAreSimplified (0.01s)
FAIL
FAIL    github.com/microsoft/retina/deploy/grafana/dashboards   0.018s
FAIL
```

## Additional Notes
Code added in this PR is put behind the go build tag `dashboard`, so these files are not compiled in Retina binaries.