### PR TITLE
fix: only invoke Generate once for plugins when reconciling in plugin manager

### DIFF
--- a/pkg/plugin/dropreason/dropreason_linux.go
+++ b/pkg/plugin/dropreason/dropreason_linux.go
@@ -95,11 +95,6 @@ func (dr *dropReason) Compile(ctx context.Context) error {
 		return err
 	}
 
-	// Generate dynamic header file.
-	if err := dr.Generate(ctx); err != nil {
-		dr.l.Error("failed to generate DropReason dynamic header:%w", zap.Error(err))
-	}
-
 	bpfSourceFile := fmt.Sprintf("%s/%s/%s", dir, bpfSourceDir, bpfSourceFileName)
 	bpfOutputFile := fmt.Sprintf("%s/%s", dir, bpfObjectFileName)
 

--- a/pkg/plugin/dropreason/dropreason_linux_test.go
+++ b/pkg/plugin/dropreason/dropreason_linux_test.go
@@ -103,7 +103,7 @@ func TestCompile(t *testing.T) {
 
 	err = p.Generate(context.Background())
 	if err != nil {
-		t.Fatalf("Expected no error. Error: %+v", err)
+		t.Fatal("Expected no error. Error:", err)
 	}
 
 	err = p.Compile(context.Background())

--- a/pkg/plugin/dropreason/dropreason_linux_test.go
+++ b/pkg/plugin/dropreason/dropreason_linux_test.go
@@ -101,6 +101,11 @@ func TestCompile(t *testing.T) {
 		t.Fatalf("Expected no error. Error: %+v", err)
 	}
 
+	err = p.Generate(context.Background())
+	if err != nil {
+		t.Fatalf("Expected no error. Error: %+v", err)
+	}
+
 	err = p.Compile(context.Background())
 	if err != nil {
 		t.Fatalf("Expected no error. Error: %+v", err)

--- a/pkg/plugin/packetparser/packetparser_linux.go
+++ b/pkg/plugin/packetparser/packetparser_linux.go
@@ -229,7 +229,6 @@ func (p *packetParser) Start(ctx context.Context) error {
 	p.recordsChannel = make(chan perf.Record, buffer)
 	p.l.Debug("Created records channel")
 
-	p.l.Info("Started packet parser")
 	return p.run(ctx)
 }
 
@@ -495,8 +494,6 @@ func (p *packetParser) createQdiscAndAttach(iface netlink.LinkAttrs, ifaceType s
 }
 
 func (p *packetParser) run(ctx context.Context) error {
-	p.l.Info("Starting packet parser")
-
 	// Start perf record handlers (consumers).
 	for i := 0; i < workers; i++ {
 		p.wg.Add(1)
@@ -507,6 +504,8 @@ func (p *packetParser) run(ctx context.Context) error {
 	// The perf reader Read call blocks until there is data available in the perf buffer.
 	// That call is unblocked when Reader is closed.
 	go p.handleEvents(ctx)
+
+	p.l.Info("Started packet parser")
 
 	// Wait for the context to be done.
 	// This will block till all consumers exit.

--- a/pkg/plugin/packetparser/packetparser_linux.go
+++ b/pkg/plugin/packetparser/packetparser_linux.go
@@ -90,10 +90,6 @@ func (p *packetParser) Compile(ctx context.Context) error {
 		return err
 	}
 
-	// Generate dynamic header file.
-	if err := p.Generate(ctx); err != nil {
-		p.l.Error("failed to generate PacketParser dynamic header:%w", zap.Error(err))
-	}
 	bpfSourceFile := fmt.Sprintf("%s/%s/%s", dir, bpfSourceDir, bpfSourceFileName)
 	bpfOutputFile := fmt.Sprintf("%s/%s", dir, bpfObjectFileName)
 	arch := runtime.GOARCH

--- a/pkg/plugin/packetparser/packetparser_linux_test.go
+++ b/pkg/plugin/packetparser/packetparser_linux_test.go
@@ -425,6 +425,11 @@ func TestCompile(t *testing.T) {
 		t.Fatalf("Expected no error. Error: %+v", err)
 	}
 
+	err = p.Generate(context.Background())
+	if err != nil {
+		t.Fatalf("Expected no error. Error: %+v", err)
+	}
+
 	err = p.Compile(context.Background())
 	if err != nil {
 		t.Fatalf("Expected no error. Error: %+v", err)


### PR DESCRIPTION
# Description

Fixes issue mentioned in https://github.com/microsoft/retina/issues/319

## Related Issue

https://github.com/microsoft/retina/issues/319