### PR TITLE
fix: Set PowerShell path using environment variables

### DIFF
--- a/pkg/telemetry/heartbeat_windows.go
+++ b/pkg/telemetry/heartbeat_windows.go
@@ -12,7 +12,7 @@ import (
 )
 
 func KernelVersion(ctx context.Context) (string, error) {
-	cmd := exec.CommandContext(ctx, ".\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", "$([Environment]::OSVersion).VersionString")
+	cmd := exec.CommandContext(ctx, "powershell", "-command", "$([Environment]::OSVersion).VersionString")
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to get windows kernel version: %s", string(output))


### PR DESCRIPTION
# Description

Kusto complain the system cannot find the powershell path in Windows, I noticed in windows we are currently hardcoding the powershell path in hpc folder, since the windows powershell in PATH environment variable lost issue was fixed, we should change it back instead of hard code the path

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
