### PR TITLE
fix: improve resiliency for e2e tests by adding tweaking retries and timeouts (partially fixes #449)

### DIFF
--- a/test/e2e/framework/azure/create-cluster-with-npm.go
+++ b/test/e2e/framework/azure/create-cluster-with-npm.go
@@ -18,7 +18,7 @@ var (
 )
 
 const (
-	clusterTimeout      = 10 * time.Minute
+	clusterTimeout      = 15 * time.Minute
 	clusterCreateTicker = 30 * time.Second
 	pollFrequency       = 5 * time.Second
 	AgentARMSKU         = "Standard_D4pls_v5"

--- a/test/e2e/framework/kubernetes/port-forward.go
+++ b/test/e2e/framework/kubernetes/port-forward.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	defaultTimeoutSeconds    = 300
-	defaultRetryDelay        = 5 * time.Second
+	defaultRetryDelay        = 500 * time.Millisecond
 	defaultRetryAttempts     = 60
 	defaultHTTPClientTimeout = 2 * time.Second
 )
@@ -27,7 +27,7 @@ const (
 var (
 	ErrNoPodWithLabelFound = fmt.Errorf("no pod with label found with matching pod affinity")
 
-	defaultRetrier = retry.Retrier{Attempts: defaultRetryAttempts, Delay: defaultRetryDelay}
+	defaultRetrier = retry.Retrier{Attempts: defaultRetryAttempts, Delay: defaultRetryDelay, ExpBackoff: true}
 )
 
 type PortForward struct {


### PR DESCRIPTION
# Description

This pull request includes several changes to improve the reliability and efficiency of the Kubernetes end-to-end testing framework. The most important changes involve adjusting timeouts and retry mechanisms to enhance robustness and reduce wait times.

### Improvements to retry mechanisms:

* [`test/e2e/framework/kubernetes/exec-pod.go`](diffhunk://#diff-ebfee2072870c7e30ca7222eab3f94550af60a5ac8de53aa632a949fcd4fd667L42-R54): Added retry logic using `retry.OnError` for executing commands in a pod to handle transient errors more gracefully.
* [`test/e2e/framework/kubernetes/port-forward.go`](diffhunk://#diff-ed249ad2b2805041dfd7ff7466005e33aa4a55adc7728524f6c060af8131dd61L22-R30): Enabled exponential backoff in the default retrier to improve the efficiency of retry attempts.

### Adjustments to timeouts and delays:

* [`test/e2e/framework/azure/create-cluster-with-npm.go`](diffhunk://#diff-bf0613d6eb45a2bdc85b1446ab964c4249722b16bdc616129ec7b71dc0185553L21-R21): Increased the `clusterTimeout` from 10 to 15 minutes to allow more time for cluster creation.
* [`test/e2e/framework/kubernetes/port-forward.go`](diffhunk://#diff-ed249ad2b2805041dfd7ff7466005e33aa4a55adc7728524f6c060af8131dd61L22-R30): Reduced the `defaultRetryDelay` from 5 seconds to 500 milliseconds to decrease the wait time between retry attempts.

### Dependency updates:

* [`test/e2e/framework/kubernetes/exec-pod.go`](diffhunk://#diff-ebfee2072870c7e30ca7222eab3f94550af60a5ac8de53aa632a949fcd4fd667R16): Added import for `k8s.io/client-go/util/retry` to support the new retry logic.

Please provide a brief description of the changes made in this pull request.

## Related Issue

It fixes the issue #449 which talk about the intermittent failures in our e2e test.

## Checklist

- [X] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [X] I have correctly attributed the author(s) of the code.
- [X] I have tested the changes locally.
- [X] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
