### PR TITLE
fix: Implement OS specific mechanism to remove memory lock for plugins

### DIFF
--- a/cmd/legacy/daemon.go
+++ b/cmd/legacy/daemon.go
@@ -25,7 +25,6 @@ import (
 	crmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
-	"github.com/cilium/ebpf/rlimit"
 	"github.com/go-logr/zapr"
 	retinav1alpha1 "github.com/microsoft/retina/crd/api/v1alpha1"
 	"github.com/microsoft/retina/internal/buildinfo"
@@ -134,7 +133,9 @@ func (d *Daemon) Start() error {
 	mainLogger := zl.Named("main").Sugar()
 
 	// Allow the current process to lock memory for eBPF resources.
-	if err = rlimit.RemoveMemlock(); err != nil {
+	// OS specific implementation.
+	// This is a no-op on Windows.
+	if err = d.RemoveMemlock(); err != nil {
 		mainLogger.Fatal("failed to remove memlock", zap.Error(err))
 	}
 

--- a/cmd/legacy/daemon_linux.go
+++ b/cmd/legacy/daemon_linux.go
@@ -1,0 +1,7 @@
+package legacy
+
+import "github.com/cilium/ebpf/rlimit"
+
+func (d *Daemon) RemoveMemlock() error {
+	return rlimit.RemoveMemlock()
+}

--- a/cmd/legacy/daemon_windows.go
+++ b/cmd/legacy/daemon_windows.go
@@ -1,0 +1,6 @@
+package legacy
+
+func (d *Daemon) RemoveMemlock() error {
+	// This function is a no-op on Windows.
+	return nil
+}


### PR DESCRIPTION
# Description

Add OS specific implementation for removing memory lock on Linux/Windows nodes.

## Related Issue

Fixes https://github.com/microsoft/retina/issues/790

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

- Can build/run manually
- Pipelines

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
