### PR TITLE
fix(bug): ignore headless svc to prevent error messages

### DIFF
--- a/pkg/controllers/daemon/service/controller_test.go
+++ b/pkg/controllers/daemon/service/controller_test.go
@@ -1,0 +1,133 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+func TestServiceFilter(t *testing.T) {
+	pred := predicate.NewPredicateFuncs(func(object client.Object) bool {
+		service, ok := object.(*corev1.Service)
+		if !ok {
+			return false
+		}
+		return service.Spec.ClusterIP != "None"
+	})
+
+	tests := []struct {
+		name   string
+		event  interface{}
+		expect bool
+	}{
+		{
+			name: "CreateEvent with ClusterIP None",
+			event: event.CreateEvent{
+				Object: &corev1.Service{
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "None",
+					},
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "CreateEvent with ClusterIP not None",
+			event: event.CreateEvent{
+				Object: &corev1.Service{
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "10.0.0.1",
+					},
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "UpdateEvent with ClusterIP None",
+			event: event.UpdateEvent{
+				ObjectNew: &corev1.Service{
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "None",
+					},
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "UpdateEvent with ClusterIP not None",
+			event: event.UpdateEvent{
+				ObjectNew: &corev1.Service{
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "10.0.0.1",
+					},
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "DeleteEvent with ClusterIP None",
+			event: event.DeleteEvent{
+				Object: &corev1.Service{
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "None",
+					},
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "DeleteEvent with ClusterIP not None",
+			event: event.DeleteEvent{
+				Object: &corev1.Service{
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "10.0.0.1",
+					},
+				},
+			},
+			expect: true,
+		},
+		{
+			name: "GenericEvent with ClusterIP None",
+			event: event.GenericEvent{
+				Object: &corev1.Service{
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "None",
+					},
+				},
+			},
+			expect: false,
+		},
+		{
+			name: "GenericEvent with ClusterIP not None",
+			event: event.GenericEvent{
+				Object: &corev1.Service{
+					Spec: corev1.ServiceSpec{
+						ClusterIP: "10.0.0.1",
+					},
+				},
+			},
+			expect: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result bool
+			switch e := tt.event.(type) {
+			case event.CreateEvent:
+				result = pred.Create(e)
+			case event.UpdateEvent:
+				result = pred.Update(e)
+			case event.DeleteEvent:
+				result = pred.Delete(e)
+			case event.GenericEvent:
+				result = pred.Generic(e)
+			}
+			assert.Equal(t, tt.expect, result)
+		})
+	}
+}


### PR DESCRIPTION
# Description

* update service controller to ignore headless svc and re-trigger reconcile when encountering one
* create test to validate UpdateRetinaSvc still throws an error if a retina svc has no IPv4 (this is to make sure existing validation post retinaSvc creation is not broken)

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

fix #547 

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
