### PR TITLE
feat(hubble): Add Ciliumendpoint and Service resource to k8s watcher

### DIFF
--- a/pkg/k8s/watcher_linux.go
+++ b/pkg/k8s/watcher_linux.go
@@ -19,14 +19,14 @@ import (
 
 const (
 	K8sAPIGroupCiliumEndpointV2 = "cilium/v2::CiliumEndpoint"
+	K8sAPIGroupServiceV1Core    = "core/v1::Service"
 )
 
 var (
-	once   sync.Once
-	w      *watchers.K8sWatcher
-	logger = logging.DefaultLogger.WithField(logfields.LogSubsys, "k8s-watcher")
-	// k8sResources = []string{K8sAPIGroupCiliumEndpointV2, resources.K8sAPIGroupServiceV1Core}
-	k8sResources = []string{}
+	once         sync.Once
+	w            *watchers.K8sWatcher
+	logger       = logging.DefaultLogger.WithField(logfields.LogSubsys, "k8s-watcher")
+	k8sResources = []string{K8sAPIGroupCiliumEndpointV2, K8sAPIGroupServiceV1Core}
 )
 
 type watcherParams struct {


### PR DESCRIPTION
# Description

Add CiliumEndpoint and Service objects to IPCache for flow enrichment.

## Related Issue

https://github.com/microsoft/retina/issues/536

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

```bash
Oct 27 18:19:13.348: kube-system/alpine:59204 (ID:45406) -> 10.0.216.107:8080 (world) to-stack FORWARDED (TCP Flags: SYN:true)
Oct 27 18:19:13.350: kube-system/alpine:59204 (ID:45406) <- 10.0.216.107:8080 (world) to-endpoint FORWARDED (TCP Flags: SYN:true  ACK:true)
Oct 27 18:19:13.350: kube-system/alpine:59204 (ID:45406) -> 10.0.216.107:8080 (world) to-stack FORWARDED (TCP Flags: ACK:true)
Oct 27 18:19:13.350: kube-system/alpine:59204 (ID:45406) -> 10.0.216.107:8080 (world) to-stack FORWARDED (TCP Flags: PSH:true  ACK:true)
Oct 27 18:19:13.352: kube-system/alpine:59204 (ID:45406) <- 10.0.216.107:8080 (world) to-endpoint FORWARDED (TCP Flags: PSH:true  ACK:true)
Oct 27 18:19:13.352: kube-system/alpine:59204 (ID:45406) <- 10.0.216.107:8080 (world) to-endpoint FORWARDED (TCP Flags: FIN:true  ACK:true)
Oct 27 18:19:13.352: 10.0.216.107:8080 (world) <- kube-system/alpine:59204 (ID:45406) to-stack FORWARDED (TCP Flags: FIN:true  ACK:true)
Oct 27 18:19:13.352: default/kapinger-good-6b6c74547d-5db4w:8080 (ID:12871) -> kube-system/alpine:59204 (ID:45406) to-stack FORWARDED (TCP Flags: SYN:true  ACK:true)
Oct 27 18:19:13.353: 10.0.216.107:8080 (world) -> kube-system/alpine:59204 (ID:45406) to-endpoint FORWARDED (TCP Flags: ACK:true)
Oct 27 18:19:13.354: default/kapinger-good-6b6c74547d-5db4w:8080 (ID:12871) -> kube-system/alpine:59204 (ID:45406) to-stack FORWARDED (TCP Flags: ACK:true)
Oct 27 18:19:13.354: default/kapinger-good-6b6c74547d-5db4w:8080 (ID:12871) -> kube-system/alpine:59204 (ID:45406) to-stack FORWARDED (TCP Flags: PSH:true  ACK:true)
Oct 27 18:19:13.355: default/kapinger-good-6b6c74547d-5db4w:8080 (ID:12871) -> kube-system/alpine:59204 (ID:45406) to-stack FORWARDED (TCP Flags: FIN:true  ACK:true)
Oct 27 18:19:13.355: kube-system/alpine:59204 (ID:45406) <- default/kapinger-good-6b6c74547d-5db4w:8080 (ID:12871) to-stack FORWARDED (TCP Flags: ACK:true)
```

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
