### PR TITLE
test: add runtime objects per step in e2e

### DIFF
--- a/test/e2e/framework/azure/create-cluster-with-npm.go
+++ b/test/e2e/framework/azure/create-cluster-with-npm.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	armcontainerservice "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4"
+	"github.com/microsoft/retina/test/e2e/framework/types"
 )
 
 var (
@@ -37,7 +38,7 @@ type CreateNPMCluster struct {
 	ServiceCidr       string
 }
 
-func (c *CreateNPMCluster) Prevalidate() error {
+func (c *CreateNPMCluster) PreRun() error {
 	return nil
 }
 
@@ -45,7 +46,7 @@ func (c *CreateNPMCluster) Stop() error {
 	return nil
 }
 
-func (c *CreateNPMCluster) Run() error {
+func (c *CreateNPMCluster) Run(_ *types.RuntimeObjects) error {
 	// Start with default cluster template
 	npmCluster := GetStarterClusterTemplate(c.Location)
 

--- a/test/e2e/framework/azure/create-cluster.go
+++ b/test/e2e/framework/azure/create-cluster.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	armcontainerservice "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4"
+	"github.com/microsoft/retina/test/e2e/framework/types"
 )
 
 const (
@@ -25,7 +26,7 @@ type CreateCluster struct {
 	ClusterName       string
 }
 
-func (c *CreateCluster) Run() error {
+func (c *CreateCluster) Run(ro *types.RuntimeObjects) error {
 	cred, err := azidentity.NewAzureCLICredential(nil)
 	if err != nil {
 		return fmt.Errorf("failed to obtain a credential: %w", err)
@@ -106,7 +107,7 @@ func GetStarterClusterTemplate(location string) armcontainerservice.ManagedClust
 	}
 }
 
-func (c *CreateCluster) Prevalidate() error {
+func (c *CreateCluster) PreRun() error {
 	return nil
 }
 

--- a/test/e2e/framework/azure/create-rg.go
+++ b/test/e2e/framework/azure/create-rg.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"github.com/microsoft/retina/test/e2e/framework/types"
 )
 
 type CreateResourceGroup struct {
@@ -16,7 +17,7 @@ type CreateResourceGroup struct {
 	Location          string
 }
 
-func (c *CreateResourceGroup) Run() error {
+func (c *CreateResourceGroup) Run(_ *types.RuntimeObjects) error {
 	cred, err := azidentity.NewAzureCLICredential(nil)
 	if err != nil {
 		return fmt.Errorf("failed to obtain a credential: %w", err)
@@ -39,7 +40,7 @@ func (c *CreateResourceGroup) Run() error {
 	return nil
 }
 
-func (c *CreateResourceGroup) Prevalidate() error {
+func (c *CreateResourceGroup) PreRun() error {
 	return nil
 }
 

--- a/test/e2e/framework/azure/create-vnet.go
+++ b/test/e2e/framework/azure/create-vnet.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v5"
+	"github.com/microsoft/retina/test/e2e/framework/types"
 )
 
 const FlowTimeoutInMinutes = 10
@@ -20,7 +21,7 @@ type CreateVNet struct {
 	VnetAddressSpace  string
 }
 
-func (c *CreateVNet) Run() error {
+func (c *CreateVNet) Run(_ *types.RuntimeObjects) error {
 	cred, err := azidentity.NewAzureCLICredential(nil)
 	if err != nil {
 		return fmt.Errorf("failed to obtain a credential: %w", err)
@@ -55,7 +56,7 @@ func (c *CreateVNet) Run() error {
 	return nil
 }
 
-func (c *CreateVNet) Prevalidate() error {
+func (c *CreateVNet) PreRun() error {
 	return nil
 }
 
@@ -72,7 +73,7 @@ type CreateSubnet struct {
 	SubnetAddressSpace string
 }
 
-func (c *CreateSubnet) Run() error {
+func (c *CreateSubnet) Run(_ *types.RuntimeObjects) error {
 	cred, err := azidentity.NewAzureCLICredential(nil)
 	if err != nil {
 		return fmt.Errorf("failed to obtain a credential: %w", err)
@@ -101,7 +102,7 @@ func (c *CreateSubnet) Run() error {
 	return nil
 }
 
-func (c *CreateSubnet) Prevalidate() error {
+func (c *CreateSubnet) PreRun() error {
 	return nil
 }
 

--- a/test/e2e/framework/azure/delete-cluster.go
+++ b/test/e2e/framework/azure/delete-cluster.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	armcontainerservice "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4"
+	"github.com/microsoft/retina/test/e2e/framework/types"
 )
 
 type DeleteCluster struct {
@@ -16,7 +17,7 @@ type DeleteCluster struct {
 	Location          string
 }
 
-func (d *DeleteCluster) Run() error {
+func (d *DeleteCluster) Run(_ *types.RuntimeObjects) error {
 	cred, err := azidentity.NewAzureCLICredential(nil)
 	if err != nil {
 		return fmt.Errorf("failed to obtain a credential: %w", err)
@@ -39,7 +40,7 @@ func (d *DeleteCluster) Run() error {
 	return nil
 }
 
-func (d *DeleteCluster) Prevalidate() error {
+func (d *DeleteCluster) PreRun() error {
 	return nil
 }
 

--- a/test/e2e/framework/azure/delete-rg.go
+++ b/test/e2e/framework/azure/delete-rg.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources"
+	"github.com/microsoft/retina/test/e2e/framework/types"
 )
 
 type DeleteResourceGroup struct {
@@ -16,7 +17,7 @@ type DeleteResourceGroup struct {
 	Location          string
 }
 
-func (d *DeleteResourceGroup) Run() error {
+func (d *DeleteResourceGroup) Run(_ *types.RuntimeObjects) error {
 	log.Printf("deleting resource group \"%s\"...", d.ResourceGroupName)
 	cred, err := azidentity.NewAzureCLICredential(nil)
 	if err != nil {
@@ -37,7 +38,7 @@ func (d *DeleteResourceGroup) Run() error {
 	return nil
 }
 
-func (d *DeleteResourceGroup) Prevalidate() error {
+func (d *DeleteResourceGroup) PreRun() error {
 	return nil
 }
 

--- a/test/e2e/framework/azure/enable-ama.go
+++ b/test/e2e/framework/azure/enable-ama.go
@@ -12,6 +12,7 @@ import (
 	armcontainerservice "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dashboard/armdashboard"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor"
+	"github.com/microsoft/retina/test/e2e/framework/types"
 )
 
 const fileperms = 0o600
@@ -23,7 +24,7 @@ type CreateAzureMonitor struct {
 	ClusterName       string
 }
 
-func (c *CreateAzureMonitor) Run() error {
+func (c *CreateAzureMonitor) Run(_ *types.RuntimeObjects) error {
 	log.Printf(`this will deploy azure monitor workspace and grafana, but as of 1/9/2024, the api docs don't show how to do 
 az aks update --enable-azure-monitor-metrics \
 -n $NAME \
@@ -108,7 +109,7 @@ az aks update --enable-azure-monitor-metrics \
 	return nil
 }
 
-func (c *CreateAzureMonitor) Prevalidate() error {
+func (c *CreateAzureMonitor) PreRun() error {
 	return nil
 }
 

--- a/test/e2e/framework/azure/get-kubeconfig.go
+++ b/test/e2e/framework/azure/get-kubeconfig.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	armcontainerservice "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4"
+	"github.com/microsoft/retina/test/e2e/framework/types"
 )
 
 const KubeConfigPerms = 0o600
@@ -20,7 +21,7 @@ type GetAKSKubeConfig struct {
 	KubeConfigFilePath string
 }
 
-func (c *GetAKSKubeConfig) Run() error {
+func (c *GetAKSKubeConfig) Run(_ *types.RuntimeObjects) error {
 	cred, err := azidentity.NewAzureCLICredential(nil)
 	if err != nil {
 		return fmt.Errorf("failed to obtain a credential: %w", err)
@@ -44,7 +45,7 @@ func (c *GetAKSKubeConfig) Run() error {
 	return nil
 }
 
-func (c *GetAKSKubeConfig) Prevalidate() error {
+func (c *GetAKSKubeConfig) PreRun() error {
 	return nil
 }
 

--- a/test/e2e/framework/generic/load-tag.go
+++ b/test/e2e/framework/generic/load-tag.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log"
 	"os"
+
+	"github.com/microsoft/retina/test/e2e/framework/types"
 )
 
 const (
@@ -31,7 +33,7 @@ type LoadFlags struct {
 	ImageRegistryEnv  string
 }
 
-func (s *LoadFlags) Run() error {
+func (s *LoadFlags) Run(_ *types.RuntimeObjects) error {
 	tag := os.Getenv(s.TagEnv)
 	imageNamespace := os.Getenv(s.ImageNamespaceEnv)
 	imageRegistry := os.Getenv(s.ImageRegistryEnv)
@@ -39,7 +41,7 @@ func (s *LoadFlags) Run() error {
 	return nil
 }
 
-func (s *LoadFlags) Prevalidate() error {
+func (s *LoadFlags) PreRun() error {
 	if err := s.validateEnvAndFlag(s.TagEnv, imageTagArg, *imageTag, ErrTagNotSet); err != nil {
 		return err
 	}

--- a/test/e2e/framework/kubernetes/create-agnhost-statefulset.go
+++ b/test/e2e/framework/kubernetes/create-agnhost-statefulset.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/microsoft/retina/test/e2e/framework/types"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -27,7 +28,7 @@ type CreateAgnhostStatefulSet struct {
 	KubeConfigFilePath string
 }
 
-func (c *CreateAgnhostStatefulSet) Run() error {
+func (c *CreateAgnhostStatefulSet) Run(_ *types.RuntimeObjects) error {
 	config, err := clientcmd.BuildConfigFromFlags("", c.KubeConfigFilePath)
 	if err != nil {
 		return fmt.Errorf("error building kubeconfig: %w", err)
@@ -62,7 +63,7 @@ func (c *CreateAgnhostStatefulSet) Run() error {
 	return nil
 }
 
-func (c *CreateAgnhostStatefulSet) Prevalidate() error {
+func (c *CreateAgnhostStatefulSet) PreRun() error {
 	return nil
 }
 

--- a/test/e2e/framework/kubernetes/create-kapinger-deployment.go
+++ b/test/e2e/framework/kubernetes/create-kapinger-deployment.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/microsoft/retina/test/e2e/framework/types"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -29,7 +30,7 @@ type CreateKapingerDeployment struct {
 	KubeConfigFilePath string
 }
 
-func (c *CreateKapingerDeployment) Run() error {
+func (c *CreateKapingerDeployment) Run(_ *types.RuntimeObjects) error {
 	_, err := strconv.Atoi(c.KapingerReplicas)
 	if err != nil {
 		return fmt.Errorf("error converting replicas to int for Kapinger replicas: %w", err)
@@ -66,7 +67,7 @@ func (c *CreateKapingerDeployment) Run() error {
 	return nil
 }
 
-func (c *CreateKapingerDeployment) Prevalidate() error {
+func (c *CreateKapingerDeployment) PreRun() error {
 	return nil
 }
 

--- a/test/e2e/framework/kubernetes/create-network-policy.go
+++ b/test/e2e/framework/kubernetes/create-network-policy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/microsoft/retina/test/e2e/framework/types"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -22,7 +23,7 @@ type CreateDenyAllNetworkPolicy struct {
 	DenyAllLabelSelector   string
 }
 
-func (c *CreateDenyAllNetworkPolicy) Run() error {
+func (c *CreateDenyAllNetworkPolicy) Run(_ *types.RuntimeObjects) error {
 	config, err := clientcmd.BuildConfigFromFlags("", c.KubeConfigFilePath)
 	if err != nil {
 		return fmt.Errorf("error building kubeconfig: %w", err)
@@ -68,7 +69,7 @@ func getNetworkPolicy(namespace, labelSelector string) *networkingv1.NetworkPoli
 	}
 }
 
-func (c *CreateDenyAllNetworkPolicy) Prevalidate() error {
+func (c *CreateDenyAllNetworkPolicy) PreRun() error {
 	return nil
 }
 
@@ -82,7 +83,7 @@ type DeleteDenyAllNetworkPolicy struct {
 	DenyAllLabelSelector   string
 }
 
-func (d *DeleteDenyAllNetworkPolicy) Run() error {
+func (d *DeleteDenyAllNetworkPolicy) Run(_ *types.RuntimeObjects) error {
 	config, err := clientcmd.BuildConfigFromFlags("", d.KubeConfigFilePath)
 	if err != nil {
 		return fmt.Errorf("error building kubeconfig: %w", err)
@@ -105,6 +106,6 @@ func (d *DeleteDenyAllNetworkPolicy) Run() error {
 	return nil
 }
 
-func (d *DeleteDenyAllNetworkPolicy) Prevalidate() error {
+func (d *DeleteDenyAllNetworkPolicy) PreRun() error {
 	return nil
 }

--- a/test/e2e/framework/kubernetes/delete-resource.go
+++ b/test/e2e/framework/kubernetes/delete-resource.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/microsoft/retina/test/e2e/framework/types"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -68,7 +69,7 @@ type DeleteKubernetesResource struct {
 	KubeConfigFilePath string
 }
 
-func (d *DeleteKubernetesResource) Run() error {
+func (d *DeleteKubernetesResource) Run(_ *types.RuntimeObjects) error {
 	config, err := clientcmd.BuildConfigFromFlags("", d.KubeConfigFilePath)
 	if err != nil {
 		return fmt.Errorf("error building kubeconfig: %w", err)
@@ -187,7 +188,7 @@ func (d *DeleteKubernetesResource) Stop() error {
 	return nil
 }
 
-func (d *DeleteKubernetesResource) Prevalidate() error {
+func (d *DeleteKubernetesResource) PreRun() error {
 	restype := ResourceType(d.ResourceType)
 	if restype == Unknown {
 		return ErrUnknownResourceType

--- a/test/e2e/framework/kubernetes/exec-pod.go
+++ b/test/e2e/framework/kubernetes/exec-pod.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/microsoft/retina/test/e2e/framework/types"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -23,7 +24,7 @@ type ExecInPod struct {
 	Command            string
 }
 
-func (e *ExecInPod) Run() error {
+func (e *ExecInPod) Run(_ *types.RuntimeObjects) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -35,7 +36,7 @@ func (e *ExecInPod) Run() error {
 	return nil
 }
 
-func (e *ExecInPod) Prevalidate() error {
+func (e *ExecInPod) PreRun() error {
 	return nil
 }
 

--- a/test/e2e/framework/kubernetes/install-retina-helm.go
+++ b/test/e2e/framework/kubernetes/install-retina-helm.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	generic "github.com/microsoft/retina/test/e2e/framework/generic"
+	"github.com/microsoft/retina/test/e2e/framework/types"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/cli"
@@ -31,7 +32,7 @@ type InstallHelmChart struct {
 	TagEnv             string
 }
 
-func (i *InstallHelmChart) Run() error {
+func (i *InstallHelmChart) Run(_ *types.RuntimeObjects) error {
 	settings := cli.New()
 	settings.KubeConfig = i.KubeConfigFilePath
 	actionConfig := new(action.Configuration)
@@ -109,7 +110,7 @@ func (i *InstallHelmChart) Run() error {
 	return nil
 }
 
-func (i *InstallHelmChart) Prevalidate() error {
+func (i *InstallHelmChart) PreRun() error {
 	_, err := os.Stat(i.ChartPath)
 
 	if os.IsNotExist(err) {

--- a/test/e2e/framework/kubernetes/port-forward.go
+++ b/test/e2e/framework/kubernetes/port-forward.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/microsoft/retina/test/e2e/framework/types"
 	retry "github.com/microsoft/retina/test/retry"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -42,7 +43,7 @@ type PortForward struct {
 	pf *PortForwarder
 }
 
-func (p *PortForward) Run() error {
+func (p *PortForward) Run(_ *types.RuntimeObjects) error {
 	lport, _ := strconv.Atoi(p.LocalPort)
 	rport, _ := strconv.Atoi(p.RemotePort)
 
@@ -153,7 +154,7 @@ func (p *PortForward) findPodsWithAffinity(ctx context.Context, clientset *kuber
 	return "", fmt.Errorf("could not find a pod with label \"%s\", on a node that also has a pod with label \"%s\": %w", p.LabelSelector, p.OptionalLabelAffinity, ErrNoPodWithLabelFound)
 }
 
-func (p *PortForward) Prevalidate() error {
+func (p *PortForward) PreRun() error {
 	return nil
 }
 

--- a/test/e2e/framework/kubernetes/upgrade-retina-helm.go
+++ b/test/e2e/framework/kubernetes/upgrade-retina-helm.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/microsoft/retina/test/e2e/framework/types"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli"
 	helmValues "helm.sh/helm/v3/pkg/cli/values"
@@ -25,7 +26,7 @@ type UpgradeRetinaHelmChart struct {
 	ValuesFile         string
 }
 
-func (u *UpgradeRetinaHelmChart) Run() error {
+func (u *UpgradeRetinaHelmChart) Run(_ *types.RuntimeObjects) error {
 	settings := cli.New()
 	settings.KubeConfig = u.KubeConfigFilePath
 	actionConfig := new(action.Configuration)
@@ -76,7 +77,7 @@ func (u *UpgradeRetinaHelmChart) Run() error {
 	return nil
 }
 
-func (u *UpgradeRetinaHelmChart) Prevalidate() error {
+func (u *UpgradeRetinaHelmChart) PreRun() error {
 	return nil
 }
 

--- a/test/e2e/framework/types/background_test.go
+++ b/test/e2e/framework/types/background_test.go
@@ -34,7 +34,7 @@ type TestBackground struct {
 	c           *counter
 }
 
-func (t *TestBackground) Run() error {
+func (t *TestBackground) Run(_ *RuntimeObjects) error {
 	t.c = newCounter()
 	err := t.c.Start()
 	if err != nil {
@@ -54,7 +54,7 @@ func (t *TestBackground) Stop() error {
 	return nil
 }
 
-func (t *TestBackground) Prevalidate() error {
+func (t *TestBackground) PreRun() error {
 	return nil
 }
 

--- a/test/e2e/framework/types/runtimeobjects.go
+++ b/test/e2e/framework/types/runtimeobjects.go
@@ -1,40 +1,32 @@
 package types
 
 import (
-	"fmt"
+	"errors"
 	"sync"
 )
 
-var (
-	ErrValueAlreadySet = fmt.Errorf("value already set")
-	ErrEmptyValue      = fmt.Errorf("empty parameter not found in values")
-)
+var ErrEmptyRuntimeObject = errors.New("empty value for runtime object key")
 
-type JobValues struct {
+type RuntimeObjects struct {
 	RWLock sync.RWMutex
-	kv     map[string]string
+	kv     map[string]interface{}
 }
 
-func (j *JobValues) New() *JobValues {
-	return &JobValues{
-		kv: make(map[string]string),
-	}
-}
-
-func (j *JobValues) Contains(key string) bool {
+func (j *RuntimeObjects) Contains(key string) bool {
 	j.RWLock.RLock()
 	defer j.RWLock.RUnlock()
 	_, ok := j.kv[key]
 	return ok
 }
 
-func (j *JobValues) Get(key string) string {
+func (j *RuntimeObjects) Get(key string) (interface{}, bool) {
 	j.RWLock.RLock()
 	defer j.RWLock.RUnlock()
-	return j.kv[key]
+	val, ok := j.kv[key]
+	return val, ok
 }
 
-func (j *JobValues) SetGet(key, value string) (string, error) {
+func (j *RuntimeObjects) SetGet(key string, value interface{}) (interface{}, error) {
 	j.RWLock.Lock()
 	defer j.RWLock.Unlock()
 

--- a/test/e2e/framework/types/runtimeobjects_test.go
+++ b/test/e2e/framework/types/runtimeobjects_test.go
@@ -1,0 +1,64 @@
+package types
+
+import (
+	"errors"
+	"testing"
+)
+
+var ErrKeyAlreadyExists = errors.New("key already exists in runtime objects")
+
+type testobj int64
+
+// Test against a BYO cluster with Cilium and Hubble enabled,
+// create a pod with a deny all network policy and validate
+// that the drop metrics are present in the prometheus endpoint
+func TestRuntimeObjects(t *testing.T) {
+	job := NewJob("Test Runtime Objects injection behavior")
+	runner := NewRunner(t, job)
+	defer runner.Run()
+
+	job.AddStep(&RuntimeObjectsTestStep{
+		TestIntKey: "test integer",
+	}, &StepOptions{
+		ExpectError:               false,
+		SkipSavingParametersToJob: true,
+	})
+
+	job.AddStep(&RuntimeObjectsTestStep{
+		TestIntKey: "test integer",
+	}, &StepOptions{
+		ExpectError:               true,
+		SkipSavingParametersToJob: true,
+	})
+}
+
+type RuntimeObjectsTestStep struct {
+	TestIntKey string
+}
+
+func (d *RuntimeObjectsTestStep) Run(ro *RuntimeObjects) error {
+	if retrieved, ok := ro.Get(d.TestIntKey); ok {
+		if retrieved.(testobj) != 1 {
+			return errors.New("value retrieved from runtime objects does not match expected value") //nolint This is a test
+		}
+
+		return ErrKeyAlreadyExists
+	}
+
+	testintvalue := testobj(1)
+
+	_, err := ro.SetGet(d.TestIntKey, testintvalue)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *RuntimeObjectsTestStep) Stop() error {
+	return nil
+}
+
+func (d *RuntimeObjectsTestStep) PreRun() error {
+	return nil
+}

--- a/test/e2e/framework/types/scenarios_test.go
+++ b/test/e2e/framework/types/scenarios_test.go
@@ -111,7 +111,7 @@ type DummyStep struct {
 	Parameter2 string
 }
 
-func (d *DummyStep) Run() error {
+func (d *DummyStep) Run(_ *RuntimeObjects) error {
 	fmt.Printf("Running DummyStep with parameter 1 as: %s\n", d.Parameter1)
 	fmt.Printf("Running DummyStep with parameter 2 as: %s\n", d.Parameter2)
 	return nil
@@ -121,6 +121,6 @@ func (d *DummyStep) Stop() error {
 	return nil
 }
 
-func (d *DummyStep) Prevalidate() error {
+func (d *DummyStep) PreRun() error {
 	return nil
 }

--- a/test/e2e/framework/types/step.go
+++ b/test/e2e/framework/types/step.go
@@ -15,11 +15,11 @@ type Step interface {
 	// if a parameter length is known to be required less than 80 characters,
 	// do this here so we don't find out later on when we run the step
 	// when possible, try to avoid making external calls, this should be fast and simple
-	Prevalidate() error
+	PreRun() error
 
 	// Primary step where test logic is executed
 	// Returning an error will cause the test to fail
-	Run() error
+	Run(ro *RuntimeObjects) error
 
 	// Require for background steps
 	Stop() error
@@ -38,4 +38,7 @@ type StepOptions struct {
 	// and then later on when Stop is called with job name,
 	// it will call Stop() on the step
 	RunInBackgroundWithID string
+
+	//
+	RuntimeObjectKeys map[string]interface{}
 }

--- a/test/e2e/framework/types/step_sleep.go
+++ b/test/e2e/framework/types/step_sleep.go
@@ -9,7 +9,7 @@ type Sleep struct {
 	Duration time.Duration
 }
 
-func (c *Sleep) Run() error {
+func (c *Sleep) Run(ro *RuntimeObjects) error {
 	log.Printf("sleeping for %s...\n", c.Duration.String())
 	time.Sleep(c.Duration)
 	return nil
@@ -19,6 +19,6 @@ func (c *Sleep) Stop() error {
 	return nil
 }
 
-func (c *Sleep) Prevalidate() error {
+func (c *Sleep) PreRun() error {
 	return nil
 }

--- a/test/e2e/framework/types/step_stop.go
+++ b/test/e2e/framework/types/step_stop.go
@@ -11,7 +11,7 @@ type Stop struct {
 	Step         Step
 }
 
-func (c *Stop) Run() error {
+func (c *Stop) Run(ro *RuntimeObjects) error {
 	stepName := reflect.TypeOf(c.Step).Elem().Name()
 	log.Println("stopping step:", stepName)
 	err := c.Step.Stop()
@@ -25,6 +25,6 @@ func (c *Stop) Stop() error {
 	return nil
 }
 
-func (c *Stop) Prevalidate() error {
+func (c *Stop) PreRun() error {
 	return nil
 }

--- a/test/e2e/scenarios/dns/validate-advanced-dns-metric.go
+++ b/test/e2e/scenarios/dns/validate-advanced-dns-metric.go
@@ -9,6 +9,7 @@ import (
 	"github.com/microsoft/retina/test/e2e/common"
 	"github.com/microsoft/retina/test/e2e/framework/kubernetes"
 	prom "github.com/microsoft/retina/test/e2e/framework/prometheus"
+	"github.com/microsoft/retina/test/e2e/framework/types"
 	"github.com/pkg/errors"
 )
 
@@ -28,7 +29,7 @@ type ValidateAdvancedDNSRequestMetrics struct {
 	KubeConfigFilePath string
 }
 
-func (v *ValidateAdvancedDNSRequestMetrics) Run() error {
+func (v *ValidateAdvancedDNSRequestMetrics) Run(_ *types.RuntimeObjects) error {
 	metricsEndpoint := fmt.Sprintf("http://localhost:%d/metrics", common.RetinaPort)
 	// Get Pod IP address
 	podIP, err := kubernetes.GetPodIP(v.KubeConfigFilePath, v.Namespace, v.PodName)
@@ -55,7 +56,7 @@ func (v *ValidateAdvancedDNSRequestMetrics) Run() error {
 	return nil
 }
 
-func (v *ValidateAdvancedDNSRequestMetrics) Prevalidate() error {
+func (v *ValidateAdvancedDNSRequestMetrics) PreRun() error {
 	return nil
 }
 
@@ -77,7 +78,7 @@ type ValidateAdvanceDNSResponseMetrics struct {
 	KubeConfigFilePath string
 }
 
-func (v *ValidateAdvanceDNSResponseMetrics) Run() error {
+func (v *ValidateAdvanceDNSResponseMetrics) Run(_ *types.RuntimeObjects) error {
 	metricsEndpoint := fmt.Sprintf("http://localhost:%d/metrics", common.RetinaPort)
 	// Get Pod IP address
 	podIP, err := kubernetes.GetPodIP(v.KubeConfigFilePath, v.Namespace, v.PodName)
@@ -111,7 +112,7 @@ func (v *ValidateAdvanceDNSResponseMetrics) Run() error {
 	return nil
 }
 
-func (v *ValidateAdvanceDNSResponseMetrics) Prevalidate() error {
+func (v *ValidateAdvanceDNSResponseMetrics) PreRun() error {
 	return nil
 }
 

--- a/test/e2e/scenarios/dns/validate-basic-dns-metric.go
+++ b/test/e2e/scenarios/dns/validate-basic-dns-metric.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/microsoft/retina/test/e2e/common"
 	prom "github.com/microsoft/retina/test/e2e/framework/prometheus"
+	"github.com/microsoft/retina/test/e2e/framework/types"
 	"github.com/pkg/errors"
 )
 
@@ -21,7 +22,7 @@ type validateBasicDNSRequestMetrics struct {
 	QueryType string
 }
 
-func (v *validateBasicDNSRequestMetrics) Run() error {
+func (v *validateBasicDNSRequestMetrics) Run(_ *types.RuntimeObjects) error {
 	metricsEndpoint := fmt.Sprintf("http://localhost:%d/metrics", common.RetinaPort)
 
 	validBasicDNSRequestMetricLabels := map[string]string{
@@ -38,7 +39,7 @@ func (v *validateBasicDNSRequestMetrics) Run() error {
 	return nil
 }
 
-func (v *validateBasicDNSRequestMetrics) Prevalidate() error {
+func (v *validateBasicDNSRequestMetrics) PreRun() error {
 	return nil
 }
 
@@ -54,7 +55,7 @@ type validateBasicDNSResponseMetrics struct {
 	Response    string
 }
 
-func (v *validateBasicDNSResponseMetrics) Run() error {
+func (v *validateBasicDNSResponseMetrics) Run(_ *types.RuntimeObjects) error {
 	metricsEndpoint := fmt.Sprintf("http://localhost:%d/metrics", common.RetinaPort)
 
 	if v.Response == EmptyResponse {
@@ -78,7 +79,7 @@ func (v *validateBasicDNSResponseMetrics) Run() error {
 	return nil
 }
 
-func (v *validateBasicDNSResponseMetrics) Prevalidate() error {
+func (v *validateBasicDNSResponseMetrics) PreRun() error {
 	return nil
 }
 

--- a/test/e2e/scenarios/drop/validate-drop-metric.go
+++ b/test/e2e/scenarios/drop/validate-drop-metric.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	prom "github.com/microsoft/retina/test/e2e/framework/prometheus"
+	"github.com/microsoft/retina/test/e2e/framework/types"
 )
 
 var (
@@ -28,7 +29,7 @@ type ValidateRetinaDropMetric struct {
 	Direction               string
 }
 
-func (v *ValidateRetinaDropMetric) Run() error {
+func (v *ValidateRetinaDropMetric) Run(_ *types.RuntimeObjects) error {
 	promAddress := fmt.Sprintf("http://localhost:%s/metrics", v.PortForwardedRetinaPort)
 
 	metric := map[string]string{
@@ -49,7 +50,7 @@ func (v *ValidateRetinaDropMetric) Run() error {
 	return nil
 }
 
-func (v *ValidateRetinaDropMetric) Prevalidate() error {
+func (v *ValidateRetinaDropMetric) PreRun() error {
 	return nil
 }
 

--- a/test/e2e/scenarios/latency/validate-latency-metric.go
+++ b/test/e2e/scenarios/latency/validate-latency-metric.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/microsoft/retina/test/e2e/common"
 	prom "github.com/microsoft/retina/test/e2e/framework/prometheus"
+	"github.com/microsoft/retina/test/e2e/framework/types"
 	"github.com/pkg/errors"
 )
 
@@ -13,11 +14,11 @@ var latencyBucketMetricName = "networkobservability_adv_node_apiserver_tcp_hands
 
 type ValidateAPIServerLatencyMetric struct{}
 
-func (v *ValidateAPIServerLatencyMetric) Prevalidate() error {
+func (v *ValidateAPIServerLatencyMetric) PreRun() error {
 	return nil
 }
 
-func (v *ValidateAPIServerLatencyMetric) Run() error {
+func (v *ValidateAPIServerLatencyMetric) Run(_ *types.RuntimeObjects) error {
 	promAddress := fmt.Sprintf("http://localhost:%d/metrics", common.RetinaPort)
 
 	metric := map[string]string{}

--- a/test/e2e/scenarios/tcp/validate-flow-metric.go
+++ b/test/e2e/scenarios/tcp/validate-flow-metric.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	prom "github.com/microsoft/retina/test/e2e/framework/prometheus"
+	"github.com/microsoft/retina/test/e2e/framework/types"
 )
 
 var tcpStateMetricName = "networkobservability_tcp_state"
@@ -21,7 +22,7 @@ type ValidateRetinaTCPStateMetric struct {
 	PortForwardedRetinaPort string
 }
 
-func (v *ValidateRetinaTCPStateMetric) Run() error {
+func (v *ValidateRetinaTCPStateMetric) Run(_ *types.RuntimeObjects) error {
 	promAddress := fmt.Sprintf("http://localhost:%s/metrics", v.PortForwardedRetinaPort)
 
 	validMetrics := []map[string]string{
@@ -41,7 +42,7 @@ func (v *ValidateRetinaTCPStateMetric) Run() error {
 	return nil
 }
 
-func (v *ValidateRetinaTCPStateMetric) Prevalidate() error {
+func (v *ValidateRetinaTCPStateMetric) PreRun() error {
 	return nil
 }
 

--- a/test/e2e/scenarios/tcp/validate-tcp-connection-remote.go
+++ b/test/e2e/scenarios/tcp/validate-tcp-connection-remote.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	prom "github.com/microsoft/retina/test/e2e/framework/prometheus"
+	"github.com/microsoft/retina/test/e2e/framework/types"
 )
 
 var tcpConnectionRemoteMetricName = "networkobservability_tcp_connection_remote"
@@ -18,7 +19,7 @@ type ValidateRetinaTCPConnectionRemoteMetric struct {
 	PortForwardedRetinaPort string
 }
 
-func (v *ValidateRetinaTCPConnectionRemoteMetric) Run() error {
+func (v *ValidateRetinaTCPConnectionRemoteMetric) Run(_ *types.RuntimeObjects) error {
 	promAddress := fmt.Sprintf("http://localhost:%s/metrics", v.PortForwardedRetinaPort)
 
 	validMetrics := []map[string]string{
@@ -36,7 +37,7 @@ func (v *ValidateRetinaTCPConnectionRemoteMetric) Run() error {
 	return nil
 }
 
-func (v *ValidateRetinaTCPConnectionRemoteMetric) Prevalidate() error {
+func (v *ValidateRetinaTCPConnectionRemoteMetric) PreRun() error {
 	return nil
 }
 


### PR DESCRIPTION
# Description

Satisfy the need to pass structs between steps. Would like runtime object keys to be more hardcoded, but for the moment this should suffice

Please provide a brief description of the changes made in this pull request.

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
