### PR TITLE
feat: add retina-shell image for Linux

### DIFF
--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -1,0 +1,31 @@
+# mcr.microsoft.com/azurelinux/base/core:3.0.20241005
+FROM mcr.microsoft.com/azurelinux/base/core@sha256:7ec490b605aac8a44aed0b0695b0ee6ae976ec898afd9ac8d5613d7f3ce2b07b
+
+# There are a two known issues with Azure Linux 3.0.20241005 that affect this image:
+# 1. `iptables-nft` binary is not yet installed, but will be fixed by https://github.com/microsoft/azurelinux/pull/10786
+#    Until then, use `nft` to view nftables rules.
+# 2. `nslookup` and `bind` print an error "Algorithm not supported by SCOSSL" (but still complete successfully).
+#    This will be fixed by https://github.com/microsoft/SymCrypt-OpenSSL/pull/92
+RUN tdnf install -y \
+	bind-utils \
+	bpftool \
+	bpftrace \
+	conntrack \
+	curl \
+	ebtables-legacy \
+	iperf3 \
+	iproute \
+	ipset \
+	iptables \
+	iputils \
+	ldns-utils \
+	net-tools \
+	nftables \
+	nmap \
+	openssh \
+	socat \
+	tcpdump \
+	wget \
+	&& tdnf clean all
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
# Description

Build a new image retina-shell for adhoc network debugging on Linux nodes/pods.

## Related Issue

https://github.com/microsoft/retina/issues/910

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Tested building with the following commands:
```
IMAGE_REGISTRY=widalytest.azurecr.io BUILDX_ACTION=--push PLATFORM=linux/amd64 make retina-shell-image
IMAGE_REGISTRY=widalytest.azurecr.io BUILDX_ACTION=--push PLATFORM=linux/arm64 make retina-shell-image
IMAGE_REGISTRY=widalytest.azurecr.io BUILDX_ACTION=--push make manifest-shell-image
```

Then ran it locally:
<img width="779" alt="image" src="https://github.com/user-attachments/assets/7a6b0163-aa90-48b1-815a-99e64a042a25">


## Additional Notes

There are two issues with the AzLinux 3 base image that should be fixed in the upcoming AzLinux3 release. See comments in the Dockerfile for details.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
