### PR TITLE
fix: pin Windows base images

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -96,9 +96,14 @@ COPY --from=controller-bin /go/src/github.com/microsoft/retina/pkg/plugin /go/sr
 COPY --from=capture-bin /go/bin/retina/captureworkload /retina/captureworkload
 ENTRYPOINT ["./retina/controller"]
 
+# intermediate for win-ltsc2019
+FROM --platform=$TARGETPLATFORM mcr.microsoft.com/windows/servercore@sha256:6fdf140282a2f809dae9b13fe441635867f0a27c33a438771673b8da8f3348a4 as ltsc2019
+
+# intermediate for win-ltsc2022
+FROM --platform=$TARGETPLATFORM mcr.microsoft.com/windows/servercore@sha256:45952938708fbde6ec0b5b94de68bcdec3f8c838be018536b1e9e5bd95e6b943 as ltsc2022
 
 # agent final image for win2019
-FROM --platform=$TARGETPLATFORM mcr.microsoft.com/windows/servercore:${OS_VERSION} as agent-win
+FROM --platform=$TARGETPLATFORM ${OS_VERSION} as agent-win
 COPY --from=controller-bin /go/src/github.com/microsoft/retina/windows/kubeconfigtemplate.yaml kubeconfigtemplate.yaml
 COPY --from=controller-bin /go/src/github.com/microsoft/retina/windows/setkubeconfigpath.ps1 setkubeconfigpath.ps1
 COPY --from=controller-bin /go/bin/retina/controller controller.exe


### PR DESCRIPTION
# Description

Pin the Windows base images by SHA. A good security practice, but also a fix to the build because the latest servercore:ltsc2019 image is broken.

## Related Issue

https://github.com/microsoft/Windows-Containers/issues/493

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.
