### PR TITLE
fix: remove redundant dns and latency metric labels

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -138,13 +138,13 @@ func InitializeMetrics() {
 		exporter.DefaultRegistry,
 		utils.DNSRequestCounterName,
 		dnsRequestCounterDescription,
-		utils.DNSLabels...,
+		utils.DNSRequestLabels...,
 	)
 	DNSResponseCounter = exporter.CreatePrometheusCounterVecForMetric(
 		exporter.DefaultRegistry,
 		utils.DNSResponseCounterName,
 		dnsResponseCounterDescription,
-		utils.DNSLabels...,
+		utils.DNSResponseLabels...,
 	)
 
 	// InfiniBand Metrics

--- a/pkg/module/metrics/dns.go
+++ b/pkg/module/metrics/dns.go
@@ -56,20 +56,35 @@ func (d *DNSMetrics) Init(metricName string) {
 			exporter.AdvancedRegistry,
 			DNSRequestCountName,
 			DNSRequestCountDesc,
-			d.getLabels()...,
+			d.getRequestLabels()...,
 		)
 	case utils.DNSResponseCounterName:
 		d.dnsMetrics = exporter.CreatePrometheusCounterVecForMetric(
 			exporter.AdvancedRegistry,
 			DNSResponseCountName,
 			DNSResponseCountDesc,
-			d.getLabels()...,
+			d.getResponseLabels()...,
 		)
 	}
 }
 
