### PR TITLE
fix: scope operator's CRD permissions to cilium endpoints/identities

### DIFF
--- a/deploy/hubble/manifests/controller/helm/retina/templates/operator/clusterrole.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/operator/clusterrole.yaml
@@ -5,12 +5,20 @@ metadata:
   creationTimestamp: null
   name: retina-operator-role
 rules:
-  - apiGroups: 
+  - apiGroups:
       - "apiextensions.k8s.io"
-    resources: 
+    resources:
       - "customresourcedefinitions"
-    verbs: 
+    verbs:
       - "create"
+  - apiGroups:
+      - "apiextensions.k8s.io"
+    resources:
+      - "customresourcedefinitions"
+    resourceNames:
+      - ciliumidentities.cilium.io
+      - ciliumendpoints.cilium.io
+    verbs:
       - "get"
       - "update"
       - "delete"


### PR DESCRIPTION
# Description

Use minimal required RBAC. Retina Operator only needs to manage CiliumEndpoints and CiliumIdentities.

Note: `create` cannot be scoped to resourceNames per the k8s documentation: https://kubernetes.io/docs/reference/access-authn-authz/rbac/#referring-to-resources

Trying to scope `create` resulted in CrashLoop for Retina operator with the error:
```
unable to create CRDs: Unable to create custom resource definition: customresourcedefinitions.apiextensions.k8s.io is forbidden: User \"system:serviceaccount:kube-system:retina-operator\" cannot create resource \"customresourcedefinitions\" in API group \"apiextensions.k8s.io\" at the cluster scope" function="github.com/Azure/retina-enterprise/operator/k8s/apis.createCRDs.func1 (workspace/operator/k8s/apis/cell.go:61)
```

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Tests

CRDs were created. Retina Operator had no errors on first install or after being manually restarted.