### PR TITLE
feat: pktmon client recreation + remove ltsc2019 in azp

### DIFF
--- a/.pipelines/cg-pipeline.yaml
+++ b/.pipelines/cg-pipeline.yaml
@@ -135,39 +135,6 @@ stages:
               pathtoPublish: "$(Build.ArtifactStagingDirectory)"
             condition: succeeded()
 
-      # windows 2019 only in buildx, windows server 2022 requires native windows container build because of cgo
-      - job: retinaagentimageswin2019
-        displayName: Build Retina Windows Images (buildx)
-        pool:
-          name: "$(BUILD_POOL_NAME_DEFAULT)"
-        strategy:
-          matrix:
-            windows-ltsc2019:
-              platform: "windows"
-              arch: "amd64"
-              year: "2019"
-
-        steps:
-          - checkout: self
-            fetchTags: true
-          - script: |
-              set -euo pipefail
-              echo "VERSION=$(make version)"
-              export VERSION=$(make version)
-              mkdir -p ./output/images/$(platform)/$(arch)/$(year)
-              make retina-image-win \
-                TARGET=final \
-                WINDOWS_YEARS=$(year) \
-                TAG=$(make version) \
-                BUILDX_ACTION="-o type=docker,dest=./output/images/$(platform)/$(arch)/$(year)/retina-agent-$VERSION-windows-ltsc$(year)-$(arch).tar"
-            displayName: "Build Retina Windows Image"
-
-          - task: PublishBuildArtifacts@1
-            inputs:
-              artifactName: output
-              pathtoPublish: ./output
-            condition: succeeded()
-
       - job: windowsnative
         displayName: Build Retina Windows Images (native)
         pool:

--- a/.pipelines/cg-pipeline.yaml
+++ b/.pipelines/cg-pipeline.yaml
@@ -143,12 +143,29 @@ stages:
           - checkout: self
             fetchTags: true
 
-          - task: Docker@2
-            displayName: Docker Login
+      
+
+          - task: DownloadPipelineArtifact@2
             inputs:
-              containerRegistry: $(WINDOWS_BUILDER_REGISTRY)
-              command: "login"
-              addPipelineData: false
+              buildType: 'specific'
+              project: $(BUILDER_ADO_PROECT)
+              definition: $(BUILDER_ADO_DEFINITION_ID) # Replace with your build definition ID
+              buildId: $(BUILDER_ADO_BUILD_ID)
+              artifactName: $(BUILDER_ADO_ARTIFACTE_NAME) # Replace with your artifact name
+              itemPattern:  '**/*builder*.tar'
+              downloadPath: '$(Pipeline.Workspace)\artifacts'
+
+          - task: PowerShell@2
+            displayName: "Load Builder Image"
+            inputs:
+              targetType: "inline"
+              script: |
+                $rootDir = "$(Pipeline.Workspace)\artifacts"
+                $dockerImages = Get-ChildItem -Path $rootDir -Recurse -Filter *.tar
+                foreach ($image in $dockerImages) {
+                    Write-Host "Loading Docker image: $($image.FullName)"
+                    docker load -i $image.FullName
+                }
 
           - task: PowerShell@2
             displayName: "Build Retina Windows Image (LTSC2022)"

--- a/controller/Dockerfile.windows-native
+++ b/controller/Dockerfile.windows-native
@@ -7,9 +7,8 @@ FROM  --platform=windows/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.22-wi
 WORKDIR C:\\retina
 COPY go.mod .
 COPY go.sum .
-ENV CGO_ENABLED=1
+ENV CGO_ENABLED=0
 RUN go mod download
-RUN go mod verify
 ADD . .
 ARG VERSION
 ARG APP_INSIGHTS_ID

--- a/controller/Dockerfile.windows-native.dockerignore
+++ b/controller/Dockerfile.windows-native.dockerignore
@@ -1,2 +1,3 @@
 pkg/plugin/windows/pktmon/packetmonitorsupport/*
 *.tar
+    

--- a/pkg/plugin/windows/pktmon/pktmon_plugin_windows.go
+++ b/pkg/plugin/windows/pktmon/pktmon_plugin_windows.go
@@ -151,7 +151,6 @@ func (p *Plugin) Start(ctx context.Context) error {
 				// Instead, we will try to recreate the client and stream
 				if _, ok := status.FromError(err); ok {
 					var clientErr error
-					clientErr = str.CloseSend()
 					if clientErr != nil {
 						return fmt.Errorf("failed to close observer after after failure: %w, parent: %w", clientErr, err)
 					}


### PR DESCRIPTION
# Description
Occasionally the grpc stream experiences transient errors, which are mitigated by recreating the client observer stream. Requires further RCA, but this avoids crashloopbackoff, and gracefully logs to continue

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
