### PR TITLE
fix: start plugins in parallel

### DIFF
--- a/pkg/managers/pluginmanager/pluginmanager.go
+++ b/pkg/managers/pluginmanager/pluginmanager.go
@@ -29,10 +29,6 @@ const (
 	MAX_RECONCILE_TIME = 10 * time.Second
 )
 
-const (
-	MAX_STARTUP_TIME = 10 * time.Second
-)
-
 var (
 	ErrNilCfg       = errors.New("pluginmanager requires a non-nil config")
 	ErrZeroInterval = errors.New("pluginmanager requires a positive MetricsInterval in its config")
@@ -128,14 +124,6 @@ func (p *PluginManager) Reconcile(ctx context.Context, plugin api.Plugin) error 
 // Note: This will block as long as main thread is running.
 func (p *PluginManager) Start(ctx context.Context) error {
 	counter := p.tel.StartPerf("start-plugin-manager")
-	// start plugins evenly throughout the interval,
-	// if 2 plugins enabled, and 10 second interval
-	// 10 / 2 = 5, then after every start sleep 5s
-	// plugin 1 = 0s
-	// plugin 2 = 5s
-	// then the plugins won't awake at the same time and they'll have even execution time
-
-	delay := float32(MAX_STARTUP_TIME) / float32(len(p.plugins))
 	p.l.Info("Starting plugin manager ...")
 	var err error
 
@@ -184,8 +172,6 @@ func (p *PluginManager) Start(ctx context.Context) error {
 			p.l.Info(fmt.Sprintf("starting plugin %s", plug.Name()))
 			return errors.Wrapf(plug.Start(ctx), "failed to start plugin %s", plug.Name())
 		})
-
-		time.Sleep(time.Duration(delay))
 	}
 
 	p.tel.StopPerf(counter)


### PR DESCRIPTION
# Description

Plugins should be started as soon as possible, arbitrary delay based off number of enabled plugins isn't helpful to getting metrics delayed from retina start.

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
