### PR TITLE
fix: fail pipeline on failure to build/push image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,7 @@ container-docker: buildx # util target to build container images using docker bu
 	image_metadata_filename="image-metadata-$$image_name-$(TAG).json"; \
 	touch $$image_metadata_filename; \
 	echo "Building $$image_name for $$os/$$arch "; \
+	set -e ; \
 	docker buildx build \
 		$(BUILDX_ACTION) \
 		--platform $(PLATFORM) \

--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,6 @@ container-docker: buildx # util target to build container images using docker bu
 	image_metadata_filename="image-metadata-$$image_name-$(TAG).json"; \
 	touch $$image_metadata_filename; \
 	echo "Building $$image_name for $$os/$$arch "; \
-	set -e ; \
 	docker buildx build \
 		$(BUILDX_ACTION) \
 		--platform $(PLATFORM) \
@@ -227,6 +226,7 @@ container-docker: buildx # util target to build container images using docker bu
 
 retina-image: ## build the retina linux container image.
 	echo "Building for $(PLATFORM)"
+	set -e ; \
 	for target in init agent; do \
 		echo "Building for $$target"; \
 		if [ "$$target" = "init" ]; then \
@@ -250,6 +250,7 @@ retina-image-win: ## build the retina Windows container image.
 	for year in 2019 2022; do \
 		tag=$(TAG)-windows-ltsc$$year-amd64; \
 		echo "Building $(RETINA_PLATFORM_TAG)"; \
+		set -e ; \
 		$(MAKE) container-$(CONTAINER_BUILDER) \
 				PLATFORM=windows/amd64 \
 				DOCKERFILE=controller/Dockerfile \
@@ -264,6 +265,7 @@ retina-image-win: ## build the retina Windows container image.
 
 retina-operator-image:  ## build the retina linux operator image.
 	echo "Building for $(PLATFORM)"
+	set -e ; \
 	$(MAKE) container-$(CONTAINER_BUILDER) \
 			PLATFORM=$(PLATFORM) \
 			DOCKERFILE=operator/Dockerfile \

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,5 +1,26 @@
 ARG OS_VERSION=ltsc2019
 
+# intermediate go generate stage
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.22 AS intermediate
+ARG APP_INSIGHTS_ID # set to enable AI telemetry
+ARG GOARCH=amd64 # default to amd64
+ARG GOOS=linux # default to linux
+ENV CGO_ENABLED=0
+ENV GOARCH=${GOARCH}
+ENV GOOS=${GOOS}
+COPY . /go/src/github.com/microsoft/retina
+WORKDIR /go/src/github.com/microsoft/retina
+RUN if [ "$GOOS" = "linux" ] ; then \
+    apt-get update && apt-get -y install lsb-release wget software-properties-common gnupg file git make; \
+    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -; \
+    add-apt-repository "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-14 main"; \
+    apt-get update; \
+    apt-get install -y clang-14 lldb-14 lld-14 clangd-14; \
+    apt-get install -y bpftool libbpf-dev; \
+    ln -s /usr/bin/clang-14 /usr/bin/clang; \
+    go generate /go/src/github.com/microsoft/retina/pkg/plugin/...; \
+    fi
+
 # capture binary
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.22 AS capture-bin
 ARG APP_INSIGHTS_ID # set to enable AI telemetry
@@ -15,7 +36,7 @@ RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /go/bin/ret
 
 
 # controller binary
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.22 AS controller-bin
+FROM intermediate AS controller-bin
 ARG APP_INSIGHTS_ID # set to enable AI telemetry
 ARG GOARCH=amd64 # default to amd64
 ARG GOOS=linux # default to linux
@@ -23,23 +44,11 @@ ARG VERSION
 ENV CGO_ENABLED=0
 ENV GOARCH=${GOARCH}
 ENV GOOS=${GOOS}
-COPY . /go/src/github.com/microsoft/retina 
-WORKDIR /go/src/github.com/microsoft/retina
-RUN if [ "$GOOS" = "linux" ] ; then \
-    apt-get update && apt-get -y install lsb-release wget software-properties-common gnupg file git make; \
-    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -; \
-    add-apt-repository "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-14 main"; \
-    apt-get update; \
-    apt-get install -y clang-14 lldb-14 lld-14 clangd-14; \
-    apt-get install -y bpftool libbpf-dev; \
-    ln -s /usr/bin/clang-14 /usr/bin/clang; \
-    go generate /go/src/github.com/microsoft/retina/pkg/plugin/...; \
-    fi
 RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /go/bin/retina/controller -ldflags "-X main.version="$VERSION" -X main.applicationInsightsID="$APP_INSIGHTS_ID"" controller/main.go 
 
 
 # init binary
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.22 AS init-bin
+FROM intermediate AS init-bin
 ARG APP_INSIGHTS_ID # set to enable AI telemetry
 ARG GOARCH=amd64 # default to amd64
 ARG GOOS=linux # default to linux
@@ -47,8 +56,6 @@ ARG VERSION
 ENV CGO_ENABLED=0
 ENV GOARCH=${GOARCH}
 ENV GOOS=${GOOS}
-COPY . /go/src/github.com/microsoft/retina 
-WORKDIR /go/src/github.com/microsoft/retina
 RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /go/bin/retina/initretina -ldflags "-X main.version="$VERSION" -X main.applicationInsightsID="$APP_INSIGHTS_ID"" init/retina/main_linux.go
 
 

--- a/controller/main.go
+++ b/controller/main.go
@@ -96,8 +96,6 @@ func main() {
 		panic(err)
 	}
 
-	metrics.InitializeMetrics()
-
 	fmt.Println("init client-go")
 	cfg, err := kcfg.GetConfig()
 	if err != nil {
@@ -124,6 +122,8 @@ func main() {
 	}
 	defer zl.Close()
 	mainLogger := zl.Named("main").Sugar()
+
+	metrics.InitializeMetrics()
 
 	var tel telemetry.Telemetry
 	if config.EnableTelemetry && applicationInsightsID != "" {


### PR DESCRIPTION
# Description

Build pipeline is green even though build was failed. This PR introduced `set -e` in the build process so the pipeline will fail fast on any error during build. Also moved the `go generate` part to an intermediate stage so we can reuse it for `controller-bin` and `init-bin`

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
