### PR TITLE
fix(docs): Typo in CLI installation options

### DIFF
--- a/docs/02-Installation/02-CLI.md
+++ b/docs/02-Installation/02-CLI.md
@@ -16,7 +16,7 @@ kubectl krew install retina
 
 Download the `kubectl-retina` package for your platform from the latest [Retina release](https://github.com/microsoft/retina/releases/latest).
 
-## Option 2: Build from source
+## Option 3: Build from source
 
 Building the CLI requires go1.21 or greater.
 


### PR DESCRIPTION
# Description

There are two "Option 2". Changing the third option to be "Option 3".

## Related Issue

na

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [] I have added tests, if applicable.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
