### PR TITLE
fix: move version and appinsightsID to a centralized location (internal/buildinfo)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ retina: ## builds retina binary
 retina-binary: ## build the Retina binary
 	export CGO_ENABLED=0 && \
 	go generate ./... && \
-	go build -v -o $(RETINA_BUILD_DIR)/retina$(EXE_EXT) -gcflags="-dwarflocationlists=true" -ldflags "-X main.version=$(TAG) -X main.applicationInsightsID=$(APP_INSIGHTS_ID)" $(RETINA_DIR)/main.go
+	go build -v -o $(RETINA_BUILD_DIR)/retina$(EXE_EXT) -gcflags="-dwarflocationlists=true" -ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version=$(TAG) -X github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID=$(APP_INSIGHTS_ID)" $(RETINA_DIR)/main.go
 
 retina-capture-workload: ## build the Retina capture workload
 	cd $(CAPTURE_WORKLOAD_DIR) && CGO_ENABLED=0 go build -v -o $(RETINA_BUILD_DIR)/captureworkload$(EXE_EXT) -gcflags="-dwarflocationlists=true"  -ldflags "-X main.version=$(TAG)"

--- a/cmd/hubble/cells_linux.go
+++ b/cmd/hubble/cells_linux.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cilium/cilium/pkg/pprof"
 	"github.com/cilium/proxy/pkg/logging"
 	"github.com/cilium/proxy/pkg/logging/logfields"
+	"github.com/microsoft/retina/internal/buildinfo"
 	"github.com/microsoft/retina/pkg/config"
 	rnode "github.com/microsoft/retina/pkg/controllers/daemon/nodereconciler"
 	hubbleserver "github.com/microsoft/retina/pkg/hubble"
@@ -59,8 +60,8 @@ var (
 			return telemetry.Config{
 				Component:             "retina-agent",
 				EnableTelemetry:       cfg.EnableTelemetry,
-				ApplicationInsightsID: applicationInsightsID,
-				RetinaVersion:         retinaVersion,
+				ApplicationInsightsID: buildinfo.ApplicationInsightsID,
+				RetinaVersion:         buildinfo.Version,
 				EnabledPlugins:        cfg.EnabledPlugin,
 			}
 		}),

--- a/cmd/hubble_linux.go
+++ b/cmd/hubble_linux.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/cilium/cilium/pkg/hive"
 	"github.com/microsoft/retina/cmd/hubble"
+	"github.com/microsoft/retina/internal/buildinfo"
 	"github.com/spf13/cobra"