-func (d *DNSMetrics) getLabels() []string {
-	labels := utils.DNSLabels
+func (d *DNSMetrics) getRequestLabels() []string {
+	labels := utils.DNSRequestLabels
+	if d.srcCtx != nil {
+		labels = append(labels, d.srcCtx.getLabels()...)
+		d.l.Info("src labels", zap.Any("labels", labels))
+	}
+
+	if d.dstCtx != nil {
+		labels = append(labels, d.dstCtx.getLabels()...)
+		d.l.Info("dst labels", zap.Any("labels", labels))
+	}
+
+	return labels
+}
+
+func (d *DNSMetrics) getResponseLabels() []string {
+	labels := utils.DNSResponseLabels
 	if d.srcCtx != nil {
 		labels = append(labels, d.srcCtx.getLabels()...)
 		d.l.Info("src labels", zap.Any("labels", labels))

--- a/pkg/module/metrics/dns_test.go
+++ b/pkg/module/metrics/dns_test.go
@@ -124,7 +124,7 @@ func TestValues(t *testing.T) {
 		},
 		{
 			name:   "Query",
-			want:   []string{"NOERROR", "A", "bing.com", "", "0"},
+			want:   []string{"A", "bing.com"},
 			d:      &DNSMetrics{metricName: utils.DNSRequestCounterName},
 			input:  testQ,
 			l7Type: flow.L7FlowType_REQUEST,
@@ -167,8 +167,22 @@ func TestValues(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.d.values(tt.input); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Values() = %v, want %v", got, tt.want)
+			switch tt.l7Type {
+			case flow.L7FlowType_REQUEST:
+				if got := tt.d.requestValues(tt.input); !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("RequestValues() = %v, want %v", got, tt.want)
+				}
+			case flow.L7FlowType_RESPONSE:
+				if got := tt.d.responseValues(tt.input); !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("ResponseValues() = %v, want %v", got, tt.want)
+				}
+			case flow.L7FlowType_UNKNOWN_L7_TYPE:
+				if got := tt.d.responseValues(tt.input); !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("ResponseValues() = %v, want %v", got, tt.want)
+				}
+			case flow.L7FlowType_SAMPLE:
+			default:
+				t.Errorf("Invalid L7FlowType")
 			}
 			if tt.input == nil {
 				return

--- a/pkg/module/metrics/latency.go
+++ b/pkg/module/metrics/latency.go
@@ -107,7 +107,6 @@ func NewLatencyMetrics(ctxOptions *api.MetricsContextOptions, fl *log.ZapLogger,
 			exporter.AdvancedRegistry,
 			noResponseFromNodeAPIServerName,
 			noResponseFromNodeAPIServerDesc,
-			"count",
 		)
 	}
 

--- a/pkg/plugin/dns/dns_linux_test.go
+++ b/pkg/plugin/dns/dns_linux_test.go
@@ -141,7 +141,7 @@ func TestRequestEventHandler(t *testing.T) {
 
 	// Basic metrics.
 	mockCV := metrics.NewMockICounterVec(ctrl)
-	mockCV.EXPECT().WithLabelValues(event.Rcode, event.QType, event.DNSName, "", "0").Return(c).Times(1)
+	mockCV.EXPECT().WithLabelValues(event.QType, event.DNSName).Return(c).Times(1)
 	before := value(c)
 	metrics.DNSRequestCounter = mockCV
 

--- a/pkg/utils/attr_utils.go
+++ b/pkg/utils/attr_utils.go
@@ -82,7 +82,8 @@ var (
 	Windows   = "windows"
 
 	// DNS labels.
-	DNSLabels = []string{"return_code", "query_type", "query", "response", "num_response"}
+	DNSRequestLabels  = []string{"query_type", "query"}
+	DNSResponseLabels = []string{"return_code", "query_type", "query", "response", "num_response"}
 )
 
 func GetPluginEventAttributes(attrs []attribute.KeyValue, pluginName, eventName, timestamp string) []attribute.KeyValue {

--- a/test/e2e/scenarios/dns/scenarios.go
+++ b/test/e2e/scenarios/dns/scenarios.go
@@ -97,9 +97,8 @@ func ValidateBasicDNSMetrics(scenarioName string, req *RequestValidationParams, 
 		},
 		{
 			Step: &validateBasicDNSRequestMetrics{
-				NumResponse: req.NumResponse,
-				Query:       req.Query,
-				QueryType:   req.QueryType,
+				Query:     req.Query,
+				QueryType: req.QueryType,
 			},
 			Opts: &types.StepOptions{
 				SkipSavingParamatersToJob: true,
@@ -203,7 +202,6 @@ func ValidateAdvancedDNSMetrics(scenarioName string, req *RequestValidationParam
 		{
 			Step: &ValidateAdvancedDNSRequestMetrics{
 				Namespace:          "kube-system",
-				NumResponse:        req.NumResponse,
 				PodName:            podName,
 				Query:              req.Query,
 				QueryType:          req.QueryType,

--- a/test/e2e/scenarios/dns/validate-advanced-dns-metric.go
+++ b/test/e2e/scenarios/dns/validate-advanced-dns-metric.go
@@ -19,7 +19,6 @@ var (
 
 type ValidateAdvancedDNSRequestMetrics struct {
 	Namespace    string
-	NumResponse  string
 	PodName      string
 	Query        string
 	QueryType    string
@@ -40,12 +39,9 @@ func (v *ValidateAdvancedDNSRequestMetrics) Run() error {
 	validateAdvancedDNSRequestMetrics := map[string]string{
 		"ip":            podIP,
 		"namespace":     v.Namespace,
-		"num_response":  v.NumResponse,
 		"podname":       v.PodName,
 		"query":         v.Query,
 		"query_type":    v.QueryType,
-		"response":      "",
-		"return_code":   "",
 		"workload_kind": v.WorkloadKind,
 		"workload_name": v.WorkloadName,
 	}

--- a/test/e2e/scenarios/dns/validate-basic-dns-metric.go
+++ b/test/e2e/scenarios/dns/validate-basic-dns-metric.go
@@ -17,20 +17,16 @@ var (
 )
 
 type validateBasicDNSRequestMetrics struct {
-	NumResponse string
-	Query       string
-	QueryType   string
+	Query     string
+	QueryType string
 }
 
 func (v *validateBasicDNSRequestMetrics) Run() error {
 	metricsEndpoint := fmt.Sprintf("http://localhost:%d/metrics", common.RetinaPort)
 
 	validBasicDNSRequestMetricLabels := map[string]string{
-		"num_response": v.NumResponse,
-		"query":        v.Query,
-		"query_type":   v.QueryType,
-		"return_code":  "",
-		"response":     "",
+		"query":      v.Query,
+		"query_type": v.QueryType,
 	}
 
 	err := prom.CheckMetric(metricsEndpoint, dnsBasicRequestCountMetricName, validBasicDNSRequestMetricLabels)


### PR DESCRIPTION
# Description

Basic DNS metrics
![image](https://github.com/microsoft/retina/assets/28567936/c0b92e94-23e6-4525-abe7-398cf9dc0120)

Advanced DNS metrics
![image](https://github.com/microsoft/retina/assets/28567936/fdd7463c-5458-4bdd-be63-f40c29672a59)


Closes https://github.com/microsoft/retina/issues/75

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
