### PR TITLE
fix: operator deployment ignores custom namespace

### DIFF
--- a/deploy/hubble/manifests/controller/helm/retina/templates/operator/clusterrolebinding.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/operator/clusterrolebinding.yaml
@@ -17,6 +17,6 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: retina-operator
-  namespace: kube-system
+  namespace: {{ .Values.namespace }}
 
 {{- end -}}

--- a/deploy/hubble/manifests/controller/helm/retina/templates/operator/deployment.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/operator/deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: retina-operator
-  namespace: kube-system
+  namespace: {{ .Values.namespace }}
   labels:
     app: retina-operator
     control-plane: retina-operator

--- a/deploy/hubble/manifests/controller/helm/retina/templates/operator/serviceaccount.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/operator/serviceaccount.yaml
@@ -11,6 +11,6 @@ metadata:
     app.kubernetes.io/part-of: operator
     app.kubernetes.io/managed-by: kustomize
   name: retina-operator
-  namespace: kube-system
+  namespace: {{ .Values.namespace }}
 
 {{- end -}}


### PR DESCRIPTION
# Description

This fixes the operator deployment actually using the namespace defined in the helm values. Without this fix, the deployment will fail, since the configuration ConfigMap for the operator is deployed in the specified namespace while the operator itself is deployed in `kube-system`.

## Related Issue

Fixes #492 

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.
