### PR TITLE
fix: set go version from mod

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -15,7 +15,6 @@ jobs:
         goos: [linux, windows]
         goarch: [amd64, arm64]
         language: [go]
-        go-version: ["1.21"]
     runs-on: ubuntu-latest
     env:
       IS_NOT_MERGE_GROUP: ${{ github.event_name != 'merge_group' }}
@@ -27,14 +26,14 @@ jobs:
       contents: read
       security-events: write
     steps:
+      - name: Checkout repository
+        if: env.IS_NOT_MERGE_GROUP
+        uses: actions/checkout@v4
       - name: Setup go
         if: env.IS_NOT_MERGE_GROUP
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
-      - name: Checkout repository
-        if: env.IS_NOT_MERGE_GROUP
-        uses: actions/checkout@v4
+          go-version-file: go.mod
       - name: Initialize CodeQL
         if: env.IS_NOT_MERGE_GROUP
         uses: github/codeql-action/init@v3

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.21.x"]
         goos: ["linux", "windows"]
         goarch: ["amd64", "arm64"]
     name: Lint
@@ -21,14 +20,14 @@ jobs:
       GOOS: ${{ matrix.goos }}
       GOARCH: ${{ matrix.goarch }}
     steps:
-      - uses: actions/setup-go@v5
-        if: env.IS_NOT_MERGE_GROUP
-        with:
-          go-version: ${{ matrix.go-version }}
       - uses: actions/checkout@v4
         if: env.IS_NOT_MERGE_GROUP
         with:
           fetch-depth: 0
+      - uses: actions/setup-go@v5
+        if: env.IS_NOT_MERGE_GROUP
+        with:
+          go-version-file: go.mod
       - name: golangci-lint
         if: env.IS_NOT_MERGE_GROUP
         uses: golangci/golangci-lint-action@v4

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: ">=1.21.0"
+          go-version-file: go.mod
       - name: Run GoReleaser build
         uses: goreleaser/goreleaser-action@v5
         with:
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: ">=1.21.0"
+          go-version-file: go.mod
       - name: Run GoReleaser release
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -1,4 +1,4 @@
-name: Build images and run E2E tests. 
+name: Build images and run E2E tests.
 
 on:
   pull_request:
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: ">=1.21.0"
+          go-version-file: go.mod
       - run: go version
 
       - name: Set up QEMU
@@ -58,7 +58,6 @@ jobs:
         env:
           IS_MERGE_GROUP: ${{ github.event_name == 'merge_group' }}
 
-
   retina-win-images:
     name: Build Agent Windows Images
     runs-on: ubuntu-latest
@@ -74,18 +73,18 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: ">=1.21.0"
+          go-version-file: go.mod
       - run: go version
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      
+
       - name: Az CLI login
         uses: azure/login@v1
         if: ${{ github.event_name == 'merge_group' }}
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
-        
+
       - name: Build Images
         shell: bash
         run: |
@@ -121,7 +120,7 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: ">=1.21.0"
+          go-version-file: go.mod
       - run: go version
 
       - name: Set up QEMU
@@ -132,7 +131,7 @@ jobs:
         if: ${{ github.event_name == 'merge_group' }}
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
-        
+
       - name: Build Images
         shell: bash
         run: |
@@ -169,7 +168,7 @@ jobs:
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v3
-      
+
       - name: Azure CLI login
         uses: azure/login@v1
         with:
@@ -182,7 +181,7 @@ jobs:
           az acr login -n ${{ vars.ACR_NAME }}  
           make manifest COMPONENT=${{ matrix.components }} \
           IMAGE_REGISTRY=${{ vars.ACR_NAME }}  \
-      
+
   e2e:
     if: ${{ github.event_name == 'merge_group' }}
     name: Run E2E Tests
@@ -200,7 +199,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v4
         with:
-          go-version: ">=1.21.0"
+          go-version-file: go.mod
       - run: go version
 
       - name: Az CLI login

--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -28,9 +28,9 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: ">=1.21.0"
+          go-version-file: go.mod
       - run: go version
-    
+
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3.5.0
 
@@ -49,7 +49,7 @@ jobs:
             IMAGE_NAMESPACE=${{ github.repository }} \
             PLATFORM=${{ matrix.platform }}/${{ matrix.arch }} \
             BUILDX_ACTION=--push
-      
+
       - name: Sign container image
         run: |
           for image in retina-agent retina-init; do
@@ -57,7 +57,6 @@ jobs:
             DIGEST=$(jq -r '.["containerimage.digest"]' image-metadata-$image-$TAG-${{ matrix.platform }}-${{ matrix.arch }}.json) 
             cosign sign --yes ${IMAGE_PATH}@${DIGEST} 
           done
-
 
   retina-win-images:
     name: Build Agent Windows Images
@@ -74,12 +73,12 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: ">=1.21.0"
+          go-version-file: go.mod
       - run: go version
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3.5.0
-      
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -121,9 +120,9 @@ jobs:
 
       - uses: actions/setup-go@v4
         with:
-          go-version: ">=1.21.0"
+          go-version-file: go.mod
       - run: go version
-    
+
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3.5.0
 
@@ -142,7 +141,7 @@ jobs:
             IMAGE_NAMESPACE=${{ github.repository }} \
             PLATFORM=${{ matrix.platform }}/${{ matrix.arch }} \
             BUILDX_ACTION=--push
-          
+
       - name: Sign container image
         run: |
           for image in retina-operator ; do
@@ -150,7 +149,6 @@ jobs:
               DIGEST=$(jq -r '.["containerimage.digest"]' image-metadata-$image-$TAG-${{ matrix.platform }}-${{ matrix.arch }}.json) 
               cosign sign --yes ${IMAGE_PATH}@${DIGEST} 
           done
-
 
   manifests:
     name: Generate Manifests
@@ -167,7 +165,7 @@ jobs:
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      
+
       - name: Install Cosign
         uses: sigstore/cosign-installer@v3.5.0
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "^1.21"
+          go-version-file: go.mod
 
       - name: Make Retina Test image
         env:


### PR DESCRIPTION
# Description

Sets the GHA `setup-go` Go version from the go.mod, instead of separately.

## Related Issue


## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
