### PR TITLE
chore(ct): add flag to mark ct_entry connection direction is unkown

### DIFF
--- a/pkg/plugin/conntrack/_cprog/conntrack.c
+++ b/pkg/plugin/conntrack/_cprog/conntrack.c
@@ -275,7 +275,7 @@ static __always_inline bool _ct_should_report_packet(struct ct_entry *entry, __u
         return true;
     }
 
-    // We will only report this packet if a new flag is seen for the given direction or the report interval has passed.
+    // We will only report this packet iff a new flag is seen for the given direction or the report interval has passed.
     if (flags != seen_flags || now - last_report >= CT_REPORT_INTERVAL) {
         if (direction == CT_PACKET_DIR_TX) {
             WRITE_ONCE(entry->flags_seen_tx_dir, flags);

--- a/pkg/plugin/conntrack/_cprog/conntrack.c
+++ b/pkg/plugin/conntrack/_cprog/conntrack.c
@@ -122,6 +122,7 @@ static __always_inline bool _ct_create_new_tcp_connection(struct ct_v4_key key, 
     }
     new_value.eviction_time = now + CT_SYN_TIMEOUT;
     new_value.flags_seen_tx_dir = flags;
+    new_value.is_direction_unknown = false;
     new_value.traffic_direction = _ct_get_traffic_direction(observation_point);
     bpf_map_update_elem(&retina_conntrack, &key, &new_value, BPF_ANY);
     return true;

--- a/pkg/plugin/conntrack/conntrack_bpfel_x86.go
+++ b/pkg/plugin/conntrack/conntrack_bpfel_x86.go
@@ -13,13 +13,13 @@ import (
 )
 
 type conntrackCtEntry struct {
-	EvictionTime     uint32
-	LastReportTxDir  uint32
-	LastReportRxDir  uint32
-	TrafficDirection uint8
-	FlagsSeenTxDir   uint8
-	FlagsSeenRxDir   uint8
-	_                [1]byte
+	EvictionTime       uint32
+	LastReportTxDir    uint32
+	LastReportRxDir    uint32
+	TrafficDirection   uint8
+	FlagsSeenTxDir     uint8
+	FlagsSeenRxDir     uint8
+	IsDirectionUnknown bool
 }
 
 type conntrackCtV4Key struct {

--- a/pkg/plugin/conntrack/conntrack_linux.go
+++ b/pkg/plugin/conntrack/conntrack_linux.go
@@ -120,6 +120,7 @@ func (ct *Conntrack) Run(ctx context.Context) error {
 					zap.String("flags_seen_rx_dir", decodeFlags(value.FlagsSeenRxDir)),
 					zap.Uint32("last_reported_tx_dir", value.LastReportTxDir),
 					zap.Uint32("last_reported_rx_dir", value.LastReportRxDir),
+					zap.Bool("is_direction_unknown", value.IsDirectionUnknown),
 				)
 			}
 			if err := iter.Err(); err != nil {

--- a/pkg/plugin/packetparser/packetparser_bpfel_x86.go
+++ b/pkg/plugin/packetparser/packetparser_bpfel_x86.go
@@ -13,13 +13,13 @@ import (
 )
 
 type packetparserCtEntry struct {
-	EvictionTime     uint32
-	LastReportTxDir  uint32
-	LastReportRxDir  uint32
-	TrafficDirection uint8
-	FlagsSeenTxDir   uint8
-	FlagsSeenRxDir   uint8
-	_                [1]byte
+	EvictionTime       uint32
+	LastReportTxDir    uint32
+	LastReportRxDir    uint32
+	TrafficDirection   uint8
+	FlagsSeenTxDir     uint8
+	FlagsSeenRxDir     uint8
+	IsDirectionUnknown bool
 }
 
 type packetparserCtV4Key struct {


### PR DESCRIPTION
# Description

* add new member is_direction_unknown to conntrack_entry struct
* set is_direction_unknown to true when the SYN packet is not captured

## Related Issue

#919 

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
