### PR TITLE
fix: restructure logger for persistent fields

### DIFF
--- a/controller/main.go
+++ b/controller/main.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -70,6 +71,7 @@ func init() {
 }
 
 func main() {
+	fmt.Printf("starting Retina %v", version)
 	var metricsAddr string
 	var enableLeaderElection bool
 	var probeAddr string
@@ -88,38 +90,40 @@ func main() {
 	flag.StringVar(&cfgFile, "config", configFileName, "config file")
 	flag.Parse()
 
+	fmt.Printf("loading config %s\n", cfgFile)
 	config, err := config.GetConfig(cfgFile)
 	if err != nil {
 		panic(err)
 	}
 
-	err = initLogging(config, applicationInsightsID)
-	if err != nil {
-		panic(err)
-	}
-
-	mainLogger := log.Logger().Named("main").Sugar()
-
-	mainLogger.Infof("starting Retina version: %s", version)
-	mainLogger.Info("Reading config ...")
-
-	mainLogger.Info("Initializing metrics")
 	metrics.InitializeMetrics()
 
-	mainLogger.Info("Initializing Kubernetes client-go ...")
+	fmt.Println("init client-go")
 	cfg, err := kcfg.GetConfig()
 	if err != nil {
 		panic(err)
 	}
-	additionalLoggerFields := []zap.Field{
+
+	fmt.Println("init logger")
+	zl, err := log.SetupZapLogger(&log.LogOpts{
+		Level:                 config.LogLevel,
+		File:                  false,
+		FileName:              logFileName,
+		MaxFileSizeMB:         100, //nolint:gomnd // defaults
+		MaxBackups:            3,   //nolint:gomnd // defaults
+		MaxAgeDays:            30,  //nolint:gomnd // defaults
+		ApplicationInsightsID: applicationInsightsID,
+		EnableTelemetry:       config.EnableTelemetry,
+	},
 		zap.String("version", version),
 		zap.String("apiserver", cfg.Host),
 		zap.String("plugins", strings.Join(config.EnabledPlugin, `,`)),
+	)
+	if err != nil {
+		panic(err)
 	}
-
-	// Setup the logger to log the version, apiserver and enabled plugin.
-	log.Logger().AddFields(additionalLoggerFields...)
-	mainLogger = log.Logger().Named("main").Sugar()
+	defer zl.Close()
+	mainLogger := zl.Named("main").Sugar()
 
 	var tel telemetry.Telemetry
 	if config.EnableTelemetry && applicationInsightsID != "" {
@@ -296,20 +300,4 @@ func main() {
 	}
 
 	mainLogger.Info("Network observability exiting. Till next time!")
-}
-
-func initLogging(config *config.Config, applicationInsightsID string) error {
-	logOpts := &log.LogOpts{
-		Level:                 config.LogLevel,
-		File:                  false,
-		FileName:              logFileName,
-		MaxFileSizeMB:         100,
-		MaxBackups:            3,
-		MaxAgeDays:            30,
-		ApplicationInsightsID: applicationInsightsID,
-		EnableTelemetry:       config.EnableTelemetry,
-	}
-
-	log.SetupZapLogger(logOpts)
-	return nil
 }

--- a/init/retina/main_linux.go
+++ b/init/retina/main_linux.go
@@ -32,9 +32,11 @@ func main() {
 		defer telemetry.TrackPanic()
 	}
 
-	log.SetupZapLogger(opts)
-	log.Logger().AddFields(zap.String("version", version))
-	l := log.Logger().Named("init-retina")
+	zl, err := log.SetupZapLogger(opts)
+	if err != nil {
+		panic(err)
+	}
+	l := zl.Named("init-retina").With(zap.String("version", version))
 
 	// Setup BPF
 	bpf.Setup(l)

--- a/pkg/bpf/setup_linux.go
+++ b/pkg/bpf/setup_linux.go
@@ -8,7 +8,6 @@ import (
 	"os"
 
 	"github.com/cilium/cilium/pkg/mountinfo"
-	"github.com/microsoft/retina/pkg/log"
 	plugincommon "github.com/microsoft/retina/pkg/plugin/common"
 	"github.com/microsoft/retina/pkg/plugin/filter"
 	"go.uber.org/zap"
@@ -54,7 +53,7 @@ func mountBpfFs() error {
 	return nil
 }
 
-func Setup(l *log.ZapLogger) {
+func Setup(l *zap.Logger) {
 	err := mountBpfFs()
 	if err != nil {
 		l.Panic("Failed to mount bpf filesystem", zap.Error(err))

--- a/pkg/log/zap_test.go
+++ b/pkg/log/zap_test.go
@@ -26,9 +26,9 @@ func TestLogFileRotation(t *testing.T) {
 
 	logsToPrint := 10
 	for i := 0; i < logsToPrint; i++ {
-		l.Info("test", zap.Int("i", i))
+		global.Info("test", zap.Int("i", i))
 	}
-	l.Close()
+	global.Close()
 
 	_, err := os.Stat(lOpts.FileName)
 	assert.NoError(t, err, "Test log file is not found")
@@ -40,7 +40,7 @@ func TestLogFileRotation(t *testing.T) {
 	assert.NoError(t, err, "Getwd failed with err")
 
 	err = filepath.Walk(p, func(path string, info os.FileInfo, err error) error {
-		l.Info("Filename: ", zap.String("path", path), zap.String("name", info.Name()))
+		global.Info("Filename: ", zap.String("path", path), zap.String("name", info.Name()))
 		if !info.IsDir() {
 			if strings.HasPrefix(info.Name(), "test") && strings.HasSuffix(info.Name(), ".log") {
 				curReplicas++


### PR DESCRIPTION
# Description

Refactoring to the `log` package.
Corrects persistent field support, returns error and logger from constructor, inlines log core creation and addition, removes unnecessary helper functions and uses zap ones directly.

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
