### PR TITLE
chore: bump github actions version

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
       - name: Run GoReleaser build
@@ -37,7 +37,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
       - name: Run GoReleaser release

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
       - run: go version
@@ -33,7 +33,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Az CLI login
-        uses: azure/login@v1
+        uses: azure/login@v2
         if: ${{ github.event_name == 'merge_group' }}
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -71,7 +71,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
       - run: go version
@@ -80,7 +80,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Az CLI login
-        uses: azure/login@v1
+        uses: azure/login@v2
         if: ${{ github.event_name == 'merge_group' }}
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -118,7 +118,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
       - run: go version
@@ -127,7 +127,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Az CLI login
-        uses: azure/login@v1
+        uses: azure/login@v2
         if: ${{ github.event_name == 'merge_group' }}
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
@@ -170,7 +170,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Azure CLI login
-        uses: azure/login@v1
+        uses: azure/login@v2
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
 
@@ -197,13 +197,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
       - run: go version
 
       - name: Az CLI login
-        uses: azure/login@v1
+        uses: azure/login@v2
         if: ${{ github.event_name == 'merge_group' }}
         with:
           creds: ${{ secrets.AZURE_CREDENTIALS }}

--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
       - run: go version
@@ -71,7 +71,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
       - run: go version
@@ -118,7 +118,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
       - run: go version


### PR DESCRIPTION
# Description

Bumping actions/setup-go v4 -> v5 and azure/login v1 -> v2
## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
