### PR TITLE
chore: Streamline Usability of Captures

### DIFF
--- a/cli/cmd/capture/capture.go
+++ b/cli/cmd/capture/capture.go
@@ -11,15 +11,16 @@ import (
 
 var name string
 
+const defaultName = "retina-capture"
+
 var capture = &cobra.Command{
 	Use:   "capture",
-	Short: "capture network traffic",
+	Short: "Capture network traffic",
 }
 
 func init() {
 	cmd.Retina.AddCommand(capture)
 	configFlags = genericclioptions.NewConfigFlags(true)
 	configFlags.AddFlags(capture.PersistentFlags())
-	capture.PersistentFlags().StringVar(&name, "name", "", "The name of the Retina Capture")
-	_ = capture.MarkPersistentFlagRequired("name")
+	capture.PersistentFlags().StringVar(&name, "name", defaultName, "The name of the Retina Capture")
 }

--- a/cli/cmd/trace.go
+++ b/cli/cmd/trace.go
@@ -9,7 +9,7 @@ import (
 
 var trace = &cobra.Command{
 	Use:   "trace",
-	Short: "retrieve status or results from Retina",
+	Short: "Retrieve status or results from Retina",
 }
 
 var getTrace = &cobra.Command{

--- a/pkg/capture/crd_to_job.go
+++ b/pkg/capture/crd_to_job.go
@@ -519,9 +519,11 @@ func (translator *CaptureToPodTranslator) validateTargetSelector(captureTarget r
 	if captureTarget.NodeSelector == nil && captureTarget.PodSelector == nil {
 		return fmt.Errorf("Neither NodeSelector nor NamespaceSelector&PodSelector is set.")
 	}
+
 	if captureTarget.NodeSelector != nil && (captureTarget.NamespaceSelector != nil || captureTarget.PodSelector != nil) {
-		return fmt.Errorf("NodeSelector is not compatible with NamespaceSelector&PodSelector.")
+		return fmt.Errorf("NodeSelector is not compatible with NamespaceSelector&PodSelector. Please use one or the other.")
 	}
+
 	return nil
 }
 

--- a/pkg/capture/utils/capture_image.go
+++ b/pkg/capture/utils/capture_image.go
@@ -40,7 +40,8 @@ func CaptureWorkloadImage(logger *log.ZapLogger, imageVersion string, debug bool
 
 	// For testing.
 	if debug {
-		if captureWorkloadImageFromEnv := os.Getenv(captureWorkloadImageEnvKey); len(captureWorkloadImageFromEnv) != 0 {
+		captureWorkloadImageFromEnv := os.Getenv(captureWorkloadImageEnvKey)
+		if captureWorkloadImageFromEnv != "" {
 			logger.Info("Debug mode: obtained capture workload image from environment variable", zap.String("environment variable key", captureWorkloadImageEnvKey), zap.String("image", captureWorkloadImageFromEnv))
 			return captureWorkloadImageFromEnv
 		}


### PR DESCRIPTION
# Description

This PR aims to improve the usability of the `retina capture create` command.

New defaults have been set, eliminating the need for required flags. The command can now be ran with just `kubectl retina capture create`.

The documentation received another overhaul - restructuring how flags are displayed into a more readable table and curating the examples which are shown.

## Related Issue

Issue related to updating usability of captures
https://github.com/microsoft/retina/issues/766

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
