### PR TITLE
fix(tests): Improve e2e resiliency

### DIFF
--- a/test/e2e/scenarios/dns/scenarios.go
+++ b/test/e2e/scenarios/dns/scenarios.go
@@ -48,6 +48,15 @@ func ValidateBasicDNSMetrics(scenarioName string, req *RequestValidationParams, 
 				AgnhostNamespace: namespace,
 			},
 		},
+		// Need this delay to guarantee that the pods will have bpf program attached
+		{
+			Step: &types.Sleep{
+				Duration: 30 * time.Second,
+			},
+			Opts: &types.StepOptions{
+				SkipSavingParametersToJob: true,
+			},
+		},
 		{
 			Step: &kubernetes.ExecInPod{
 				PodName:      podName,
@@ -150,6 +159,15 @@ func ValidateAdvancedDNSMetrics(scenarioName string, req *RequestValidationParam
 			Step: &kubernetes.CreateAgnhostStatefulSet{
 				AgnhostName:      agnhostName,
 				AgnhostNamespace: namespace,
+			},
+		},
+		// Need this delay to guarantee that the pods will have bpf program attached
+		{
+			Step: &types.Sleep{
+				Duration: 30 * time.Second,
+			},
+			Opts: &types.StepOptions{
+				SkipSavingParametersToJob: true,
 			},
 		},
 		{


### PR DESCRIPTION
# Description

This pull request includes changes to improve the end-to-end resiliency in DNS scenarios. The changes include:

- Added a delay to guarantee that the pods will have the BPF program attached before executing further steps in the scenario.

- Updated the label selector for the `CreateDenyAllNetworkPolicy` step to target the `agnhost-drop` pods instead of `agnhost-a` pods.

- Updated the `CreateAgnhostStatefulSet` step to use the `agnhost-drop` name instead of `agnhost-a`.

- Updated the `ExecInPod` steps to target the `agnhost-drop-0` pod instead of `agnhost-a-0`.

- Updated the `ValidateRetinaDropMetric` step to use the `agnhost-drop` source instead of `agnhost-a`.

- Updated the `DeleteKubernetesResource` step to target the `agnhost-drop` stateful set instead of `agnhost-a`.


## Related Issue

It addresses the issue #449 which talk about the intermittent failures in our e2e test.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

![image](https://github.com/user-attachments/assets/5d8697b9-99e1-4bf7-9db8-12055b2d5ce0)

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
