### PR TITLE
fix: Fix missing return code for dns response

### DIFF
--- a/pkg/plugin/common/common_linux.go
+++ b/pkg/plugin/common/common_linux.go
@@ -7,11 +7,11 @@ package common
 import (
 	"errors"
 	"os"
-	"strings"
 	"syscall"
 
 	"github.com/cilium/ebpf"
 	"github.com/cilium/ebpf/perf"
+	"github.com/google/gopacket/layers"
 	"github.com/microsoft/retina/pkg/log"
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"
@@ -41,18 +41,21 @@ func ProtocolToFlow(protocol string) int {
 }
 
 // Refer: https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml#dns-parameters-6
+// Inspektor gadget uses Gopacket pkg for DNS response codes.
+// Ref: https://github.com/google/gopacket/blob/32ee38206866f44a74a6033ec26aeeb474506804/layers/dns.go#L129
 func RCodeToFlow(rCode string) uint32 {
-	if strings.EqualFold(rCode, "NoError") {
+	switch rCode {
+	case layers.DNSResponseCodeNoErr.String():
 		return 0
-	} else if strings.EqualFold(rCode, "FormErr") {
+	case layers.DNSResponseCodeFormErr.String():
 		return 1
-	} else if strings.EqualFold(rCode, "ServFail") {
+	case layers.DNSResponseCodeServFail.String():
 		return 2
-	} else if strings.EqualFold(rCode, "NXDomain") {
+	case layers.DNSResponseCodeNXDomain.String():
 		return 3
-	} else if strings.EqualFold(rCode, "NotImp") {
+	case layers.DNSResponseCodeNotImp.String():
 		return 4
-	} else if strings.EqualFold(rCode, "Refused") {
+	case layers.DNSResponseCodeRefused.String():
 		return 5
 	}
 	return 24

--- a/pkg/plugin/dns/dns_linux_test.go
+++ b/pkg/plugin/dns/dns_linux_test.go
@@ -125,7 +125,7 @@ func TestRequestEventHandler(t *testing.T) {
 
 	event := &types.Event{
 		Qr:         "Q",
-		Rcode:      "NOERROR",
+		Rcode:      "No Error",
 		QType:      "A",
 		DNSName:    "test.com",
 		Addresses:  []string{},
@@ -175,7 +175,7 @@ func TestResponseEventHandler(t *testing.T) {
 
 	event := &types.Event{
 		Qr:         "R",
-		Rcode:      "NOERROR",
+		Rcode:      "No Error",
 		QType:      "A",
 		DNSName:    "test.com",
 		Addresses:  []string{"1.1.1.1", "2.2.2.2"},


### PR DESCRIPTION
# Description

IG recently changed the return code of the DNS gadget and moved to gopacket - https://github.com/inspektor-gadget/inspektor-gadget/blame/6a5937bba8f13fee889a24340f309d57e8ecabb6/pkg/gadgets/trace/dns/tracer/tracer.go#L168 . Fix the map in utils.

## Related Issue

Fix: https://github.com/microsoft/retina/issues/330

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
