### PR TITLE
fix: annotation tag in documentation

### DIFF
--- a/docs/02-Installation/03-Config.md
+++ b/docs/02-Installation/03-Config.md
@@ -9,7 +9,7 @@ Defaults are specified for each component in *deploy/legacy/manifests/controller
 
 * `enablePodLevel`: When this toggle is set to true, Retina will gather Advanced/Pod-Level metrics. Advanced metrics can attach Pod metadata to Retina's metrics.
 * `remoteContext`: When this toggle is set to true, retina will watch Pods on the cluster.
-* `enableAnnotations`: When this toggle is set to true, retina will gather metrics for the annotated resources. Namespaces or Pods can be annotated with `retina.sh/v1alpha=observe`. The operator and enableRetinaEndpoint for the operator should be enabled.
+* `enableAnnotations`: When this toggle is set to true, retina will gather metrics for the annotated resources. Namespaces or Pods can be annotated with `retina.sh=observe`. The operator and enableRetinaEndpoint for the operator should be enabled.
 * `enabledPlugin_linux`: Array of enabled plugins for linux.
 * `enabledPlugin_win`: Array of enabled plugins for windows.
 * `metricsInterval`: the interval for which metrics will be gathered.


### PR DESCRIPTION
# Description

Annotation in this page is different than [here](https://retina.sh/docs/metrics/annotations/) and it does not work correctly. 

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
