### PR TITLE
fix: Add Hubble Scrape Job for Prometheus

### DIFF
--- a/deploy/hubble/prometheus/values.yaml
+++ b/deploy/hubble/prometheus/values.yaml
@@ -1,0 +1,91 @@
+windowsMonitoring:
+  enabled: true
+
+prometheusOperator:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                  - linux
+
+  admissionWebhooks:
+    deployment:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+    patch:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                      - linux
+
+prometheus:
+  prometheusSpec:
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: kubernetes.io/os
+                  operator: In
+                  values:
+                    - linux
+    additionalScrapeConfigs: |
+      - job_name: "retina-pods"
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_pod_container_name]
+            action: keep
+            regex: retina
+          - source_labels:
+              [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+            separator: ":"
+            regex: ([^:]+)(?::\d+)?
+            target_label: __address__
+            replacement: ${1}:${2}
+            action: replace
+          - source_labels: [__meta_kubernetes_pod_node_name]
+            action: replace
+            target_label: instance
+        metric_relabel_configs:
+          - source_labels: [__name__]
+            action: keep
+            regex: (.*)
+      - job_name: networkobservability-hubble
+        kubernetes_sd_configs:
+          - role: pod
+        relabel_configs:
+          - target_label: cluster
+            replacement: myAKSCluster
+            action: replace
+          - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_label_k8s_app]
+            regex: kube-system;(retina)
+            action: keep
+          - source_labels: [__address__]
+            action: replace
+            regex: ([^:]+)(?::\d+)?
+            replacement: $1:9965
+            target_label: __address__
+          - source_labels: [__meta_kubernetes_pod_node_name]
+            target_label: instance
+            action: replace
+        metric_relabel_configs:
+          - source_labels: [__name__]
+            regex: '|hubble_dns_queries_total|hubble_dns_responses_total|hubble_drop_total|hubble_tcp_flags_total|hubble_flows_processed_total'
+            action: keep


### PR DESCRIPTION
# Description

Adding Hubble scrap job for Prometheus as legacy [values.yaml](https://github.com/microsoft/retina/blob/main/deploy/legacy/prometheus/values.yaml) does not include [Hubble scrape job](https://learn.microsoft.com/en-us/azure/aks/advanced-network-observability-bring-your-own-cli?tabs=non-cilium#visualization-using-grafana).

![image](https://github.com/user-attachments/assets/0d9629ee-181e-4769-974c-21a6a1cc5496)
![image](https://github.com/user-attachments/assets/a3e2be57-0901-4043-8846-b7be3ffc240a)



## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
