### PR TITLE
feat(helm): Added support for affinity, readinessProbe and custom probes

### DIFF
--- a/deploy/legacy/manifests/controller/helm/retina/templates/daemonset.yaml
+++ b/deploy/legacy/manifests/controller/helm/retina/templates/daemonset.yaml
@@ -44,12 +44,24 @@ spec:
             mountPath: /retina/config
       containers:
         - name: {{ include "retina.name" . }} 
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: {{ .Values.retinaPort }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds | default "30" }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds | default "30" }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds | default "1" }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold | default "3" }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold | default "1" }}
           livenessProbe:
             httpGet:
               path: /metrics
               port: {{ .Values.retinaPort }}
-            initialDelaySeconds: 30
-            periodSeconds: 30
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds | default "30" }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds | default "30" }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds | default "1" }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold | default "3" }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold | default "1" }}
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           {{- if .Values.daemonset.container.retina.command }}
@@ -128,6 +140,9 @@ spec:
       - name: sysclassinfiniband
         hostPath: 
           path: /sys/class/infiniband
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity: {{- toYaml .Values.affinity | nindent 8 }}
       {{- end }}
       nodeSelector:
         kubernetes.io/os: linux
@@ -213,6 +228,9 @@ spec:
               mountPath: {{ $mountPath }}
           {{- end }}
         {{- end }}
+      {{- if .Values.affinity }}
+      affinity: {{- toYaml .Values.affinity | nindent 8 }}
+      {{- end }}
       nodeSelector:
         kubernetes.io/os: windows
         {{- if .Values.nodeSelector }}

--- a/deploy/legacy/manifests/controller/helm/retina/values.yaml
+++ b/deploy/legacy/manifests/controller/helm/retina/values.yaml
@@ -154,6 +154,37 @@ nodeSelector: {}
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
 tolerations: []
+## @param affinity [object] Affinity rules for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+##
+affinity: []
+
+## @param readinessProbe.initialDelaySeconds [array] Initial delay seconds for readinessProbe
+## @param readinessProbe.periodSeconds [array] Period seconds for readinessProbe
+## @param readinessProbe.timeoutSeconds [array] Timeout seconds for readinessProbe
+## @param readinessProbe.failureThreshold [array] Failure threshold for readinessProbe
+## @param readinessProbe.successThreshold [array] Success threshold for readinessProbe
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+##
+readinessProbe: {}
+  # initialDelaySeconds: 30
+  # periodSeconds: 10
+  # timeoutSeconds: 15
+  # failureThreshold: 5
+  # successThreshold: 1
+## @param livenessProbe.initialDelaySeconds [array] Initial delay seconds for livenessProbe
+## @param livenessProbe.periodSeconds [array] Period seconds for livenessProbe
+## @param livenessProbe.timeoutSeconds [array] Timeout seconds for livenessProbe
+## @param livenessProbe.failureThreshold [array] Failure threshold for livenessProbe
+## @param livenessProbe.successThreshold [array] Success threshold for livenessProbe
+## Ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+##
+livenessProbe: {}
+  # initialDelaySeconds: 30
+  # periodSeconds: 10
+  # timeoutSeconds: 15
+  # failureThreshold: 5
+  # successThreshold: 1
 
 metrics:
   ## Prometheus Service Monitor


### PR DESCRIPTION
# Description

Added support for `affinity`, `readinessProbe` and `custom probes`.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Affinity:
![retina-affinity](https://github.com/user-attachments/assets/5a467c1a-9fbd-4abb-a01b-b317ff5f9b54)

Probes:
![retina-probes](https://github.com/user-attachments/assets/26bef305-25d3-4397-8ff4-590ee8fc5b61)

