### PR TITLE
fix(operator): broken CiliumEndpoint garbage collection

### DIFF
--- a/operator/cilium-crds/k8s/fakeresource.go
+++ b/operator/cilium-crds/k8s/fakeresource.go
@@ -1,0 +1,23 @@
+package k8s
+
+import (
+	"context"
+
+	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/cilium/cilium/pkg/k8s/resource"
+)
+
+type fakeresource[T k8sRuntime.Object] struct {
+}
+
+func (f *fakeresource[T]) Events(ctx context.Context, opts ...resource.EventsOpt) <-chan resource.Event[T] {
+	return make(<-chan resource.Event[T])
+}
+
+func (f *fakeresource[T]) Store(ctx context.Context) (resource.Store[T], error) {
+	return nil, nil
+}
+
+func (f *fakeresource[T]) Observe(ctx context.Context, next func(resource.Event[T]), complete func(error)) {
+}

--- a/operator/cilium-crds/k8s/resources.go
+++ b/operator/cilium-crds/k8s/resources.go
@@ -36,7 +36,9 @@ var ResourcesCell = cell.Module(
 		k8s.CiliumIdentityResource,
 		CiliumEndpointResource,
 		CiliumEndpointSliceResource,
-		k8s.CiliumNodeResource,
+		func() resource.Resource[*cilium_api_v2.CiliumNode] {
+			return &fakeresource[*cilium_api_v2.CiliumNode]{}
+		},
 		k8s.PodResource,
 		k8s.NamespaceResource,
 	),


### PR DESCRIPTION
# Description

Retina Operator deletes endpoints when processing Pod delete events, but if for some reason an endpoint exists after its Pod was deleted, then endpoint GC comes into play.

Endpoint GC was broken because it was failing to watch CiliumNodes. Fix by using a fake CiliumNodes resource.

## Related Issue

Fixes #598 (logs and details there)

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Testing Completed

Manual testing. Operator e2e's are WIP in another PR.