-	"go.etcd.io/etcd/version"
 )
 
 var (
@@ -19,7 +19,7 @@ var (
 		Short: "Start Hubble control plane",
 		Run: func(cobraCmd *cobra.Command, _ []string) {
 			if v, _ := cobraCmd.Flags().GetBool("version"); v {
-				fmt.Printf("%s %s\n", cobraCmd.Name(), version.Version)
+				fmt.Printf("%s %s\n", cobraCmd.Name(), buildinfo.Version)
 			}
 			hubble.Execute(cobraCmd, h)
 		},

--- a/cmd/legacy/daemon.go
+++ b/cmd/legacy/daemon.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/go-logr/zapr"
 	retinav1alpha1 "github.com/microsoft/retina/crd/api/v1alpha1"
+	"github.com/microsoft/retina/internal/buildinfo"
 	"github.com/microsoft/retina/pkg/config"
 	controllercache "github.com/microsoft/retina/pkg/controllers/cache"
 	mcc "github.com/microsoft/retina/pkg/controllers/daemon/metricsconfiguration"
@@ -52,15 +53,7 @@ const (
 	nodeIPEnvKey   = "NODE_IP"
 )
 
-var (
-	scheme = k8sruntime.NewScheme()
-
-	// applicationInsightsID is the instrumentation key for Azure Application Insights
-	// It is set during the build process using the -ldflags flag
-	// If it is set, the application will send telemetry to the corresponding Application Insights resource.
-	applicationInsightsID string
-	version               string
-)
+var scheme = k8sruntime.NewScheme()
 
 func init() {
 	//+kubebuilder:scaffold:scheme
@@ -85,10 +78,10 @@ func NewDaemon(metricsAddr, probeAddr, configFile string, enableLeaderElection b
 }
 
 func (d *Daemon) Start() error {
-	fmt.Printf("starting Retina daemon with legacy control plane %v\n", version)
+	fmt.Printf("starting Retina daemon with legacy control plane %v\n", buildinfo.Version)
 
-	if applicationInsightsID != "" {
-		telemetry.InitAppInsights(applicationInsightsID, version)
+	if buildinfo.ApplicationInsightsID != "" {
+		telemetry.InitAppInsights(buildinfo.ApplicationInsightsID, buildinfo.Version)
 		defer telemetry.ShutdownAppInsights()
 		defer telemetry.TrackPanic()
 	}
@@ -112,10 +105,10 @@ func (d *Daemon) Start() error {
 		MaxFileSizeMB:         100, //nolint:gomnd // defaults
 		MaxBackups:            3,   //nolint:gomnd // defaults
 		MaxAgeDays:            30,  //nolint:gomnd // defaults
-		ApplicationInsightsID: applicationInsightsID,
+		ApplicationInsightsID: buildinfo.ApplicationInsightsID,
 		EnableTelemetry:       daemonConfig.EnableTelemetry,
 	},
-		zap.String("version", version),
+		zap.String("version", buildinfo.Version),
 		zap.String("apiserver", cfg.Host),
 		zap.String("plugins", strings.Join(daemonConfig.EnabledPlugin, `,`)),
 	)
@@ -128,10 +121,10 @@ func (d *Daemon) Start() error {
 	metrics.InitializeMetrics()
 
 	var tel telemetry.Telemetry
-	if daemonConfig.EnableTelemetry && applicationInsightsID != "" {
-		mainLogger.Info("telemetry enabled", zap.String("applicationInsightsID", applicationInsightsID))
+	if daemonConfig.EnableTelemetry && buildinfo.ApplicationInsightsID != "" {
+		mainLogger.Info("telemetry enabled", zap.String("applicationInsightsID", buildinfo.ApplicationInsightsID))
 		tel = telemetry.NewAppInsightsTelemetryClient("retina-agent", map[string]string{
-			"version":   version,
+			"version":   buildinfo.Version,
 			"apiserver": cfg.Host,
 			"plugins":   strings.Join(daemonConfig.EnabledPlugin, `,`),
 		})

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -46,7 +46,7 @@ ENV GOARCH=${GOARCH}
 ENV GOOS=${GOOS}
 COPY . /go/src/github.com/microsoft/retina 
 WORKDIR /go/src/github.com/microsoft/retina
-RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /go/bin/retina/captureworkload -ldflags "-X main.version="$VERSION" -X main.applicationInsightsID="$APP_INSIGHTS_ID"" captureworkload/main.go
+RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /go/bin/retina/captureworkload -ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version="$VERSION" -X github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID="$APP_INSIGHTS_ID"" captureworkload/main.go
 
 
 # controller binary
@@ -58,7 +58,7 @@ ARG VERSION
 ENV CGO_ENABLED=0
 ENV GOARCH=${GOARCH}
 ENV GOOS=${GOOS}
-RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /go/bin/retina/controller -ldflags "-X main.version="$VERSION" -X main.applicationInsightsID="$APP_INSIGHTS_ID"" controller/main.go 
+RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /go/bin/retina/controller -ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version="$VERSION" -X github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID="$APP_INSIGHTS_ID"" controller/main.go 
 
 
 # init binary
@@ -70,7 +70,7 @@ ARG VERSION
 ENV CGO_ENABLED=0
 ENV GOARCH=${GOARCH}
 ENV GOOS=${GOOS}
-RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /go/bin/retina/initretina -ldflags "-X main.version="$VERSION" -X main.applicationInsightsID="$APP_INSIGHTS_ID"" init/retina/main_linux.go
+RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /go/bin/retina/initretina -ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version="$VERSION" -X github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID="$APP_INSIGHTS_ID"" init/retina/main_linux.go
 
 
 # tools image

--- a/controller/Dockerfile.windows-2019
+++ b/controller/Dockerfile.windows-2019
@@ -10,7 +10,7 @@ WORKDIR /usr/src/retina
 # Copy the source
 COPY . .
 
-RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /usr/bin/controller.exe -ldflags "-X main.version="$VERSION" -X "main.applicationInsightsID"="$APP_INSIGHTS_ID""  ./controller/
+RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /usr/bin/controller.exe -ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version="$VERSION" -X "github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID"="$APP_INSIGHTS_ID""  ./controller/
 RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /usr/bin/captureworkload.exe ./captureworkload/
 
 # Copy into final image

--- a/controller/Dockerfile.windows-2022
+++ b/controller/Dockerfile.windows-2022
@@ -9,7 +9,7 @@ WORKDIR /usr/src/retina
 # Copy the source
 COPY . .
 
-RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /usr/bin/controller.exe -ldflags "-X main.version="$VERSION" -X "main.applicationInsightsID"="$APP_INSIGHTS_ID"" ./controller/
+RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /usr/bin/controller.exe -ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version="$VERSION" -X "github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID"="$APP_INSIGHTS_ID"" ./controller/
 RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /usr/bin/captureworkload.exe ./captureworkload/
 
 # Copy into final image

--- a/controller/Dockerfile.windows-native
+++ b/controller/Dockerfile.windows-native
@@ -17,8 +17,8 @@ SHELL ["cmd", "/S", "/C"]
 ENV VERSION=$VERSION
 
 ENV APP_INSIGHTS_ID=$APP_INSIGHTS_ID
-RUN go build -v -o controller.exe -ldflags="-X main.version=%VERSION% -X main.applicationInsightsID=%APP_INSIGHTS_ID%" .\controller
-RUN go build -v -o captureworkload.exe -ldflags="-X main.version=%VERSION% -X main.applicationInsightsID=%APP_INSIGHTS_ID%" .\captureworkload
+RUN go build -v -o controller.exe -ldflags="-X github.com/microsoft/retina/internal/buildinfo.Version=%VERSION% -X github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID=%APP_INSIGHTS_ID%" .\controller
+RUN go build -v -o captureworkload.exe -ldflags="-X github.com/microsoft/retina/internal/buildinfo.Version=%VERSION% -X github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID=%APP_INSIGHTS_ID%" .\captureworkload
 
 FROM --platform=windows/amd64 ${BUILDER_IMAGE} as pktmon-builder
 WORKDIR C:\\retina

--- a/init/retina/main_linux.go
+++ b/init/retina/main_linux.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"github.com/microsoft/retina/internal/buildinfo"
 	"github.com/microsoft/retina/pkg/bpf"
 	"github.com/microsoft/retina/pkg/ciliumfs"
 	"github.com/microsoft/retina/pkg/log"
@@ -11,24 +12,16 @@ import (
 	"go.uber.org/zap"
 )
 
-var (
-	// applicationInsightsID is the instrumentation key for Azure Application Insights
-	// It is set during the build process using the -ldflags flag
-	// If it is set, the application will send telemetry to the corresponding Application Insights resource.
-	applicationInsightsID string
-	version               string
-)
-
 func main() {
 	// Initialize logger
 	opts := log.GetDefaultLogOpts()
 
 	// Enable telemetry if applicationInsightsID is provided
-	if applicationInsightsID != "" {
+	if buildinfo.ApplicationInsightsID != "" {
 		opts.EnableTelemetry = true
-		opts.ApplicationInsightsID = applicationInsightsID
+		opts.ApplicationInsightsID = buildinfo.ApplicationInsightsID
 		// Initialize application insights
-		telemetry.InitAppInsights(applicationInsightsID, version)
+		telemetry.InitAppInsights(buildinfo.ApplicationInsightsID, buildinfo.Version)
 		defer telemetry.ShutdownAppInsights()
 		defer telemetry.TrackPanic()
 	}
@@ -37,7 +30,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	l := zl.Named("init-retina").With(zap.String("version", version))
+	l := zl.Named("init-retina").With(zap.String("version", buildinfo.Version))
 
 	// Setup BPF
 	bpf.Setup(l)

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -1,0 +1,12 @@
+package buildinfo
+
+// These variables will be populate by the Go compiler via
+// the -ldflags, which insert dynamic information
+// into the binary at build time
+var (
+	// ApplicationInsightsID is the instrumentation key for Azure Application Insights
+	// It is set during the build process using the -ldflags flag
+	// If it is set, the application will send telemetry to the corresponding Application Insights resource.
+	ApplicationInsightsID string
+	Version               string
+)

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -16,8 +16,8 @@ ENV GOARCH=${GOARCH}
 RUN make manifests
 RUN --mount=type=cache,target="/root/.cache/go-build" \
 	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
-	-ldflags "-X main.version="$VERSION" \
-    -X "main.applicationInsightsID"="$APP_INSIGHTS_ID"" \
+	-ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version="$VERSION" \
+    -X "github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID"="$APP_INSIGHTS_ID"" \
 	-a -o retina-operator operator/main.go
 
 ##################### controller #######################

--- a/operator/Dockerfile.windows-2019
+++ b/operator/Dockerfile.windows-2019
@@ -11,7 +11,7 @@ WORKDIR /usr/src/retina
 # Copy the source
 COPY . .
 
-RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -ldflags "-X main.version="$VERSION" -X "main.applicationInsightsID"="$APP_INSIGHTS_ID"" -o -o /usr/bin/retina-operator.exe retina-operator operator/main.go
+RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version="$VERSION" -X "github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID"="$APP_INSIGHTS_ID"" -o -o /usr/bin/retina-operator.exe retina-operator operator/main.go
 
 # Copy into final image
 FROM  mcr.microsoft.com/windows/nanoserver:ltsc2019

--- a/operator/Dockerfile.windows-2022
+++ b/operator/Dockerfile.windows-2022
@@ -11,7 +11,7 @@ WORKDIR /usr/src/retina
 # Copy the source
 COPY . .
 
-RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -ldflags "-X main.version="$VERSION" -X "main.applicationInsightsID"="$APP_INSIGHTS_ID"" -o -o /usr/bin/retina-operator.exe retina-operator operator/main.go
+RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version="$VERSION" -X "github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID"="$APP_INSIGHTS_ID"" -o -o /usr/bin/retina-operator.exe retina-operator operator/main.go
 
 # Copy into final image
 FROM  mcr.microsoft.com/windows/nanoserver:ltsc2022

--- a/operator/cmd/cilium-crds/cells_linux.go
+++ b/operator/cmd/cilium-crds/cells_linux.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"sync/atomic"
 
+	"github.com/microsoft/retina/internal/buildinfo"
 	"github.com/microsoft/retina/pkg/shared/telemetry"
 	"github.com/sirupsen/logrus"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
@@ -69,8 +70,8 @@ var (
 			return telemetry.Config{
 				Component:             "retina-operator",
 				EnableTelemetry:       cfg.EnableTelemetry,
-				ApplicationInsightsID: applicationInsightsID,
-				RetinaVersion:         retinaVersion,
+				ApplicationInsightsID: buildinfo.ApplicationInsightsID,
+				RetinaVersion:         buildinfo.Version,
 			}
 		}),
 		telemetry.Constructor,

--- a/operator/cmd/cilium-crds/root_linux.go
+++ b/operator/cmd/cilium-crds/root_linux.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/microsoft/retina/internal/buildinfo"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
@@ -33,10 +34,6 @@ import (
 )
 
 var (
-	// set at build time in Dockerfile
-	applicationInsightsID string
-	retinaVersion         string
-
 	// set logger field: subsys=retina-operator
 	binaryName       = filepath.Base(os.Args[0])
 	logger           = logging.DefaultLogger.WithField(logfields.LogSubsys, binaryName)
@@ -92,7 +89,7 @@ func initEnv(vp *viper.Viper) {
 	}
 
 	option.LogRegisteredOptions(vp, logger)
-	logger.Infof("retina operator version: %s", retinaVersion)
+	logger.Infof("retina operator version: %s", buildinfo.Version)
 }
 
 func doCleanup() {

--- a/operator/cmd/cilium-crds/zap_linux.go
+++ b/operator/cmd/cilium-crds/zap_linux.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/option"
+	"github.com/microsoft/retina/internal/buildinfo"
 	"github.com/microsoft/retina/pkg/log"
 	"github.com/sirupsen/logrus"
 	"go.uber.org/zap"
@@ -52,12 +53,12 @@ func setupZapHook(p params) {
 		MaxFileSizeMB:         MaxFileSizeMB,
 		MaxBackups:            MaxBackups,
 		MaxAgeDays:            MaxAgeDays,
-		ApplicationInsightsID: applicationInsightsID,
+		ApplicationInsightsID: buildinfo.ApplicationInsightsID,
 		EnableTelemetry:       p.OperatorCfg.EnableTelemetry,
 	}
 
 	persistentFields := []zap.Field{
-		zap.String("version", retinaVersion),
+		zap.String("version", buildinfo.Version),
 		zap.String("apiserver", p.K8sCfg.Host),
 	}
 
@@ -67,7 +68,7 @@ func setupZapHook(p params) {
 	}
 
 	namedLogger := log.Logger().Named("retina-operator-v2")
-	namedLogger.Info("Traces telemetry initialized with zapai", zap.String("version", retinaVersion), zap.String("appInsightsID", lOpts.ApplicationInsightsID))
+	namedLogger.Info("Traces telemetry initialized with zapai", zap.String("version", buildinfo.Version), zap.String("appInsightsID", lOpts.ApplicationInsightsID))
 
 	var hook *zaphook.ZapHook
 	hook, err = zaphook.NewZapHook(namedLogger.Logger)


### PR DESCRIPTION
# Description

As title. These will be populated by the Go compiler via the -ldflags during build. Also fixed https://github.com/microsoft/retina/issues/530

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
