### PR TITLE
fix(bug): update scrapeConfig to filer retina container specifically

### DIFF
--- a/deploy/legacy/prometheus/values.yaml
+++ b/deploy/legacy/prometheus/values.yaml
@@ -52,7 +52,7 @@ prometheus:
         relabel_configs:
           - source_labels: [__meta_kubernetes_pod_container_name]
             action: keep
-            regex: retina(.*)
+            regex: retina
           - source_labels:
               [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
             separator: ":"


### PR DESCRIPTION
# Description

* update additionalScrapeConfigs to filter containers named `retina` (retina agent)
* this will exclude retina-operator container in retina-operator pod

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

fix #177 

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Deployed unmanaged Prometheus as per doc instructions, [see here](https://retina.sh/docs/Installation/Grafana/prometheus-unmanaged#configuring-prometheus)

The target for retina-operator is no longer appearing since it is no longer scraped

![image](https://github.com/user-attachments/assets/01657195-6e13-44be-ada5-500aaeeb8b1d)


Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
