### PR TITLE
chore: move E2E to separate GHA

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,47 @@
+name: E2E
+
+on:
+  workflow_run:
+    workflows: [Build Images]
+    types:
+      - completed
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    if: ${{ github.event_name == 'merge_group' }}
+    name: E2E
+    runs-on: ubuntu-latest
+    needs: [manifests]
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: go version
+
+      - name: Az CLI login
+        uses: azure/login@v2
+        if: ${{ github.event_name == 'merge_group' }}
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Run E2E
+        env:
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION }}
+          AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          go test -v ./test/e2e/scenarios/retina/*.go -timeout 30m -tags=e2e -count=1  -args -image-tag=$(make version) -image-registry=${{ vars.ACR_NAME }}  -image-namespace=${{ github.repository}}

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -1,4 +1,4 @@
-name: Build images and run E2E tests.
+name: Build Images
 
 on:
   pull_request:


### PR DESCRIPTION
Part 1: Moves the E2E to a separate GHA to logically separate it from other checks
will follow up to remove e2e from Images workflow entirely.