### PR TITLE
feat: add runtime telemetry to heartbeat

### DIFF
--- a/cmd/legacy/daemon.go
+++ b/cmd/legacy/daemon.go
@@ -47,7 +47,7 @@ import (
 
 const (
 	logFileName       = "retina.log"
-	heartbeatInterval = 5 * time.Minute
+	heartbeatInterval = 10 * time.Minute
 
 	nodeNameEnvKey = "NODE_NAME"
 	nodeIPEnvKey   = "NODE_IP"

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -21,14 +21,13 @@ import (
 var (
 	client  appinsights.TelemetryClient
 	version string
-	btoMb   uint64 = 1024
+	mbShift uint64 = 20
 
 	// property keys
-	kernelversion     = "kernelversion"
-	allocatedmem      = "allocmem"
-	totalallocatedmem = "totalallocmem"
-	sysmem            = "sysmem"
-	goroutines        = "goroutines"
+	kernelversion = "kernelversion"
+	allocatedmem  = "allocmem"
+	sysmem        = "sysmem"
+	goroutines    = "goroutines"
 )
 
 type Telemetry interface {
@@ -155,18 +154,17 @@ func (t *TelemetryClient) heartbeat(ctx context.Context) {
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)
 	props := map[string]string{
-		kernelversion:     kernelVersion,
-		allocatedmem:      strconv.FormatUint(bToMb(m.Alloc), 10),
-		totalallocatedmem: strconv.FormatUint(bToMb(m.TotalAlloc), 10),
-		sysmem:            strconv.FormatUint(bToMb(m.Sys), 10),
-		goroutines:        strconv.Itoa(runtime.NumGoroutine()),
+		kernelversion: kernelVersion,
+		allocatedmem:  strconv.FormatUint(bToMb(m.Alloc), 10),
+		sysmem:        strconv.FormatUint(bToMb(m.Sys), 10),
+		goroutines:    strconv.Itoa(runtime.NumGoroutine()),
 	}
 
 	t.TrackEvent("heartbeat", props)
 }
 
 func bToMb(b uint64) uint64 {
-	return b / btoMb / btoMb
+	return b >> mbShift
 }
 
 func (t *TelemetryClient) TrackEvent(name string, properties map[string]string) {

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"runtime"
 	"runtime/debug"
+	"strconv"
 	"sync"
 	"time"
 
@@ -20,6 +21,14 @@ import (
 var (
 	client  appinsights.TelemetryClient
 	version string
+	btoMb   uint64 = 1024
+
+	// property keys
+	kernelversion     = "kernelversion"
+	allocatedmem      = "allocmem"
+	totalallocatedmem = "totalallocmem"
+	sysmem            = "sysmem"
+	goroutines        = "goroutines"
 )
 
 type Telemetry interface {
@@ -143,7 +152,21 @@ func (t *TelemetryClient) heartbeat(ctx context.Context) {
 		t.trackWarning(err, "failed to get kernel version")
 	}
 
-	t.TrackEvent("heartbeat", map[string]string{"kernelversion": kernelVersion})
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	props := map[string]string{
+		kernelversion:     kernelVersion,
+		allocatedmem:      strconv.FormatUint(bToMb(m.Alloc), 10),
+		totalallocatedmem: strconv.FormatUint(bToMb(m.TotalAlloc), 10),
+		sysmem:            strconv.FormatUint(bToMb(m.Sys), 10),
+		goroutines:        strconv.Itoa(runtime.NumGoroutine()),
+	}
+
+	t.TrackEvent("heartbeat", props)
+}
+
+func bToMb(b uint64) uint64 {
+	return b / btoMb / btoMb
 }
 
 func (t *TelemetryClient) TrackEvent(name string, properties map[string]string) {

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -130,3 +130,7 @@ func TestTelemetryClient_StopPerf(t *testing.T) {
 		})
 	}
 }
+
+func TestBtoMB(t *testing.T) {
+	require.Equal(t, uint64(1), bToMb(1048576))
+}


### PR DESCRIPTION
# Description

Please provide a brief description of the changes made in this pull request.

Add runtime profile metrics to the heartbeat for long term performance metrics.

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
