### PR TITLE
feat: migrate to Mariner containers

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,7 +1,9 @@
 ARG OS_VERSION=ltsc2019
 
 # intermediate go generate stage
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.22 AS intermediate
+# mcr.microsoft.com/oss/go/microsoft/golang:1.22.2-1-cbl-mariner2.0
+# mcr.microsoft.com/oss/go/microsoft/golang@sha256:87e7359c0b4b4e3ca0d4be7fe5099423ec3431d6c44021a84569dba71ac5463e
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:87e7359c0b4b4e3ca0d4be7fe5099423ec3431d6c44021a84569dba71ac5463e AS intermediate 
 ARG APP_INSIGHTS_ID # set to enable AI telemetry
 ARG GOARCH=amd64 # default to amd64
 ARG GOOS=linux # default to linux
@@ -11,18 +13,14 @@ ENV GOOS=${GOOS}
 COPY . /go/src/github.com/microsoft/retina
 WORKDIR /go/src/github.com/microsoft/retina
 RUN if [ "$GOOS" = "linux" ] ; then \
-    apt-get update && apt-get -y install lsb-release wget software-properties-common gnupg file git make; \
-    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -; \
-    add-apt-repository "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-14 main"; \
-    apt-get update; \
-    apt-get install -y clang-14 lldb-14 lld-14 clangd-14; \
-    apt-get install -y bpftool libbpf-dev; \
-    ln -s /usr/bin/clang-14 /usr/bin/clang; \
-    go generate /go/src/github.com/microsoft/retina/pkg/plugin/...; \
+    tdnf install -y clang16 lld16 bpftool libbpf-devel; \
+    go generate -x /go/src/github.com/microsoft/retina/pkg/plugin/...; \
     fi
 
 # capture binary
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.22 AS capture-bin
+# mcr.microsoft.com/oss/go/microsoft/golang:1.22.2-1-cbl-mariner2.0
+# mcr.microsoft.com/oss/go/microsoft/golang@sha256:87e7359c0b4b4e3ca0d4be7fe5099423ec3431d6c44021a84569dba71ac5463e
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:87e7359c0b4b4e3ca0d4be7fe5099423ec3431d6c44021a84569dba71ac5463e AS capture-bin
 ARG APP_INSIGHTS_ID # set to enable AI telemetry
 ARG GOARCH=amd64 # default to amd64
 ARG GOOS=linux # default to linux
@@ -60,17 +58,15 @@ RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /go/bin/ret
 
 
 # tools image
-FROM  --platform=$TARGETPLATFORM mcr.microsoft.com/mirror/docker/library/debian:bookworm@sha256:1aadfee8d292f64b045adb830f8a58bfacc15789ae5f489a0fedcd517a862cb9 AS tools
-RUN apt-get update && \
-    apt-get install -y \
-    apt-file \
-    clang \
-    curl \
-    gnupg2 \
-    iproute2 \
+# mcr.microsoft.com/cbl-mariner/base/core:2.0
+# mcr.microsoft.com/cbl-mariner/base/core@sha256:77651116f2e83cf50fddd8a0316945499f8ce6521ff8e94e67539180d1e5975a
+FROM  --platform=$TARGETPLATFORM mcr.microsoft.com/cbl-mariner/base/core@sha256:77651116f2e83cf50fddd8a0316945499f8ce6521ff8e94e67539180d1e5975a AS tools
+RUN tdnf install -y \
+    clang16 \
+    iproute \
     iptables \
-    tcpdump 
-
+    tcpdump \
+    which
 RUN mkdir -p /tmp/bin
 RUN arr="clang tcpdump ip ss iptables-legacy iptables-legacy-save iptables-nft iptables-nft-save cp uname" ;\
     for i in $arr; do    \
@@ -79,16 +75,19 @@ RUN arr="clang tcpdump ip ss iptables-legacy iptables-legacy-save iptables-nft i
 
 
 # init final image
-FROM --platform=$TARGETPLATFORM gcr.io/distroless/cc-debian12:debug as init
+# mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
+# mcr.microsoft.com/cbl-mariner/distroless/minimal@sha256:63a0a70ceaa1320bc6eb98b81106667d43e46b674731ea8d28e4de1b87e0747f
+FROM --platform=$TARGETPLATFORM mcr.microsoft.com/cbl-mariner/distroless/minimal@sha256:63a0a70ceaa1320bc6eb98b81106667d43e46b674731ea8d28e4de1b87e0747f as init
 COPY --from=init-bin /go/bin/retina/initretina /retina/initretina
 COPY --from=tools /lib/ /lib
 COPY --from=tools /usr/lib/ /usr/lib
-COPY --from=tools /bin/mount /bin/mount
 ENTRYPOINT ["./retina/initretina"]
 
 
 # agent final image
-FROM --platform=$TARGETPLATFORM gcr.io/distroless/cc-debian12:debug as agent
+# mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
+# mcr.microsoft.com/cbl-mariner/distroless/minimal@sha256:63a0a70ceaa1320bc6eb98b81106667d43e46b674731ea8d28e4de1b87e0747f
+FROM --platform=$TARGETPLATFORM mcr.microsoft.com/cbl-mariner/distroless/minimal@sha256:63a0a70ceaa1320bc6eb98b81106667d43e46b674731ea8d28e4de1b87e0747f as agent
 COPY --from=tools /lib/ /lib
 COPY --from=tools /usr/lib/ /usr/lib
 COPY --from=tools /tmp/bin/ /bin

