### PR TITLE
feat: kapinger add burst delay and interval

### DIFF
--- a/hack/tools/kapinger/config/config.go
+++ b/hack/tools/kapinger/config/config.go
@@ -53,10 +53,12 @@ func LoadConfigFromEnv() *KapingerConfig {
 		log.Printf("%s not set, defaulting to port %d\n", EnvHTTPPort, defaultHTTPPort)
 	}
 
-	k.BurstVolume, err = strconv.Atoi(os.Getenv(EnvHTTPPort))
+	k.BurstVolume, err = strconv.Atoi(os.Getenv(EnvBurstVolume))
 	if err != nil {
 		k.BurstVolume = defaultBurstVolume
 		log.Printf("%s not set, defaulting to %d\n", EnvBurstVolume, defaultBurstVolume)
+	} else {
+		log.Printf("%s set to: %d\n", EnvBurstVolume, k.BurstVolume)
 	}
 
 	burstInterval, err := strconv.Atoi(os.Getenv(EnvBurstInterval))
@@ -65,6 +67,7 @@ func LoadConfigFromEnv() *KapingerConfig {
 		log.Printf("%s not set, defaulting to %d\n", EnvBurstInterval, defaultBurstInterval)
 	} else {
 		k.BurstInterval = time.Duration(burstInterval) * time.Millisecond
+		log.Printf("%s set to: %s\n", EnvBurstInterval, k.BurstInterval)
 	}
 
 	return k

--- a/hack/tools/kapinger/config/config.go
+++ b/hack/tools/kapinger/config/config.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"log"
+	"os"
+	"strconv"
+	"time"
+)
+
+const (
+	defaultHTTPPort      = 8080
+	defaultTCPPort       = 8085
+	defaultUDPPort       = 8086
+	defaultBurstVolume   = 1
+	defaultBurstInterval = 500 * time.Millisecond
+
+	EnvHTTPPort      = "HTTP_PORT"
+	EnvTCPPort       = "TCP_PORT"
+	EnvUDPPort       = "UDP_PORT"
+	EnvBurstVolume   = "BURST_VOLUME"
+	EnvBurstInterval = "BURST_INTERVAL_MS"
+)
+
+// just basic homebrew config, no viper/cobra to keep binary tiny
+type KapingerConfig struct {
+	BurstVolume   int
+	BurstInterval time.Duration
+	HTTPPort      int
+	TCPPort       int
+	UDPPort       int
+}
+
+// configmap later, but for now env is fine
+func LoadConfigFromEnv() *KapingerConfig {
+	k := &KapingerConfig{}
+	var err error
+
+	k.TCPPort, err = strconv.Atoi(os.Getenv(EnvTCPPort))
+	if err != nil {
+		k.TCPPort = defaultTCPPort
+		log.Printf("%s not set, defaulting to port %d\n", EnvTCPPort, defaultTCPPort)
+	}
+
+	k.UDPPort, err = strconv.Atoi(os.Getenv(EnvUDPPort))
+	if err != nil {
+		k.UDPPort = defaultUDPPort
+		log.Printf("%s not set, defaulting to port %d\n", EnvUDPPort, defaultUDPPort)
+	}
+
+	k.HTTPPort, err = strconv.Atoi(os.Getenv(EnvHTTPPort))
+	if err != nil {
+		k.HTTPPort = defaultHTTPPort
+		log.Printf("%s not set, defaulting to port %d\n", EnvHTTPPort, defaultHTTPPort)
+	}
+
+	k.BurstVolume, err = strconv.Atoi(os.Getenv(EnvHTTPPort))
+	if err != nil {
+		k.BurstVolume = defaultBurstVolume
+		log.Printf("%s not set, defaulting to %d\n", EnvBurstVolume, defaultBurstVolume)
+	}
+
+	burstInterval, err := strconv.Atoi(os.Getenv(EnvBurstInterval))
+	if err != nil {
+		k.BurstInterval = defaultBurstInterval
+		log.Printf("%s not set, defaulting to %d\n", EnvBurstInterval, defaultBurstInterval)
+	} else {
+		k.BurstInterval = time.Duration(burstInterval) * time.Millisecond
+	}
+
+	return k
+}

