### PR TITLE
fix(docs): update doc, codespaces config and GHA on commit GPG signed

### DIFF
--- a/docs/07-Contributing/developing.md
+++ b/docs/07-Contributing/developing.md
@@ -190,8 +190,25 @@ In order to certify the provenance of commits and defend against impersonation, 
 Documentation for setting up Git and Github to sign your commits can be found [here](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
 Additional information about Git's use of GPG can be found [here](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work)
 
+This can be accomplished by providing a `-S` flag to `git commit` as documented [here](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--Sltkeyidgt)
+
 ### Developers Certificate of Origin (DCO)
 
 Contributions to Retina must contain a Developers Certificate of Origin within their constituent commits.
 This can be accomplished by providing a `-s` flag to `git commit` as documented [here](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s).
 This will add a `Signed-off-by` trailer to your Git commit, affirming your acceptance of the Contributor License Agreement.
+
+### Example commit
+
+Here is an example development flow to add a change made to file `docs/07-Contributing/developing.md`
+
+```sh
+git checkout -b feat-branch-1
+git add docs/07-Contributing/developing.md
+git commit -m "fix(doc): update contributing docs" -sS
+git push origin feat-branch-1 -u
+```
+
+After committing your change, when accessing [retina project's repo](https://github.com/microsoft/retina) you will get a prompt to create a PR from your fork.
+
+> Note: the DCO is not mandatory (i.e. the `-s` flag) - however, the cryptographically signing of commit is mandatory for all contributors. Hence, please make sure to always include the `-S` flag to your `git commit` instructions. 

--- a/docs/07-Contributing/developing.md
+++ b/docs/07-Contributing/developing.md
@@ -190,23 +190,12 @@ In order to certify the provenance of commits and defend against impersonation, 
 Documentation for setting up Git and Github to sign your commits can be found [here](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
 Additional information about Git's use of GPG can be found [here](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work)
 
-This can be accomplished by providing a `-S` flag to `git commit` as documented [here](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--Sltkeyidgt)
+> To configure your Git client to sign commits by default for a local repository, run `git config --add commit.gpgsign true`.
+
+For **GitHub Codespaces** users, please follow [this doc](https://docs.github.com/en/codespaces/managing-your-codespaces/managing-gpg-verification-for-github-codespaces) to configure GitHub to automatically use GPG to sign commits you make in your Codespaces.
 
 ### Developers Certificate of Origin (DCO)
 
 Contributions to Retina must contain a Developers Certificate of Origin within their constituent commits.
 This can be accomplished by providing a `-s` flag to `git commit` as documented [here](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s).
 This will add a `Signed-off-by` trailer to your Git commit, affirming your acceptance of the Contributor License Agreement.
-
-### Example commit
-
-Here is an example development flow to add a change made to file `docs/07-Contributing/developing.md`
-
-```sh
-git checkout -b feat-branch-1
-git add docs/07-Contributing/developing.md
-git commit -m "fix(doc): update contributing docs" -sS
-git push origin feat-branch-1 -u
-```
-
-After committing your change, when accessing [retina project's repo](https://github.com/microsoft/retina) you will get a prompt to create a PR from your fork.

--- a/docs/07-Contributing/developing.md
+++ b/docs/07-Contributing/developing.md
@@ -211,4 +211,4 @@ git push origin feat-branch-1 -u
 
 After committing your change, when accessing [retina project's repo](https://github.com/microsoft/retina) you will get a prompt to create a PR from your fork.
 
-> Note: the DCO is not mandatory (i.e. the `-s` flag) - however, the cryptographically signing of commit is mandatory for all contributors. Hence, please make sure to always include the `-S` flag to your `git commit` instructions. 
+> Note: the DCO is not mandatory (i.e. the `-s` flag) - however, the cryptographically signing of commit is mandatory for all contributors. Hence, please make sure to always include the `-S` flag to your `git commit` instructions.

--- a/docs/07-Contributing/developing.md
+++ b/docs/07-Contributing/developing.md
@@ -210,5 +210,3 @@ git push origin feat-branch-1 -u
 ```
 
 After committing your change, when accessing [retina project's repo](https://github.com/microsoft/retina) you will get a prompt to create a PR from your fork.
-
-> Note: the DCO is not mandatory (i.e. the `-s` flag) - however, the cryptographically signing of commit is mandatory for all contributors. Hence, please make sure to always include the `-S` flag to your `git commit` instructions.


### PR DESCRIPTION
# Description

* update contributing doc to add a note about signing commits by default
* add instructions for  codespaces users to use GPG to sign commits

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

![image](https://github.com/user-attachments/assets/0bec8adb-dcf7-46c0-aedf-466306d99c1f)

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
