### PR TITLE
fix: update readdirs in infiniband plugin

### DIFF
--- a/pkg/plugin/infiniband/filesystem_test.go
+++ b/pkg/plugin/infiniband/filesystem_test.go
@@ -2,7 +2,7 @@ package infiniband
 
 import "testing/fstest"
 
-var embeddedFs = fstest.MapFS{ // nolint unused
+var testFS = fstest.MapFS{ // nolint unused
 	"infiniband/mlx5_ib0/ports/1/counters/excessive_buffer_overrun_errors": &fstest.MapFile{
 		Data: []byte("1"),
 	},

--- a/pkg/plugin/infiniband/infiniband_linux.go
+++ b/pkg/plugin/infiniband/infiniband_linux.go
@@ -6,6 +6,7 @@ package infiniband
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	hubblev1 "github.com/cilium/cilium/pkg/hubble/api/v1"
@@ -14,6 +15,8 @@ import (
 	"github.com/microsoft/retina/pkg/plugin/api"
 	"go.uber.org/zap"
 )
+
+var ErrAlreadyRunning = errors.New("infiniband plugin is already running")
 
 // New creates a infiniband plugin.
 func New(cfg *kcfg.Config) api.Plugin {
@@ -36,12 +39,17 @@ func (ib *infiniband) Compile(ctx context.Context) error { //nolint // implement
 }
 
 func (ib *infiniband) Init() error {
-	ib.l.Info("Initializing infiniband plugin...")
 	return nil
 }
 
 func (ib *infiniband) Start(ctx context.Context) error {
+	ib.l.Info("Starting infiniband plugin")
+	ib.startLock.Lock()
+	if ib.isRunning {
+		return ErrAlreadyRunning
+	}
 	ib.isRunning = true
+	ib.startLock.Unlock()
 	return ib.run(ctx)
 }
 

--- a/pkg/plugin/infiniband/infiniband_stats_linux_test.go
+++ b/pkg/plugin/infiniband/infiniband_stats_linux_test.go
@@ -73,7 +73,11 @@ func TestReadCounterStats(t *testing.T) {
 			MockGaugeVec.EXPECT().WithLabelValues(gomock.Any()).Return(testmetric).AnyTimes()
 
 			assert.NotNil(t, nr)
-			err := nr.readCounterStats(embeddedFs, tt.filePath)
+			ibFS, err := testFS.Sub(tt.filePath)
+			if err != nil {
+				t.Fatalf("Error reading fs: %v", err)
+			}
+			err = nr.readCounterStats(ibFS)
 			if tt.wantErr {
 				assert.NotNil(t, err, "Expected error but got nil")
 			} else {
@@ -82,7 +86,7 @@ func TestReadCounterStats(t *testing.T) {
 				for _, val := range nr.counterStats {
 					assert.Equal(t, val, uint64(1))
 				}
-				assert.Equal(t, 4, len(nr.counterStats), "Read values are not equal to expected")
+				assert.Equal(t, 6, len(nr.counterStats), "Read values are not equal to expected")
 				nr.updateMetrics()
 			}
 		})
@@ -127,7 +131,11 @@ func TestReadStatusParamStats(t *testing.T) {
 
 			MockGaugeVec.EXPECT().WithLabelValues(gomock.Any()).Return(testmetric).AnyTimes()
 
-			err := nr.readStatusParamStats(embeddedFs, tt.filePath)
+			netFS, err := testFS.Sub(tt.filePath)
+			if err != nil {
+				t.Fatalf("Error reading fs: %v", err)
+			}
+			err = nr.readStatusParamStats(netFS)
 			if tt.wantErr {
 				assert.NotNil(t, err, "Expected error but got nil") // nolint std. fmt.
 			} else {

--- a/pkg/plugin/infiniband/types_linux.go
+++ b/pkg/plugin/infiniband/types_linux.go
@@ -3,6 +3,8 @@
 package infiniband
 
 import (
+	"sync"
+
 	kcfg "github.com/microsoft/retina/pkg/config"
 	"github.com/microsoft/retina/pkg/log"
 	"github.com/microsoft/retina/pkg/plugin/api"
@@ -17,6 +19,7 @@ type infiniband struct {
 	cfg       *kcfg.Config
 	l         *log.ZapLogger
 	isRunning bool
+	startLock sync.Mutex
 }
 
 type CounterStat struct {


### PR DESCRIPTION
Fixes some issues in the infiniband plugin/tests.

After testing, IB stats are successfully exposed through Retina:
```text
# HELP networkobservability_infiniband_counter_stats InfiniBand Counter Statistics
# TYPE networkobservability_infiniband_counter_stats gauge
networkobservability_infiniband_counter_stats{device="mlx5_0",port="1",statistic_name="VL15_dropped"} 0
networkobservability_infiniband_counter_stats{device="mlx5_0",port="1",statistic_name="excessive_buffer_overrun_errors"} 0
networkobservability_infiniband_counter_stats{device="mlx5_0",port="1",statistic_name="link_downed"} 0
networkobservability_infiniband_counter_stats{device="mlx5_0",port="1",statistic_name="link_error_recovery"} 0
networkobservability_infiniband_counter_stats{device="mlx5_0",port="1",statistic_name="local_link_integrity_errors"} 0
networkobservability_infiniband_counter_stats{device="mlx5_0",port="1",statistic_name="multicast_rcv_packets"} 0
networkobservability_infiniband_counter_stats{device="mlx5_0",port="1",statistic_name="multicast_xmit_packets"} 0
networkobservability_infiniband_counter_stats{device="mlx5_0",port="1",statistic_name="port_rcv_constraint_errors"} 0
networkobservability_infiniband_counter_stats{device="mlx5_0",port="1",statistic_name="port_rcv_data"} 0
networkobservability_infiniband_counter_stats{device="mlx5_0",port="1",statistic_name="port_rcv_errors"} 0
networkobservability_infiniband_counter_stats{device="mlx5_0",port="1",statistic_name="port_rcv_packets"} 0
networkobservability_infiniband_counter_stats{device="mlx5_0",port="1",statistic_name="port_rcv_remote_physical_errors"} 0
networkobservability_infiniband_counter_stats{device="mlx5_0",port="1",statistic_name="port_rcv_switch_relay_errors"} 0
networkobservability_infiniband_counter_stats{device="mlx5_0",port="1",statistic_name="port_xmit_constraint_errors"} 0
networkobservability_infiniband_counter_stats{device="mlx5_0",port="1",statistic_name="port_xmit_data"} 1008
networkobservability_infiniband_counter_stats{device="mlx5_0",port="1",statistic_name="port_xmit_discards"} 0
networkobservability_infiniband_counter_stats{device="mlx5_0",port="1",statistic_name="port_xmit_packets"} 14
networkobservability_infiniband_counter_stats{device="mlx5_0",port="1",statistic_name="port_xmit_wait"} 0
networkobservability_infiniband_counter_stats{device="mlx5_0",port="1",statistic_name="symbol_error"} 0
networkobservability_infiniband_counter_stats{device="mlx5_0",port="1",statistic_name="unicast_rcv_packets"} 0
networkobservability_infiniband_counter_stats{device="mlx5_0",port="1",statistic_name="unicast_xmit_packets"} 14
```