--- a/hack/tools/kapinger/main.go
+++ b/hack/tools/kapinger/main.go
@@ -1,20 +1,16 @@
 package main
 
 import (
+	"context"
 	"log"
 	"math/rand"
-	"os"
-	"strconv"
 	"time"
 
 	"github.com/microsoft/retina/hack/tools/kapinger/clients"
+	"github.com/microsoft/retina/hack/tools/kapinger/config"
 	"github.com/microsoft/retina/hack/tools/kapinger/servers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-)
-
-const (
-	delay = 500 * time.Millisecond
 )
 
 func main() {
@@ -24,16 +20,13 @@ func main() {
 		log.Fatal(err)
 	}
 
-	httpPort, err := strconv.Atoi(os.Getenv(servers.EnvHTTPPort))
-	if err != nil {
-		httpPort = servers.HTTPPort
-		log.Printf("HTTP_PORT not set, defaulting to port %d\n", servers.HTTPPort)
-	}
+	config := config.LoadConfigFromEnv()
 
-	go servers.StartAll()
+	ctx := context.Background()
+	go servers.StartAll(ctx, config)
 
-	// Create an HTTP client with the custom Transport
-	client, err := clients.NewKapingerHTTPClient(clientset, "app=kapinger", httpPort)
+	// Create an HTTP httpclient with the custom Transport
+	httpclient, err := clients.NewKapingerHTTPClient(clientset, "app=kapinger", config.HTTPPort)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -45,12 +38,9 @@ func main() {
 	jitter := rand.Intn(100) + 1
 	time.Sleep(time.Duration(jitter) * time.Millisecond)
 
-	for {
-		err := client.MakeRequest()
-		if err != nil {
-			log.Printf("error making request: %v", err)
-		}
-		time.Sleep(delay)
+	err = httpclient.MakeRequests(ctx, config.BurstVolume, config.BurstInterval)
+	if err != nil {
+		log.Printf("error making request: %v", err)
 	}
 }
 

--- a/hack/tools/kapinger/servers/server.go
+++ b/hack/tools/kapinger/servers/server.go
@@ -3,19 +3,11 @@ package servers
 import (
 	"context"
 	"log"
-	"os"
-	"strconv"
+
+	"github.com/microsoft/retina/hack/tools/kapinger/config"
 )
 
-const (
-	HTTPPort = 8080
-	TCPPort  = 8085
-	UDPPort  = 8086
-
-	EnvHTTPPort = "HTTP_PORT"
-	EnvTCPPort  = "TCP_PORT"
-	EnvUDPPort  = "UDP_PORT"
-)
+const ()
 
 type Server interface {
 	Start(ctx context.Context) error
@@ -37,34 +29,15 @@ func (k *Kapinger) Start(ctx context.Context) {
 	<-ctx.Done()
 }
 
-func StartAll() {
-	tcpPort, err := strconv.Atoi(os.Getenv(EnvTCPPort))
-	if err != nil {
-		tcpPort = TCPPort
-		log.Printf("TCP_PORT not set, defaulting to port %d\n", TCPPort)
-	}
-
-	udpPort, err := strconv.Atoi(os.Getenv(EnvUDPPort))
-	if err != nil {
-		udpPort = UDPPort
-		log.Printf("UDP_PORT not set, defaulting to port %d\n", UDPPort)
-	}
-
-	httpPort, err := strconv.Atoi(os.Getenv(EnvHTTPPort))
-	if err != nil {
-		httpPort = HTTPPort
-		log.Printf("HTTP_PORT not set, defaulting to port %d\n", HTTPPort)
-	}
-
+func StartAll(ctx context.Context, config *config.KapingerConfig) {
 	k := &Kapinger{
 		servers: []Server{
-			NewKapingerTCPServer(tcpPort),
-			NewKapingerUDPServer(udpPort),
-			NewKapingerHTTPServer(httpPort),
+			NewKapingerTCPServer(config.TCPPort),
+			NewKapingerUDPServer(config.UDPPort),
+			NewKapingerHTTPServer(config.HTTPPort),
 		},
 	}
 
 	// cancel
-	ctx := context.Background()
 	k.Start(ctx)
 }

--- a/test/prometheus/ama-metrics-node/prometheus-config
+++ b/test/prometheus/ama-metrics-node/prometheus-config
@@ -1,5 +1,6 @@
 global:
   scrape_interval: 10s
+  
 scrape_configs:
   - job_name: "networkobservability-retina-test"
     kubernetes_sd_configs:
@@ -29,3 +30,7 @@ scrape_configs:
       - source_labels: [__address__]
         replacement: "$NODE_NAME"
         target_label: instance
+
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: "pod"

--- a/test/prometheus/ama-metrics/prometheus-config
+++ b/test/prometheus/ama-metrics/prometheus-config
@@ -1,0 +1,8 @@
+kind: ConfigMap
+apiVersion: v1
+data:
+  pod-annotation-based-scraping: |-
+    podannotationnamespaceregex = ""
+metadata:
+  name: ama-metrics-settings-configmap
+  namespace: kube-system

--- a/test/prometheus/create-cm.sh
+++ b/test/prometheus/create-cm.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 kubectl apply -f ./test/prometheus/service.yaml
+
 kubectl delete configmap ama-metrics-prometheus-config-node -n kube-system
-kubectl create configmap ama-metrics-prometheus-config-node --from-file=./test/prometheus/prometheus-config -n kube-system 
+#kubectl create configmap ama-metrics-prometheus-config-node --from-file=./test/prometheus/ama-metrics-node/prometheus-config -n kube-system 
+
+kubectl delete configmap ama-metrics-prometheus-config -n kube-system
+# kubectl create configmap ama-metrics-prometheus-config --from-file=./test/prometheus/ama-metrics/prometheus-config -n kube-system 
+kubectl apply -f ./test/prometheus/ama-metrics/prometheus-config -n kube-system
+
 kubectl rollout restart ds ama-metrics-node -n kube-system
+kubectl rollout restart deploy ama-metrics -n kube-system

--- a/test/prometheus/create-cm.sh
+++ b/test/prometheus/create-cm.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+kubectl apply -f ./test/prometheus/service.yaml
+kubectl delete configmap ama-metrics-prometheus-config-node -n kube-system
+kubectl create configmap ama-metrics-prometheus-config-node --from-file=./test/prometheus/prometheus-config -n kube-system 
+kubectl rollout restart ds ama-metrics-node -n kube-system

--- a/test/prometheus/prometheus-config
+++ b/test/prometheus/prometheus-config
@@ -1,0 +1,31 @@
+global:
+  scrape_interval: 10s
+scrape_configs:
+  - job_name: "networkobservability-retina-test"
+    kubernetes_sd_configs:
+      - role: service
+    scheme: http
+    relabel_configs:
+      - source_labels:
+          [
+            __meta_kubernetes_namespace,
+            __meta_kubernetes_service_name,
+            __meta_kubernetes_service_port_name,
+          ]
+        action: keep
+        regex: kube-system;networkobservability-test;retina
+
+      - source_labels: [__address__]
+        target_label: __address__
+        replacement: $NODE_IP
+        action: replace
+
+      - source_labels: [__address__, __meta_kubernetes_service_port_number]
+        action: replace
+        regex: ([^:]+)(?::\d+)?;(\d+)
+        replacement: $1:$2
+        target_label: __address__
+
+      - source_labels: [__address__]
+        replacement: "$NODE_NAME"
+        target_label: instance

--- a/test/prometheus/service.yaml
+++ b/test/prometheus/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: networkobservability-test
+spec:
+  ports:
+    - name: retina
+      protocol: TCP
+      port: 10093
+      targetPort: 10093

--- a/test/trafficgen/kapinger.yaml
+++ b/test/trafficgen/kapinger.yaml
@@ -47,7 +47,7 @@ spec:
       serviceAccountName: kapinger-sa
       containers:
         - name: kapinger
-          image: ghcr.io/microsoft/retina/kapinger:latest
+          image: acnpublic.azurecr.io/kapinger:20241009.5
           resources:
             limits:
               memory: 20Mi
@@ -70,6 +70,10 @@ spec:
               value: "8085"
             - name: UDP_PORT
               value: "8086"
+            - name: BURST_INTERVAL_MS
+              value: "500"
+            - name: BURST_VOLUME
+              value: "1"
           ports:
             - containerPort: 8080
 ---


### PR DESCRIPTION
# Description

Provide request burst and interval for Kapinger, used to tune volume of http requests

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
