### PR TITLE
fix(helm): PodMonitor additional labels YAML

### DIFF
--- a/deploy/manifests/controller/helm/retina/templates/podmonitor.yaml
+++ b/deploy/manifests/controller/helm/retina/templates/podmonitor.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     k8s-app: {{ include "retina.name" . }}
     {{- if .Values.metrics.podMonitor.additionalLabels }}
-    {{- .Values.metrics.podMonitor.additionalLabels | nindent 4 }}
+    {{- toYaml .Values.metrics.podMonitor.additionalLabels | nindent 4 }}
     {{- end }}
 spec:
   podMetricsEndpoints:


### PR DESCRIPTION
# Description

Error during Helm templating if we pass some additional labels to the PodMonitor resources

## Related Issue



## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Before:
```
$ helm template . -f values.yaml --set metrics.podMonitor.enabled=true --set metrics.podMonitor.additionalLabels"foo"=bar
Error: template: retina/templates/podmonitor.yaml:10:62: executing "retina/templates/podmonitor.yaml" at <4>: wrong type for value; expected string; got map[string]interface {}
```

After:
```
$ helm template . -f values.yaml --set metrics.podMonitor.enabled=true --set metrics.podMonitor.additionalLabels"foo"=bar
---
# Source: retina/templates/podmonitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: PodMonitor
metadata:
  name: retina-svc
  namespace: kube-system
  labels:
    k8s-app: retina
    foo: bar
spec:
  podMetricsEndpoints:
    - port: retina
      path: /metrics
      interval: 30s
      scrapeTimeout: 30s
      scheme: http
  namespaceSelector:
    matchNames:
      - kube-system
  selector:
    matchLabels:
      app: retina
```

## Additional Notes


---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
