### PR TITLE
fix: stale bot PR label

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -24,7 +24,7 @@ jobs:
           days-before-pr-stale: 30
           delete-branch: true
           stale-issue-label: "meta/waiting-for-author"
-          stale-pr-labels: "meta/waiting-for-author"
+          stale-pr-label: "meta/waiting-for-author"
           operations-per-run: 100
           stale-issue-message: "This issue will be closed in 7 days due to inactivity."
           stale-pr-message: "This PR will be closed in 7 days due to inactivity."


### PR DESCRIPTION
# Description

s/stale-pr-label**s**/stale-pr-label

https://github.com/actions/stale?tab=readme-ov-file#list-of-input-options

This is why PRs are being labelled with `Stale` instead of the configured `meta/waiting-for-author` 🙁 

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
