### PR TITLE
fix: correctly assign the subtype value in flow for drop reason

### DIFF
--- a/pkg/utils/flow_utils.go
+++ b/pkg/utils/flow_utils.go
@@ -266,10 +266,6 @@ func AddDropReason(f *flow.Flow, meta *RetinaMetadata, dropReason uint32) {
 	meta.DropReason = DropReason(dropReason)
 
 	f.Verdict = flow.Verdict_DROPPED
-	f.EventType = &flow.CiliumEventType{
-		Type:    int32(api.MessageTypeDrop),
-		SubType: int32(api.TraceToNetwork), // This is a drop event and direction is determined later.
-	}
 
 	// Set the drop reason.
 	// Retina drop reasons are different from the drop reasons available in flow library.
@@ -284,6 +280,11 @@ func AddDropReason(f *flow.Flow, meta *RetinaMetadata, dropReason uint32) {
 		f.DropReasonDesc = flow.DropReason_UNKNOWN_CONNECTION_TRACKING_STATE
 	default:
 		f.DropReasonDesc = flow.DropReason_DROP_REASON_UNKNOWN
+	}
+
+	f.EventType = &flow.CiliumEventType{
+		Type:    int32(api.MessageTypeDrop),
+		SubType: int32(f.GetDropReasonDesc()), // This is the drop reason.
 	}
 }
 

--- a/pkg/utils/utils_linux_test.go
+++ b/pkg/utils/utils_linux_test.go
@@ -158,6 +158,7 @@ func TestAddDropReason(t *testing.T) {
 			assert.Equal(t, f.DropReasonDesc, tc.expectedDesc)
 			assert.Equal(t, f.Verdict, flow.Verdict_DROPPED)
 			assert.NotNil(t, f.EventType.Type, 1)
+			assert.EqualValues(t, f.EventType.GetSubType(), int32(tc.expectedDesc))
 			assert.NotNil(t, DropReasonDescription(f), DropReason_name[int32(tc.dropReason)])
 		})
 	}


### PR DESCRIPTION
# Description

The `subType` field for flows of type Drop needs to be the DropReason, not the point of observation.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Checked the flows through debug logging to make sure the SubType is set correctly.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
