### PR TITLE
fix: updated llvm version in docs to 16

### DIFF
--- a/docs/contributing/developing.md
+++ b/docs/contributing/developing.md
@@ -11,7 +11,7 @@ The easiest way to set up your Development Environment is to use the provided Gi
 To manually configure your DevEnv:
 
 ```bash
-export LLVM_VERSION=14
+export LLVM_VERSION=16
 curl -sL https://apt.llvm.org/llvm.sh  | sudo bash -s "$LLVM_VERSION"
 ```
 


### PR DESCRIPTION
# Description

Updated LLVM version to 16 in `docs/contributing/developing.md` file.

## Related Issue

Issue #425 

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Additional Notes

Should we consider updating the LLVM version in `.devcontainer/installMoreTools.sh` too ?

---
