### PR TITLE
fix: capture commands should respect --namespace

### DIFF
--- a/cli/cmd/capture/capture.go
+++ b/cli/cmd/capture/capture.go
@@ -9,7 +9,10 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
-var name string
+var opts = struct {
+	genericclioptions.ConfigFlags
+	Name *string
+}{}
 
 const defaultName = "retina-capture"
 
@@ -20,7 +23,7 @@ var capture = &cobra.Command{
 
 func init() {
 	cmd.Retina.AddCommand(capture)
-	configFlags = genericclioptions.NewConfigFlags(true)
-	configFlags.AddFlags(capture.PersistentFlags())
-	capture.PersistentFlags().StringVar(&name, "name", defaultName, "The name of the Retina Capture")
+	opts.ConfigFlags = *genericclioptions.NewConfigFlags(true)
+	opts.AddFlags(capture.PersistentFlags())
+	capture.PersistentFlags().StringVar(opts.Name, "name", defaultName, "The name of the Retina Capture")
 }

--- a/cli/cmd/capture/download.go
+++ b/cli/cmd/capture/download.go
@@ -45,14 +45,14 @@ var downloadCapture = &cobra.Command{
 		splitPath := strings.SplitN(containerPath, "/", 2) //nolint:gomnd // TODO string splitting probably isn't the right way to parse this URL?
 		containerName := splitPath[0]
 
-		params := storage.ListBlobsParameters{Prefix: name}
+		params := storage.ListBlobsParameters{Prefix: *opts.Name}
 		blobList, err := blobService.GetContainerReference(containerName).ListBlobs(params)
 		if err != nil {
 			return errors.Wrap(err, "failed to list blobstore ")
 		}
 
 		if len(blobList.Blobs) == 0 {
-			return errors.Errorf("no blobs found with prefix: %s", name)
+			return errors.Errorf("no blobs found with prefix: %s", *opts.Name)
 		}
 
 		for _, v := range blobList.Blobs {

--- a/cli/cmd/capture/list.go
+++ b/cli/cmd/capture/list.go
@@ -26,7 +26,7 @@ var listCaptures = &cobra.Command{
 	Short:   "List Retina Captures",
 	Example: listExample,
 	RunE: func(*cobra.Command, []string) error {
-		kubeConfig, err := configFlags.ToRESTConfig()
+		kubeConfig, err := opts.ToRESTConfig()
 		if err != nil {
 			return errors.Wrap(err, "failed to compose k8s rest config")
 		}
@@ -36,7 +36,7 @@ var listCaptures = &cobra.Command{
 			return errors.Wrap(err, "failed to initialize kubernetes client")
 		}
 
-		captureNamespace := namespace
+		captureNamespace := *opts.Namespace
 		if allNamespaces {
 			captureNamespace = ""
 		}
@@ -46,7 +46,6 @@ var listCaptures = &cobra.Command{
 
 func init() {
 	capture.AddCommand(listCaptures)
-	listCaptures.Flags().StringVarP(&namespace, "namespace", "n", "default", "Namespace to host capture job")
 	listCaptures.Flags().BoolVarP(&allNamespaces, "all-namespaces", "A", allNamespaces,
 		"If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
 }


### PR DESCRIPTION
# Description

Fix `capture` subcommands to respect the cli-runtime `--namespace` CLI flag.

## Related Issue

Closes #477

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
