### PR TITLE
feat(helm): Refactoring Kubernetes recommended labels

### DIFF
--- a/deploy/manifests/controller/helm/retina/templates/_helpers.tpl
+++ b/deploy/manifests/controller/helm/retina/templates/_helpers.tpl
@@ -40,6 +40,7 @@ helm.sh/chart: {{ include "retina.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: retina
 {{- end }}
 
 {{/*

--- a/deploy/manifests/controller/helm/retina/templates/configmap.yaml
+++ b/deploy/manifests/controller/helm/retina/templates/configmap.yaml
@@ -2,6 +2,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  labels:
+    {{- include "retina.labels" . | nindent 4 }}
+    app.kubernetes.io/component: config
+    k8s-app: {{ include "retina.name" . }}
   name: {{ include "retina.name" . }}-config
   namespace: {{ .Values.namespace }}
 data:
@@ -22,6 +26,10 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  labels:
+    {{- include "retina.labels" . | nindent 4 }}
+    app.kubernetes.io/component: config
+    k8s-app: {{ include "retina.name" . }}
   name: {{ include "retina.name" . }}-config-win
   namespace: {{ .Values.namespace }}
 data:

--- a/deploy/manifests/controller/helm/retina/templates/daemonset.yaml
+++ b/deploy/manifests/controller/helm/retina/templates/daemonset.yaml
@@ -5,15 +5,19 @@ metadata:
   name: {{ .Values.agent.name }}
   namespace: {{ .Values.namespace }}
   labels:
+    {{- include "retina.labels" . | nindent 4 }}
+    app.kubernetes.io/component: workload
     k8s-app: {{ include "retina.name" . }}
 spec:
   selector:
     matchLabels:
-      app: {{ include "retina.name" . }}
+      {{- include "retina.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: workload
   template:
     metadata:
       labels:
-        app: {{ include "retina.name" . }}
+        {{- include "retina.labels" . | nindent 8 }}
+        app.kubernetes.io/component: workload
         k8s-app: {{ include "retina.name" . }}
       annotations:
         prometheus.io/port: "{{ .Values.retinaPort }}"
@@ -121,6 +125,8 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
+    {{- include "retina.labels" . | nindent 4 }}
+    app.kubernetes.io/component: workload
     k8s-app: {{ include "retina.name" . }}
   name: {{ .Values.agent_win.name }}
   namespace: {{ .Values.namespace }}
@@ -131,11 +137,13 @@ metadata:
 spec:
   selector:
     matchLabels:
-      k8s-app: {{ include "retina.name" . }}
+      {{- include "retina.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: workload
   template:
     metadata:
       labels:
-        app: {{ include "retina.name" . }}
+        {{- include "retina.labels" . | nindent 8 }}
+        app.kubernetes.io/component: workload
         k8s-app: {{ include "retina.name" . }}
       name: {{ include "retina.name" . }}
       namespace: {{ .Values.namespace }}

--- a/deploy/manifests/controller/helm/retina/templates/podmonitor.yaml
+++ b/deploy/manifests/controller/helm/retina/templates/podmonitor.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ ternary .Values.metrics.podMonitor.namespace .Values.namespace (not (empty .Values.metrics.podMonitor.namespace)) }}
   labels:
     k8s-app: {{ include "retina.name" . }}
+    {{- include "retina.labels" . | nindent 4 }}
+    app.kubernetes.io/component: metrics
     {{- if .Values.metrics.podMonitor.additionalLabels }}
     {{- .Values.metrics.podMonitor.additionalLabels | nindent 4 }}
     {{- end }}

--- a/deploy/manifests/controller/helm/retina/templates/rbac.yaml
+++ b/deploy/manifests/controller/helm/retina/templates/rbac.yaml
@@ -1,6 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  labels:
+    k8s-app: {{ include "retina.name" . }}
+    {{- include "retina.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
   namespace: {{ .Values.namespace }}
   name: retina-cluster-reader
 rules:
@@ -73,6 +77,10 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  labels:
+    k8s-app: {{ include "retina.name" . }}
+    {{- include "retina.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
   name: retina-cluster-reader-binding
   namespace: {{ .Values.namespace }}
 subjects:

--- a/deploy/manifests/controller/helm/retina/templates/service.yaml
+++ b/deploy/manifests/controller/helm/retina/templates/service.yaml
@@ -4,10 +4,13 @@ metadata:
   name: {{ include "retina.fullname" . }}
   namespace: {{ .Values.namespace }}
   labels:
-    app: {{ include "retina.name" . }}
+    k8s-app: {{ include "retina.name" . }}
+    {{- include "retina.labels" . | nindent 4 }}
+    app.kubernetes.io/component: networking
 spec:
   ports:
     - port: {{ .Values.service.port }}
       targetPort: {{ .Values.service.targetPort }}
   selector:
-    app: {{ include "retina.name" . }}
+    {{- include "retina.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: workload

--- a/deploy/manifests/controller/helm/retina/templates/serviceaccount.yaml
+++ b/deploy/manifests/controller/helm/retina/templates/serviceaccount.yaml
@@ -1,5 +1,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  labels:
+    {{- include "retina.labels" . | nindent 4 }}
+    app.kubernetes.io/component: rbac
+    k8s-app: {{ include "retina.name" . }}
   name: {{ .Values.serviceAccount.name }}
   namespace: {{ .Values.namespace }}


### PR DESCRIPTION
# Description

Provide [Kubernetes recommended labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/)

## Related Issue

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

<details>

```yaml
$ helm template . -f values.yaml --set metrics.podMonitor.enabled=true --set operator.enabled=true
---
# Source: retina/templates/operator.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  labels:
    app.kubernetes.io/name: serviceaccount
    app.kubernetes.io/instance: retina-operator
    app.kubernetes.io/component: rbac
    app.kubernetes.io/created-by: operator
    app.kubernetes.io/part-of: operator
    app.kubernetes.io/managed-by: kustomize
  name: retina-operator
  namespace: kube-system
---
# Source: retina/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  labels:
    helm.sh/chart: retina-0.0.1
    app.kubernetes.io/name: retina
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: retina
    app.kubernetes.io/component: rbac
    k8s-app: retina
  name: retina-agent
  namespace: kube-system
---
# Source: retina/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  labels:
    helm.sh/chart: retina-0.0.1
    app.kubernetes.io/name: retina
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: retina
    app.kubernetes.io/component: config
    k8s-app: retina
  name: retina-config
  namespace: kube-system
data:
  config.yaml: |-
    apiServer:
      host: 0.0.0.0
      port: 10093
    logLevel: debug
    enabledPlugin: ["dropreason","packetforward","linuxutil","dns"]
    metricsInterval: 10
    enableTelemetry: false
    enablePodLevel: false
    remoteContext: false
    enableAnnotations: false
---
# Source: retina/templates/configmap.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  labels:
    helm.sh/chart: retina-0.0.1
    app.kubernetes.io/name: retina
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: retina
    app.kubernetes.io/component: config
    k8s-app: retina
  name: retina-config-win
  namespace: kube-system
data:
  config.yaml: |-
    apiServer:
      host: 0.0.0.0
      port: 10093
    logLevel: debug
    enabledPlugin: ["hnsstats"]
    metricsInterval: 10
    enableTelemetry: false
    enablePodLevel: false
    remoteContext: false
---
# Source: retina/templates/operator.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: retina-operator-config
  namespace: kube-system
data:
  operator-config.yaml: |-
    installCRDs: true
    enableTelemetry: false
    remoteContext: false
    captureDebug: true
    captureJobNumLimit: 0
---
# Source: retina/templates/operator.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  creationTimestamp: null
  name: retina-operator-role
rules:
  - apiGroups: 
      - "apiextensions.k8s.io"
    resources: 
      - "customresourcedefinitions"
    verbs: 
      - "create"
      - "get"
      - "update"
      - "delete"
      - "patch"
  - apiGroups:
    - ""
    resources:
      - pods
    verbs:
      - get
      - list
      - watch
  - apiGroups:
    - ""
    resources:
      - namespaces
    verbs:
      - get
      - list
      - watch
  - apiGroups:
      - retina.sh
    resources:
      - retinaendpoints
    verbs:
      - create
      - delete
      - get
      - list
      - patch
      - update
      - watch
  - apiGroups:
      - retina.sh
    resources:
      - metricsconfigurations
    verbs:
      - create
      - delete
      - get
      - list
      - patch
      - update
      - watch
  - apiGroups:
      - retina.sh
    resources:
      - metricsconfigurations/status
    verbs:
      - create
      - delete
      - get
      - list
      - patch
      - update
      - watch
  - apiGroups:
      - retina.sh
    resources:
      - retinaendpoints/finalizers
    verbs:
      - update
  - apiGroups:
      - retina.sh
    resources:
      - retinaendpoints/status
    verbs:
      - get
      - patch
      - update
  - apiGroups:
      - ""
    resources:
    - namespaces
    - pods
    - nodes
    - secrets
    verbs:
    - get
    - list
  - apiGroups:
      - batch
    resources:
    - jobs
    verbs:
    - create
    - delete
    - deletecollection
    - get
    - list
    - patch
    - update
    - watch
  - apiGroups:
      - batch
    resources:
    - jobs/status
    verbs:
    - get
  - apiGroups:
    - retina.sh
    resources:
    - captures
    verbs:
    - create
    - delete
    - get
    - list
    - patch
    - update
    - watch
  - apiGroups:
      - retina.sh
    resources:
    - captures/finalizers
    verbs:
    - update
  - apiGroups:
      - retina.sh
    resources:
    - captures/status
    verbs:
    - get
    - patch
    - update
---
# Source: retina/templates/rbac.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  labels:
    k8s-app: retina
    helm.sh/chart: retina-0.0.1
    app.kubernetes.io/name: retina
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: retina
    app.kubernetes.io/component: rbac
  namespace: kube-system
  name: retina-cluster-reader
rules:
  - apiGroups: [""] # "" indicates the core API group
    resources: ["pods", "services", "replicationcontrollers", "nodes", "namespaces"]
    verbs: ["get", "watch", "list"]
  - apiGroups: ["apps"]
    resources: ["deployments", "replicasets"]
    verbs: ["get", "watch", "list"]
  - apiGroups: ["networking.azure.com"]
    resources: ["clusterobservers"]
    verbs: ["get", "list", "watch"]
  - apiGroups:
      - retina.sh
    resources:
      - retinaendpoints
    verbs:
      - get
      - list
      - watch
  - apiGroups:
    - ""
    resources:
      - namespaces
    verbs:
      - get
      - list
      - watch
  - apiGroups:
      - retina.sh
    resources:
      - retinaendpoints
    verbs:
      - create
      - delete
      - get
      - list
      - patch
      - update
      - watch
  - apiGroups:
      - retina.sh
    resources:
      - metricsconfigurations
    verbs:
      - create
      - delete
      - get
      - list
      - patch
      - update
      - watch
  - apiGroups:
      - retina.sh
    resources:
      - retinaendpoints/finalizers
    verbs:
      - update
  - apiGroups:
      - retina.sh
    resources:
      - retinaendpoints/status
    verbs:
      - get
      - patch
      - update
---
# Source: retina/templates/operator.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  labels:
    app.kubernetes.io/name: clusterrolebinding
    app.kubernetes.io/instance: retina-operator-rolebinding
    app.kubernetes.io/component: rbac
    app.kubernetes.io/created-by: operator
    app.kubernetes.io/part-of: operator
    app.kubernetes.io/managed-by: kustomize
  name: retina-operator-rolebinding
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: retina-operator-role
subjects:
- kind: ServiceAccount
  name: retina-operator
  namespace: kube-system
---
# Source: retina/templates/rbac.yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  labels:
    k8s-app: retina
    helm.sh/chart: retina-0.0.1
    app.kubernetes.io/name: retina
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: retina
    app.kubernetes.io/component: rbac
  name: retina-cluster-reader-binding
  namespace: kube-system
subjects:
  - kind: ServiceAccount
    name: retina-agent
    namespace: kube-system
roleRef:
  kind: ClusterRole
  name: retina-cluster-reader
  apiGroup: rbac.authorization.k8s.io
---
# Source: retina/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: retina-svc
  namespace: kube-system
  labels:
    k8s-app: retina
    helm.sh/chart: retina-0.0.1
    app.kubernetes.io/name: retina
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: retina
    app.kubernetes.io/component: networking
spec:
  ports:
    - port: 10093
      targetPort: 10093
  selector:
    app.kubernetes.io/name: retina
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/component: workload
---
# Source: retina/templates/daemonset.yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: retina-agent
  namespace: kube-system
  labels:
    helm.sh/chart: retina-0.0.1
    app.kubernetes.io/name: retina
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: retina
    app.kubernetes.io/component: workload
    k8s-app: retina
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: retina
      app.kubernetes.io/instance: release-name
      app.kubernetes.io/component: workload
  template:
    metadata:
      labels:
        helm.sh/chart: retina-0.0.1
        app.kubernetes.io/name: retina
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/version: "0.0.1"
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/part-of: retina
        app.kubernetes.io/component: workload
        k8s-app: retina
      annotations:
        prometheus.io/port: "10093"
        prometheus.io/scrape: "true"
        checksum/config: faf69acaa3a534c0ea0c8e2caac72fcd7abf27c8a231d51a432c1db918cd20f0
    spec:
      hostNetwork: true
      serviceAccountName: retina-agent
      initContainers:
        - name: init-retina
          image: ghcr.io/microsoft/retina/retina-init:v0.0.2
          imagePullPolicy: Always
          terminationMessagePolicy: FallbackToLogsOnError
          securityContext:
            privileged: true
          volumeMounts:
          - name: bpf
            mountPath: /sys/fs/bpf
            mountPropagation: Bidirectional
      containers:
        - name: retina 
          livenessProbe:
            httpGet:
              path: /metrics
              port: 10093
            initialDelaySeconds: 30
            periodSeconds: 30
          image: ghcr.io/microsoft/retina/retina-agent:v0.0.2
          imagePullPolicy: Always
          command:
          - /retina/controller
          args:
          - --health-probe-bind-address=:18081
          - --metrics-bind-address=:18080
          - "--config"
          - "/retina/config/config.yaml"
          ports:
          - name: retina
            containerPort: 10093
          resources:
            limits:
              cpu: 500m
              memory: 300Mi
            requests:
              cpu: 500m
              memory: 300Mi
          env:
          - name: POD_NAME
            valueFrom:
              fieldRef:
                apiVersion: v1
                fieldPath: metadata.name
          - name: NODE_NAME
            valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: spec.nodeName
          - name: NODE_IP
            valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: status.hostIP
          securityContext:
            capabilities:
              add:
              - SYS_ADMIN
              - SYS_RESOURCE
              - NET_ADMIN
              - IPC_LOCK
            privileged: false
          volumeMounts:
            - name: bpf
              mountPath: /sys/fs/bpf
            - name: cgroup
              mountPath: /sys/fs/cgroup
            - name: config
              mountPath: /retina/config
            - name: debug
              mountPath: /sys/kernel/debug
            - name: tmp
              mountPath: /tmp
            - name: trace
              mountPath: /sys/kernel/tracing
      terminationGracePeriodSeconds: 90 # Allow for retina to cleanup plugin resources.
      volumes:
      - name: bpf
      
        hostPath:
          path: /sys/fs/bpf
      
      - name: cgroup
      
        hostPath:
          path: /sys/fs/cgroup
      
      - name: config
      
        configMap:
          name: retina-config
      
      - name: debug
      
        hostPath:
          path: /sys/kernel/debug
      
      - name: tmp
      
        emptyDir: {}
      
      - name: trace
      
        hostPath:
          path: /sys/kernel/tracing
      
      nodeSelector:
        kubernetes.io/os: linux
---
# Source: retina/templates/daemonset.yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  labels:
    helm.sh/chart: retina-0.0.1
    app.kubernetes.io/name: retina
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: retina
    app.kubernetes.io/component: workload
    k8s-app: retina
  name: retina-agent-win
  namespace: kube-system
  annotations:
    prometheus.io/port: "10093"
    prometheus.io/scrape: "true"
    checksum/config: faf69acaa3a534c0ea0c8e2caac72fcd7abf27c8a231d51a432c1db918cd20f0
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: retina
      app.kubernetes.io/instance: release-name
      app.kubernetes.io/component: workload
  template:
    metadata:
      labels:
        helm.sh/chart: retina-0.0.1
        app.kubernetes.io/name: retina
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/version: "0.0.1"
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/part-of: retina
        app.kubernetes.io/component: workload
        k8s-app: retina
      name: retina
      namespace: kube-system
    spec:
      serviceAccountName: retina-agent
      securityContext:
        windowsOptions:
          hostProcess: true
          runAsUserName: NT AUTHORITY\SYSTEM
        runAsNonRoot: false
      hostNetwork: true
      containers:
        - name: retinawin
          image: ghcr.io/microsoft/retina/retina-agent:v0.0.2
          ports:
          - name: retina
            containerPort: 10093
          command:
            - powershell.exe
            - -command
            - .\setkubeconfigpath.ps1; ./controller.exe --config ./retina/config.yaml --kubeconfig ./kubeconfig
          env:
          - name: POD_NAME
            valueFrom:
              fieldRef:
                apiVersion: v1
                fieldPath: metadata.name
          - name: NODE_NAME
            valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: spec.nodeName
          - name: NODE_IP
            valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: status.hostIP
          securityContext:
            capabilities:
              add:
              - SYS_ADMIN
              - SYS_RESOURCE
              - NET_ADMIN
              - IPC_LOCK
            privileged: false
          volumeMounts:
            - name: retina-config-win
              mountPath: retina
      nodeSelector:
        kubernetes.io/os: windows
      volumes:
        - name: retina-config-win
          configMap:
            name: retina-config-win
---
# Source: retina/templates/operator.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: retina-operator
  namespace: kube-system
  labels:
    k8s-app: retina-operator
    control-plane: retina-operator
    app.kubernetes.io/name: deployment
    app.kubernetes.io/instance: retina-operator
    app.kubernetes.io/component: retina-operator
    app.kubernetes.io/created-by: operator
    app.kubernetes.io/part-of: operator
    app.kubernetes.io/managed-by: kustomize
spec:
  selector:
    matchLabels:
      control-plane: retina-operator
  replicas: 1
  template:
    metadata:
      annotations:
        kubectl.kubernetes.io/default-container: retina-operator
      labels:
        k8s-app: retina-operator
        control-plane: retina-operator
        app.kubernetes.io/name: deployment
        app.kubernetes.io/instance: retina-operator
        app.kubernetes.io/component: retina-operator
        app.kubernetes.io/created-by: operator
        app.kubernetes.io/part-of: operator
        app.kubernetes.io/managed-by: kustomize
    spec:
      # TODO(user): Uncomment the following code to configure the nodeAffinity expression
      # according to the platforms which are supported by your solution.
      # It is considered best practice to support multiple architectures. You can
      # build your manager image using the makefile target docker-buildx.
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution:
            nodeSelectorTerms:
              - matchExpressions:
                  - key: kubernetes.io/arch
                    operator: In
                    values:
                      - amd64
                      #- arm64
                      #- ppc64le
                      #- s390x
                  - key: kubernetes.io/os
                    operator: In
                    values:
                      - linux
                      #- windows
      securityContext:
        runAsNonRoot: true
      containers:
        - command:
            - /retina-operator
          image: ghcr.io/microsoft/retina/retina-operator:v0.0.2
          name: retina-operator
          volumeMounts:
            - name: retina-operator-config
              mountPath: /retina/
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
                - "ALL"
          livenessProbe:
            httpGet:
              path: /healthz
              port: 8081
            initialDelaySeconds: 15
            periodSeconds: 20
          readinessProbe:
            httpGet:
              path: /readyz
              port: 8081
            initialDelaySeconds: 5
            periodSeconds: 10
          resources:
            limits:
              cpu: 500m
              memory: 128Mi
            requests:
              cpu: 10m
              memory: 128Mi
      serviceAccountName: retina-operator
      terminationGracePeriodSeconds: 10
      volumes:
        - name: retina-operator-config
          configMap:
            name: retina-operator-config
---
# Source: retina/templates/networkobserver.yaml
# apiVersion: networking.azure.com/v1alpha1
# kind: ClusterObserver
# metadata:
#   name: retina
#   namespace: retina
# spec:
#   ignoreAllowed: true
#   exportList:
#     - otelAgent
#   observeList:
#     namespaceSelector:
#       matchLabels:
#     podSelector:
#       matchLabels:
#     direction: 
#   ignoreList:
#     namespaceSelector:
#       matchLabels:
#     podSelector:
#       matchLabels:
---
# Source: retina/templates/podmonitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: PodMonitor
metadata:
  name: retina-svc
  namespace: kube-system
  labels:
    k8s-app: retina
    helm.sh/chart: retina-0.0.1
    app.kubernetes.io/name: retina
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: retina
    app.kubernetes.io/component: metrics
spec:
  podMetricsEndpoints:
    - port: retina
      path: /metrics
      interval: 30s
      scrapeTimeout: 30s
      scheme: http
  namespaceSelector:
    matchNames:
      - kube-system
  selector:
    matchLabels:
      app: retina
---
# Source: retina/templates/tests/test-connection.yaml
apiVersion: v1
kind: Pod
metadata:
  name: "retina-svc-test-connection"
  labels:
    helm.sh/chart: retina-0.0.1
    app.kubernetes.io/name: retina
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: retina
  annotations:
    "helm.sh/hook": test
spec:
  containers:
    - name: wget
      image: busybox
      command: ['wget']
      args: ['retina-svc:10093']
  restartPolicy: Never

```

</details>

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
