### PR TITLE
chore: build tags for test files

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -213,4 +213,4 @@ jobs:
         run: |
           set -euo pipefail
           export AZURE_SUBSCRIPTION_ID=${{ secrets.AZURE_SUBSCRIPTION }}
-          go test -v ./test/e2e/scenarios/retina/*.go -timeout 30m -tags=e2e -count=1  -args -image-tag=$(make version) -image-registry=${{ vars.ACR_NAME }}  -image-namespace=${{ github.repository}}
+          go test -v ./test/e2e/scenarios/retina/*.go -timeout 30m -tags=e2e,e2eframework -count=1  -args -image-tag=$(make version) -image-registry=${{ vars.ACR_NAME }}  -image-namespace=${{ github.repository}}

--- a/Makefile
+++ b/Makefile
@@ -324,7 +324,7 @@ test-image: ## build the retina container image for testing.
 COVER_PKG ?= .
 
 test: $(ENVTEST) # Run unit tests.
-	go build -o test-summary ./test/utsummary/main.go
+	go build -tags=localtest -o test-summary ./test/utsummary/main.go
 	CGO_ENABLED=0 KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use -p path)" go test -tags=unit,dashboard -skip=TestE2E* -coverprofile=coverage.out -v -json ./... | ./test-summary --progress --verbose
 
 coverage: # Code coverage.

--- a/test/e2e/framework/azure/create-cluster-with-npm.go
+++ b/test/e2e/framework/azure/create-cluster-with-npm.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package azure
 
 import (

--- a/test/e2e/framework/azure/create-cluster.go
+++ b/test/e2e/framework/azure/create-cluster.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package azure
 
 import (

--- a/test/e2e/framework/azure/create-rg.go
+++ b/test/e2e/framework/azure/create-rg.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package azure
 
 import (

--- a/test/e2e/framework/azure/create-vnet.go
+++ b/test/e2e/framework/azure/create-vnet.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package azure
 
 import (

--- a/test/e2e/framework/azure/delete-cluster.go
+++ b/test/e2e/framework/azure/delete-cluster.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package azure
 
 import (

--- a/test/e2e/framework/azure/delete-rg.go
+++ b/test/e2e/framework/azure/delete-rg.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package azure
 
 import (

--- a/test/e2e/framework/azure/enable-ama.go
+++ b/test/e2e/framework/azure/enable-ama.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package azure
 
 import (

--- a/test/e2e/framework/azure/get-kubeconfig.go
+++ b/test/e2e/framework/azure/get-kubeconfig.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package azure
 
 import (

--- a/test/e2e/framework/generic/load-tag.go
+++ b/test/e2e/framework/generic/load-tag.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package generic
 
 import (

--- a/test/e2e/framework/kubernetes/create-agnhost-statefulset.go
+++ b/test/e2e/framework/kubernetes/create-agnhost-statefulset.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package kubernetes
 
 import (

--- a/test/e2e/framework/kubernetes/create-kapinger-deployment.go
+++ b/test/e2e/framework/kubernetes/create-kapinger-deployment.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package kubernetes
 
 import (

--- a/test/e2e/framework/kubernetes/create-network-policy.go
+++ b/test/e2e/framework/kubernetes/create-network-policy.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package kubernetes
 
 import (

--- a/test/e2e/framework/kubernetes/create-resource.go
+++ b/test/e2e/framework/kubernetes/create-resource.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package kubernetes
 
 import (

--- a/test/e2e/framework/kubernetes/delete-resource.go
+++ b/test/e2e/framework/kubernetes/delete-resource.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package kubernetes
 
 import (

--- a/test/e2e/framework/kubernetes/exec-pod.go
+++ b/test/e2e/framework/kubernetes/exec-pod.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package kubernetes
 
 import (

--- a/test/e2e/framework/kubernetes/get-logs.go
+++ b/test/e2e/framework/kubernetes/get-logs.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package kubernetes
 
 import (

--- a/test/e2e/framework/kubernetes/install-retina-helm.go
+++ b/test/e2e/framework/kubernetes/install-retina-helm.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package kubernetes
 
 import (

--- a/test/e2e/framework/kubernetes/port-forward.go
+++ b/test/e2e/framework/kubernetes/port-forward.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 // todo: matmerr, this is just going to remain broken until it can be validated with scenarios pr
 
 package kubernetes

--- a/test/e2e/framework/kubernetes/portforward.go
+++ b/test/e2e/framework/kubernetes/portforward.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package kubernetes
 
 import (

--- a/test/e2e/framework/kubernetes/wait-pod-ready.go
+++ b/test/e2e/framework/kubernetes/wait-pod-ready.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package kubernetes
 
 import (

--- a/test/e2e/framework/prometheus/prometheus.go
+++ b/test/e2e/framework/prometheus/prometheus.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package prom
 
 import (

--- a/test/e2e/framework/types/background_test.go
+++ b/test/e2e/framework/types/background_test.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package types
 
 import (

--- a/test/e2e/framework/types/job.go
+++ b/test/e2e/framework/types/job.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package types
 
 import (

--- a/test/e2e/framework/types/jobvalues.go
+++ b/test/e2e/framework/types/jobvalues.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package types
 
 import (

--- a/test/e2e/framework/types/runner.go
+++ b/test/e2e/framework/types/runner.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package types
 
 import (

--- a/test/e2e/framework/types/scenarios_test.go
+++ b/test/e2e/framework/types/scenarios_test.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package types
 
 import (

--- a/test/e2e/framework/types/step.go
+++ b/test/e2e/framework/types/step.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package types
 
 var DefaultOpts = StepOptions{

--- a/test/e2e/framework/types/step_sleep.go
+++ b/test/e2e/framework/types/step_sleep.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package types
 
 import (

--- a/test/e2e/framework/types/step_stop.go
+++ b/test/e2e/framework/types/step_stop.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package types
 
 import (

--- a/test/e2e/scenarios/retina/drop/scenario.go
+++ b/test/e2e/scenarios/retina/drop/scenario.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package drop
 
 import (

--- a/test/e2e/scenarios/retina/drop/validate-drop-metric.go
+++ b/test/e2e/scenarios/retina/drop/validate-drop-metric.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package drop
 
 import (

--- a/test/e2e/scenarios/retina/retina_scenarios_test.go
+++ b/test/e2e/scenarios/retina/retina_scenarios_test.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package retina
 
 import (

--- a/test/e2e/scenarios/retina/tcp/scenario.go
+++ b/test/e2e/scenarios/retina/tcp/scenario.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package flow
 
 import (

--- a/test/e2e/scenarios/retina/tcp/validate-flow-metric.go
+++ b/test/e2e/scenarios/retina/tcp/validate-flow-metric.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package flow
 
 import (

--- a/test/e2e/scenarios/retina/tcp/validate-tcp-connection-remote.go
+++ b/test/e2e/scenarios/retina/tcp/validate-tcp-connection-remote.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 package flow
 
 import (

--- a/test/enricher/main.go
+++ b/test/enricher/main.go
@@ -1,3 +1,5 @@
+//go:build localtest
+
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 // nolint

--- a/test/managers/filtermanager/main.go
+++ b/test/managers/filtermanager/main.go
@@ -1,3 +1,5 @@
+//go:build localtest
+
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 // nolint

--- a/test/plugin/dns/main_linux.go
+++ b/test/plugin/dns/main_linux.go
@@ -1,3 +1,5 @@
+//go:build localtest
+
 // Copyright 2022 The Inspektor Gadget authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/plugin/dropreason/main_linux.go
+++ b/test/plugin/dropreason/main_linux.go
@@ -1,3 +1,5 @@
+//go:build localtest
+
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 package main

--- a/test/plugin/linuxutil/main_linux.go
+++ b/test/plugin/linuxutil/main_linux.go
@@ -1,3 +1,5 @@
+//go:build localtest
+
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 package main

--- a/test/plugin/packetforward/main_linux.go
+++ b/test/plugin/packetforward/main_linux.go
@@ -1,3 +1,5 @@
+//go:build localtest
+
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 // nolint

--- a/test/plugin/packetparser/main_linux.go
+++ b/test/plugin/packetparser/main_linux.go
@@ -1,3 +1,5 @@
+//go:build localtest
+
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 // nolint

--- a/test/retry/retry.go
+++ b/test/retry/retry.go
@@ -1,3 +1,5 @@
+//go:build e2eframework
+
 // todo: there are more robust retry packages out there, discuss with team
 package retry
 

--- a/test/utsummary/main.go
+++ b/test/utsummary/main.go
@@ -1,3 +1,5 @@
+//go:build localtest
+
 // Copyright 2019 The Go Cloud Development Kit Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/watchers/apiserver/main.go
+++ b/test/watchers/apiserver/main.go
@@ -1,3 +1,5 @@
+//go:build localtest
+
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 // nolint

--- a/test/watchers/veth/main.go
+++ b/test/watchers/veth/main.go
@@ -1,3 +1,5 @@
+//go:build localtest
+
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 // nolint


### PR DESCRIPTION
# Description

Might be best practice to skip building test files unless their build tag is set. This change doesn't seem to impact _go.mod_

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.
