### PR TITLE
fix(e2e): add an extra nslookup when testing for advanced DNS metrics

### DIFF
--- a/test/e2e/scenarios/dns/scenarios.go
+++ b/test/e2e/scenarios/dns/scenarios.go
@@ -64,6 +64,7 @@ func ValidateBasicDNSMetrics(scenarioName string, req *RequestValidationParams, 
 				Duration: sleepDelay,
 			},
 		},
+		// Ref: https://github.com/microsoft/retina/issues/415
 		{
 			Step: &kubernetes.ExecInPod{
 				PodName:      podName,
@@ -152,6 +153,23 @@ func ValidateAdvancedDNSMetrics(scenarioName string, req *RequestValidationParam
 				AgnhostNamespace: "kube-system",
 			},
 		},
+		{
+			Step: &kubernetes.ExecInPod{
+				PodName:      podName,
+				PodNamespace: "kube-system",
+				Command:      req.Command,
+			},
+			Opts: &types.StepOptions{
+				ExpectError:               req.ExpectError,
+				SkipSavingParamatersToJob: true,
+			},
+		},
+		{
+			Step: &types.Sleep{
+				Duration: sleepDelay,
+			},
+		},
+		// Ref: https://github.com/microsoft/retina/issues/415
 		{
 			Step: &kubernetes.ExecInPod{
 				PodName:      podName,


### PR DESCRIPTION
# Description
Ref: https://github.com/microsoft/retina/issues/415. Added for Basic DNS metrics but missed for Adv DNS metrics
## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
