### PR TITLE
chore: change the setupchannel caller level from warn

### DIFF
--- a/pkg/plugin/linuxutil/linuxutil_linux.go
+++ b/pkg/plugin/linuxutil/linuxutil_linux.go
@@ -49,7 +49,7 @@ func (lu *linuxUtil) Start(ctx context.Context) error {
 }
 
 func (lu *linuxUtil) SetupChannel(ch chan *hubblev1.Event) error {
-	lu.l.Warn("Plugin does not support SetupChannel", zap.String("plugin", string(Name)))
+	lu.l.Debug("Plugin does not support SetupChannel", zap.String("plugin", string(Name)))
 	return nil
 }
 

--- a/pkg/plugin/packetforward/packetforward_linux.go
+++ b/pkg/plugin/packetforward/packetforward_linux.go
@@ -199,7 +199,7 @@ func (p *packetForward) Stop() error {
 }
 
 func (p *packetForward) SetupChannel(ch chan *hubblev1.Event) error {
-	p.l.Warn("SetupChannel is not supported by plugin", zap.String("plugin", string(Name)))
+	p.l.Debug("SetupChannel is not supported by plugin", zap.String("plugin", string(Name)))
 	return nil
 }
 


### PR DESCRIPTION
# Description

Linuxutil and packetforward plugin, these SetupChannel func are not supported setup channel; in order to reduce the unnecessary error log in Kusto, we change the caller level

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
