### PR TITLE
fix: scope Hubble TLS CronJob's secret access to its namespace

### DIFF
--- a/deploy/hubble/manifests/controller/helm/retina/templates/hubble/tls-cronjob/rolebinding.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/hubble/tls-cronjob/rolebinding.yaml
@@ -1,8 +1,9 @@
 {{- if and .Values.hubble.enabled .Values.hubble.tls.enabled .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "cronJob") .Values.serviceAccounts.hubblecertgen.create }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
   name: hubble-generate-certs
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}


### PR DESCRIPTION
# Description

Use minimal required RBAC. CronJob only needs access to secrets in its namespace.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Tests

Secrets were still created, Hubble Relay ran with no issues, and `hubble observe flows` works