### PR TITLE
fix: add secondary IPs for enrichment

### DIFF
--- a/pkg/common/ipaddr.go
+++ b/pkg/common/ipaddr.go
@@ -19,7 +19,7 @@ func (i *IPAddresses) AddIPv6(ip net.IP) {
 	i.OtherIPv6s = append(i.OtherIPv6s, ip)
 }
 
-func (i *IPAddresses) GetIPs() []net.IP {
+func (i *IPAddresses) GetNetIPs() []net.IP {
 	ips := []net.IP{}
 	if i.IPv4 != nil {
 		ips = append(ips, i.IPv4)
@@ -32,7 +32,24 @@ func (i *IPAddresses) GetIPs() []net.IP {
 	return ips
 }
 
-func (i *IPAddresses) GetIPv4s() []net.IP {
+func (i *IPAddresses) GetIPs() []string {
+	ips := []string{}
+	if i.IPv4 != nil {
+		ips = append(ips, i.IPv4.String())
+	}
+	if i.IPv6 != nil {
+		ips = append(ips, i.IPv6.String())
+	}
+	for _, ip := range i.OtherIPv4s {
+		ips = append(ips, ip.String())
+	}
+	for _, ip := range i.OtherIPv6s {
+		ips = append(ips, ip.String())
+	}
+	return ips
+}
+
+func (i *IPAddresses) GetNetIPv4s() []net.IP {
 	ips := []net.IP{}
 	if i.IPv4 != nil {
 		ips = append(ips, i.IPv4)
@@ -41,7 +58,7 @@ func (i *IPAddresses) GetIPv4s() []net.IP {
 	return ips
 }
 
-func (i *IPAddresses) GetIPv6s() []net.IP {
+func (i *IPAddresses) GetNetIPv6s() []net.IP {
 	ips := []net.IP{}
 	if i.IPv6 != nil {
 		ips = append(ips, i.IPv6)

--- a/pkg/controllers/cache/cache_test.go
+++ b/pkg/controllers/cache/cache_test.go
@@ -50,7 +50,8 @@ func TestCacheEndpoints(t *testing.T) {
 	assert.Error(t, err)
 
 	addEndpoints.SetIPs(&common.IPAddresses{
-		IPv4: net.IPv4(1, 2, 3, 4),
+		IPv4:       net.IPv4(1, 2, 3, 4),
+		OtherIPv4s: []net.IP{net.IPv4(1, 2, 3, 5)},
 	})
 
 	err = c.UpdateRetinaEndpoint(addEndpoints)
@@ -59,17 +60,33 @@ func TestCacheEndpoints(t *testing.T) {
 	obj := c.GetObjByIP("1.2.3.4")
 	assert.NotNil(t, obj)
 	ep := obj.(*common.RetinaEndpoint)
-	assert.Equal(t, addEndpoints.Name(), ep.Name())
-	assert.Equal(t, addEndpoints.Namespace(), ep.Namespace())
-	assert.Equal(t, addEndpoints.Labels()["app"], ep.Labels()["app"])
-	assert.Equal(t, addEndpoints.Annotations()[common.RetinaPodAnnotation], ep.Annotations()[common.RetinaPodAnnotation])
+	assert.Equal(t, ep.Name(), addEndpoints.Name())
+	assert.Equal(t, ep.Namespace(), addEndpoints.Namespace())
+	assert.Equal(t, ep.Labels()["app"], addEndpoints.Labels()["app"])
+	assert.Equal(t, ep.Annotations()[common.RetinaPodAnnotation], addEndpoints.Annotations()[common.RetinaPodAnnotation])
 
-	// normal get
+	// normal get by PrimaryIP
 	ep = c.GetPodByIP("1.2.3.4")
-	assert.Equal(t, addEndpoints.Name(), ep.Name())
-	assert.Equal(t, addEndpoints.Namespace(), ep.Namespace())
-	assert.Equal(t, addEndpoints.Labels()["app"], ep.Labels()["app"])
-	assert.Equal(t, addEndpoints.Annotations()[common.RetinaPodAnnotation], ep.Annotations()[common.RetinaPodAnnotation])
+	assert.Equal(t, ep.Name(), addEndpoints.Name())
+	assert.Equal(t, ep.Namespace(), addEndpoints.Namespace())
+	assert.Equal(t, ep.Labels()["app"], addEndpoints.Labels()["app"])
+	assert.Equal(t, ep.Annotations()[common.RetinaPodAnnotation], addEndpoints.Annotations()[common.RetinaPodAnnotation])
+
+	// get by secondary IP
+	obj = c.GetObjByIP("1.2.3.5")
+	assert.NotNil(t, obj)
+	ep = obj.(*common.RetinaEndpoint)
+	assert.Equal(t, ep.Name(), addEndpoints.Name())
+	assert.Equal(t, ep.Namespace(), addEndpoints.Namespace())
+	assert.Equal(t, ep.Labels()["app"], addEndpoints.Labels()["app"])
+	assert.Equal(t, ep.Annotations()[common.RetinaPodAnnotation], addEndpoints.Annotations()[common.RetinaPodAnnotation])
+
+	// normal get by secondary IP
+	ep = c.GetPodByIP("1.2.3.5")
+	assert.Equal(t, ep.Name(), addEndpoints.Name())
+	assert.Equal(t, ep.Namespace(), addEndpoints.Namespace())
+	assert.Equal(t, ep.Labels()["app"], addEndpoints.Labels()["app"])
+	assert.Equal(t, ep.Annotations()[common.RetinaPodAnnotation], addEndpoints.Annotations()[common.RetinaPodAnnotation])
 
 	// delete
 	err = c.DeleteRetinaEndpoint(addEndpoints.Key())


### PR DESCRIPTION
# Description

Please provide a brief description of the changes made in this pull request.

## Related Issue
Fixes #224 

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed
![image](https://github.com/microsoft/retina/assets/22489650/9a38aae1-ecd9-49fe-bfa8-4f5898aadd1f)



## Additional Notes
Both the previous implementation and this PR don't clear stale IP-endpoint bindings immediately from the ipToEpKey Map.
E.g. When endpoint A changes from IP address "1.1.1.1" to "2.2.2.2", the stale binding between the IP address "1.1.1.1" and endpoint A is still in the ipToEpKey map until the IP address "1.1.1.1" gets reassigned to another pod.
However, this shouldn't be a problem. The DNS is supposed to provide up-to-date IP addresses for the sender and receiver so that any flow event will always contain the latest IP addresses.


