### PR TITLE
fix: correct selector in PodMonitor

### DIFF
--- a/deploy/manifests/controller/helm/retina/templates/podmonitor.yaml
+++ b/deploy/manifests/controller/helm/retina/templates/podmonitor.yaml
@@ -36,5 +36,5 @@ spec:
       - {{ .Values.namespace }}
   selector:
     matchLabels:
-      app: {{ include "retina.name" . }}
+      {{- include "retina.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/deploy/manifests/controller/helm/retina/templates/podmonitor.yaml
+++ b/deploy/manifests/controller/helm/retina/templates/podmonitor.yaml
@@ -37,4 +37,5 @@ spec:
   selector:
     matchLabels:
       {{- include "retina.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: workload
 {{- end }}


### PR DESCRIPTION
Update matchLabels from https://github.com/microsoft/retina/pull/324

# Description
Corrects the match label to use new k8s labels introduced in #324 

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Generated yaml:
```yaml
---
# Source: retina/templates/podmonitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: PodMonitor
metadata:
  name: retina-svc
  namespace: kube-system
  labels:
    k8s-app: retina
    helm.sh/chart: retina-0.0.1
    app.kubernetes.io/name: retina
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: retina
    app.kubernetes.io/component: metrics
spec:
  podMetricsEndpoints:
    - port: retina
      path: /metrics
      interval: 30s
      scrapeTimeout: 30s
      scheme: http
  namespaceSelector:
    matchNames:
      - kube-system
  selector:
    matchLabels:
      app.kubernetes.io/name: retina
      app.kubernetes.io/instance: release-name
      app.kubernetes.io/component: workload

```

Which matches the selector labels that the DaemonSet uses
```yaml
---
# Source: retina/templates/daemonset.yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  labels:
    helm.sh/chart: retina-0.0.1
    app.kubernetes.io/name: retina
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/part-of: retina
    app.kubernetes.io/component: workload
    k8s-app: retina
  name: retina-agent-win
  namespace: kube-system
  annotations:
    prometheus.io/port: "10093"
    prometheus.io/scrape: "true"
    checksum/config: faf69acaa3a534c0ea0c8e2caac72fcd7abf27c8a231d51a432c1db918cd20f0
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: retina
      app.kubernetes.io/instance: release-name
      app.kubernetes.io/component: workload
  template:
    metadata:
      labels:
        helm.sh/chart: retina-0.0.1
        app.kubernetes.io/name: retina
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/version: "0.0.1"
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/part-of: retina
        app.kubernetes.io/component: workload
        k8s-app: retina
      name: retina
      namespace: kube-system
    spec:
      serviceAccountName: retina-agent
      securityContext:
        windowsOptions:
          hostProcess: true
          runAsUserName: NT AUTHORITY\SYSTEM
        runAsNonRoot: false
      hostNetwork: true
      containers:
        - name: retinawin
          image: ghcr.io/microsoft/retina/retina-agent:v0.0.2
          ports:
            - name: retina
              containerPort: 10093
          command:
            - powershell.exe
            - -command
            - .\setkubeconfigpath.ps1; ./controller.exe --config ./retina/config.yaml --kubeconfig ./kubeconfig
          env:
            - name: POD_NAME
              valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: metadata.name
            - name: NODE_NAME
              valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: spec.nodeName
            - name: NODE_IP
              valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: status.hostIP
          securityContext:
            capabilities:
              add:
                - SYS_ADMIN
                - SYS_RESOURCE
                - NET_ADMIN
                - IPC_LOCK
            privileged: false
          volumeMounts:
            - name: retina-config-win
              mountPath: retina
      nodeSelector:
        kubernetes.io/os: windows
      volumes:
        - name: retina-config-win
          configMap:
            name: retina-config-win
```
 
## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