--- a/pkg/plugin/dropreason/dropreason_linux.go
+++ b/pkg/plugin/dropreason/dropreason_linux.go
@@ -33,7 +33,7 @@ import (
 	"go.uber.org/zap"
 )
 
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go@master -cc clang-14 -cflags "-g -O2 -Wall -D__TARGET_ARCH_${GOARCH} -Wall" -target ${GOARCH} -type metrics_map_value -type drop_reason_t -type packet kprobe ./_cprog/drop_reason.c -- -I../lib/_${GOARCH} -I../lib/common/libbpf/_src -I../filter/_cprog/
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go@master -cflags "-g -O2 -Wall -D__TARGET_ARCH_${GOARCH} -Wall" -target ${GOARCH} -type metrics_map_value -type drop_reason_t -type packet kprobe ./_cprog/drop_reason.c -- -I../lib/_${GOARCH} -I../lib/common/libbpf/_src -I../filter/_cprog/
 const (
 	nfHookSlowFn         = "nf_hook_slow"
 	tcpConnectFn         = "tcp_v4_connect"

--- a/pkg/plugin/filter/filter_map_linux.go
+++ b/pkg/plugin/filter/filter_map_linux.go
@@ -20,7 +20,7 @@ import (
 	_ "github.com/microsoft/retina/pkg/plugin/filter/_cprog" // nolint
 )
 
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go@master -cc clang-14 -cflags "-g -O2 -Wall -D__TARGET_ARCH_${GOARCH} -Wall" -target ${GOARCH} -type mapKey filter ./_cprog/retina_filter.c -- -I../lib/_${GOARCH} -I../lib/common/libbpf/_src
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go@master -cflags "-g -O2 -Wall -D__TARGET_ARCH_${GOARCH} -Wall" -target ${GOARCH} -type mapKey filter ./_cprog/retina_filter.c -- -I../lib/_${GOARCH} -I../lib/common/libbpf/_src
 
 var (
 	f    *FilterMap

--- a/pkg/plugin/packetforward/packetforward_linux.go
+++ b/pkg/plugin/packetforward/packetforward_linux.go
@@ -29,7 +29,7 @@ import (
 	_ "github.com/microsoft/retina/pkg/plugin/packetforward/_cprog" // nolint
 )
 
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go@master -cc clang-14 -cflags "-g -O2 -Wall -D__TARGET_ARCH_${GOARCH} -Wall" -target ${GOARCH} -type metric packetforward ./_cprog/packetforward.c -- -I../lib/_${GOARCH} -I../lib/common/libbpf/_src
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go@master -cflags "-g -O2 -Wall -D__TARGET_ARCH_${GOARCH} -Wall" -target ${GOARCH} -type metric packetforward ./_cprog/packetforward.c -- -I../lib/_${GOARCH} -I../lib/common/libbpf/_src
 
 // New creates a new packetforward plugin.
 func New(cfg *kcfg.Config) api.Plugin {

--- a/pkg/plugin/packetparser/packetparser_linux.go
+++ b/pkg/plugin/packetparser/packetparser_linux.go
@@ -42,11 +42,9 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go@master -cc clang-14 -cflags "-g -O2 -Wall -D__TARGET_ARCH_${GOARCH} -Wall" -target ${GOARCH} -type packet packetparser ./_cprog/packetparser.c -- -I../lib/_${GOARCH} -I../lib/common/libbpf/_src -I../filter/_cprog/
+//go:generate go run github.com/cilium/ebpf/cmd/bpf2go@master -cflags "-g -O2 -Wall -D__TARGET_ARCH_${GOARCH} -Wall" -target ${GOARCH} -type packet packetparser ./_cprog/packetparser.c -- -I../lib/_${GOARCH} -I../lib/common/libbpf/_src -I../filter/_cprog/
 
-var (
-	errNoOutgoingLinks = errors.New("could not determine any outgoing links")
-)
+var errNoOutgoingLinks = errors.New("could not determine any outgoing links")
 
 // New creates a packetparser plugin.
 func New(cfg *kcfg.Config) api.Plugin {

--- a/test/image/Dockerfile
+++ b/test/image/Dockerfile
@@ -1,31 +1,15 @@
 # build stage
-FROM mcr.microsoft.com/oss/go/microsoft/golang:1.22 AS builder
-
+FROM mcr.microsoft.com/oss/go/microsoft/golang@sha256:87e7359c0b4b4e3ca0d4be7fe5099423ec3431d6c44021a84569dba71ac5463e AS builder
 ENV CGO_ENABLED=0
-
-RUN apt-get update &&\
-    apt-get -y install lsb-release wget software-properties-common gnupg file git make
-
-RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
-RUN add-apt-repository "deb http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-14 main"
-RUN apt-get update
-
-RUN apt-get install -y clang-14 lldb-14 lld-14 clangd-14 man-db
-RUN apt-get install -y bpftool libbpf-dev
-
-RUN ln -s /usr/bin/clang-14 /usr/bin/clang
-
 COPY . /go/src/github.com/microsoft/retina 
 WORKDIR /go/src/github.com/microsoft/retina
-
+RUN tdnf install -y clang16 lld16 bpftool libbpf-devel make git
 RUN go generate /go/src/github.com/microsoft/retina/pkg/plugin/...
-
 # RUN go mod edit -module retina
 # RUN make all generate
 #RUN go generate ./...
 RUN make test
 #RUN go test -covermode count -coverprofile /home/runner/work/_temp/go.cov -coverpkg ./... ./...
-
 RUN cat coverage.out
 
 FROM scratch AS artifacts


### PR DESCRIPTION
# Description

Migrates the images from Ubuntu/Debian builder and Debian-distroless final image to Mariner for everything. Incidentally also moves from clang-14 to clang-16.



## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.
