### PR TITLE
fix: mount ib and net dirs when ib plugin enabled

### DIFF
--- a/deploy/legacy/manifests/controller/helm/retina/templates/daemonset.yaml
+++ b/deploy/legacy/manifests/controller/helm/retina/templates/daemonset.yaml
@@ -89,26 +89,38 @@ spec:
               - {{ . }}
               {{- end }}
             privileged: {{ .Values.securityContext.privileged }}
-        {{- if .Values.volumeMounts }}
           volumeMounts:
+          {{- if .Values.volumeMounts }}
           {{- range $name, $mountPath := .Values.volumeMounts }}
-            - name: {{ $name }}
-              mountPath: {{ $mountPath }}
+          - name: {{ $name }}
+            mountPath: {{ $mountPath }}
           {{- end }}
-        {{- end }}
+          {{- end }}
+          {{- if fromYamlArray .Values.enabledPlugin_linux | has "infiniband" }}
+          - name: sysclassnet
+            mountPath: /sys/class/net
+          - name: sysclassinfiniband
+            mountPath: /sys/class/infiniband
+          {{- end }}
       terminationGracePeriodSeconds: 90 # Allow for retina to cleanup plugin resources.
       volumes:
       {{- range $name, $hostPath := .Values.volumeMounts}}
       - name: {{ $name }}
-      {{ if eq $name "config" }}
+      {{- if eq $name "config" }}
         configMap:
           name: {{ $.Values.nameOverride }}-config
-      {{ else if eq $name "tmp"}}
+      {{- else if eq $name "tmp"}}
         emptyDir: {}
-      {{ else }}
+      {{- else }}
         hostPath:
           path: {{ $hostPath }}
-      {{ end }}
+      {{- end }}
+      {{- end }}
+      {{- if fromYamlArray .Values.enabledPlugin_linux | has "infiniband" }}
+      - name: sysclassnet
+        hostPath: /sys/class/net
+      - name: sysclassinfiniband
+        hostPath: /sys/class/infiniband
       {{- end }}
       nodeSelector:
         kubernetes.io/os: linux


### PR DESCRIPTION
# Description

Mounts /sys/class/net and /sys/class/infiniband to the Linux daemonset when the `infiniband` plugin is enabled via Helm. Incidentally fixes some templating whitespace.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

<details><summary>Before</summary>

```yaml
          volumeMounts:
            - name: bpf
              mountPath: /sys/fs/bpf
            - name: cgroup
              mountPath: /sys/fs/cgroup
            - name: config
              mountPath: /retina/config
            - name: debug
              mountPath: /sys/kernel/debug
            - name: tmp
              mountPath: /tmp
            - name: trace
              mountPath: /sys/kernel/tracing
      terminationGracePeriodSeconds: 90 # Allow for retina to cleanup plugin resources.
      volumes:
      - name: bpf
      
        hostPath:
          path: /sys/fs/bpf
      
      - name: cgroup
      
        hostPath:
          path: /sys/fs/cgroup
      
      - name: config
      
        configMap:
          name: retina-config
      
      - name: debug
      
        hostPath:
          path: /sys/kernel/debug
      
      - name: tmp
      
        emptyDir: {}
      
      - name: trace
      
        hostPath:
          path: /sys/kernel/tracing
      
      nodeSelector:
        kubernetes.io/os: linux
```

</details>

<details><summary>After (with IB plugin enabled)</summary>

```yaml
          volumeMounts:
          - name: bpf
            mountPath: /sys/fs/bpf
          - name: cgroup
            mountPath: /sys/fs/cgroup
          - name: config
            mountPath: /retina/config
          - name: debug
            mountPath: /sys/kernel/debug
          - name: tmp
            mountPath: /tmp
          - name: trace
            mountPath: /sys/kernel/tracing
          - name: sysclassnet
            mountPath: /sys/class/net
          - name: sysclassinfiniband
            mountPath: /sys/class/infiniband
      terminationGracePeriodSeconds: 90 # Allow for retina to cleanup plugin resources.
      volumes:
      - name: bpf
        hostPath:
          path: /sys/fs/bpf
      - name: cgroup
        hostPath:
          path: /sys/fs/cgroup
      - name: config
        configMap:
          name: retina-config
      - name: debug
        hostPath:
          path: /sys/kernel/debug
      - name: tmp
        emptyDir: {}
      - name: trace
        hostPath:
          path: /sys/kernel/tracing
      - name: sysclassnet
        hostPath: /sys/class/net
      - name: sysclassinfiniband
        hostPath: /sys/class/infiniband
```

</details>
