### PR TITLE
fix: init metrics after logger

### DIFF
--- a/controller/main.go
+++ b/controller/main.go
@@ -96,8 +96,6 @@ func main() {
 		panic(err)
 	}
 
-	metrics.InitializeMetrics()
-
 	fmt.Println("init client-go")
 	cfg, err := kcfg.GetConfig()
 	if err != nil {
@@ -124,6 +122,8 @@ func main() {
 	}
 	defer zl.Close()
 	mainLogger := zl.Named("main").Sugar()
+
+	metrics.InitializeMetrics()
 
 	var tel telemetry.Telemetry
 	if config.EnableTelemetry && applicationInsightsID != "" {


### PR DESCRIPTION
# Description

Metrics package uses the global logger (😠), so it needs to init after the logger.

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
