### PR TITLE
feat: Replace CGO_ENABLED=0 with //go:build ignore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,14 +139,14 @@ setup-envtest: $(ENVTEST)
 all: generate
 
 generate: generate-bpf-go
-	CGO_ENABLED=0 go generate ./...
+	go generate ./...
 	for dir in $(GENERATE_TARGET_DIRS); do \
 			make -C $$dir $@; \
 	done
 
 generate-bpf-go: ## generate ebpf wrappers for plugins for all archs
 	for arch in $(ALL_ARCH.linux); do \
-        CGO_ENABLED=0 GOARCH=$$arch go generate ./pkg/plugin/...; \
+        GOARCH=$$arch go generate ./pkg/plugin/...; \
     done
 	
 .PHONY: all generate generate-bpf-go
@@ -174,12 +174,11 @@ retina: ## builds retina binary
 	$(MAKE) retina-binary 
 
 retina-binary: ## build the Retina binary
-	export CGO_ENABLED=0 && \
 	go generate ./... && \
 	go build -v -o $(RETINA_BUILD_DIR)/retina$(EXE_EXT) -gcflags="-dwarflocationlists=true" -ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version=$(TAG) -X github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID=$(APP_INSIGHTS_ID)" $(RETINA_DIR)/main.go
 
 retina-capture-workload: ## build the Retina capture workload
-	cd $(CAPTURE_WORKLOAD_DIR) && CGO_ENABLED=0 go build -v -o $(RETINA_BUILD_DIR)/captureworkload$(EXE_EXT) -gcflags="-dwarflocationlists=true"  -ldflags "-X main.version=$(TAG)"
+	cd $(CAPTURE_WORKLOAD_DIR) && go build -v -o $(RETINA_BUILD_DIR)/captureworkload$(EXE_EXT) -gcflags="-dwarflocationlists=true"  -ldflags "-X main.version=$(TAG)"
 
 ##@ Containers
 
@@ -410,7 +409,7 @@ COVER_PKG ?= .
 
 test: $(ENVTEST) # Run unit tests.
 	go build -o test-summary ./test/utsummary/main.go
-	CGO_ENABLED=0 KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use -p path)" go test -tags=unit,dashboard -skip=TestE2E* -coverprofile=coverage.out -v -json ./... | ./test-summary --progress --verbose
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use -p path)" go test -tags=unit,dashboard -skip=TestE2E* -coverprofile=coverage.out -v -json ./... | ./test-summary --progress --verbose
 
 coverage: # Code coverage.
 #	go generate ./... && go test -tags=unit -coverprofile=coverage.out.tmp ./...

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -25,7 +25,6 @@ FROM golang AS intermediate
 ARG APP_INSIGHTS_ID # set to enable AI telemetry
 ARG GOARCH=amd64 # default to amd64
 ARG GOOS=linux # default to linux
-ENV CGO_ENABLED=0
 ENV GOARCH=${GOARCH}
 ENV GOOS=${GOOS}
 RUN if [ "$GOOS" = "linux" ] ; then \
@@ -52,7 +51,6 @@ ARG APP_INSIGHTS_ID # set to enable AI telemetry
 ARG GOARCH=amd64 # default to amd64
 ARG GOOS=linux # default to linux
 ARG VERSION
-ENV CGO_ENABLED=0
 ENV GOARCH=${GOARCH}
 ENV GOOS=${GOOS}
 RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /go/bin/retina/captureworkload -ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version="$VERSION" -X github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID="$APP_INSIGHTS_ID"" captureworkload/main.go
@@ -64,7 +62,6 @@ ARG APP_INSIGHTS_ID # set to enable AI telemetry
 ARG GOARCH=amd64 # default to amd64
 ARG GOOS=linux # default to linux
 ARG VERSION
-ENV CGO_ENABLED=0
 ENV GOARCH=${GOARCH}
 ENV GOOS=${GOOS}
 RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /go/bin/retina/controller -ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version="$VERSION" -X github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID="$APP_INSIGHTS_ID"" controller/main.go 
@@ -76,7 +73,6 @@ ARG APP_INSIGHTS_ID # set to enable AI telemetry
 ARG GOARCH=amd64 # default to amd64
 ARG GOOS=linux # default to linux
 ARG VERSION
-ENV CGO_ENABLED=0
 ENV GOARCH=${GOARCH}
 ENV GOOS=${GOOS}
 RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /go/bin/retina/initretina -ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version="$VERSION" -X github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID="$APP_INSIGHTS_ID"" init/retina/main_linux.go

--- a/controller/Dockerfile.windows-native
+++ b/controller/Dockerfile.windows-native
@@ -8,7 +8,6 @@ FROM --platform=windows/amd64 mcr.microsoft.com/oss/go/microsoft/golang@sha256:e
 WORKDIR C:\\retina
 COPY go.mod .
 COPY go.sum .
-ENV CGO_ENABLED=0
 RUN go mod download
 ADD . .
 ARG VERSION

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -26,6 +26,8 @@ RUN --mount=type=cache,target="/root/.cache/go-build" \
 # mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/cbl-mariner/distroless/minimal@sha256:db87903c5d4d9d6760e86a274914efd6a3bb5914c0b5a6c6b35350ec297fea4f
 WORKDIR /
+COPY --from=builder /lib /lib
+COPY --from=builder /usr/lib/ /usr/lib
 COPY --from=builder /workspace/retina-operator .
 USER 65532:65532
 

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -17,7 +17,7 @@ ENV GOARCH=${GOARCH}
 
 RUN make manifests
 RUN --mount=type=cache,target="/root/.cache/go-build" \
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+	GOOS=linux GOARCH=amd64 go build \
 	-ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version="$VERSION" \
 	-X "github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID"="$APP_INSIGHTS_ID"" \
 	-a -o retina-operator operator/main.go

--- a/pkg/plugin/conntrack/_cprog/conntrack.c
+++ b/pkg/plugin/conntrack/_cprog/conntrack.c
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 

--- a/pkg/plugin/dropreason/_cprog/drop_reason.c
+++ b/pkg/plugin/dropreason/_cprog/drop_reason.c
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 

--- a/pkg/plugin/filter/_cprog/retina_filter.c
+++ b/pkg/plugin/filter/_cprog/retina_filter.c
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 

--- a/pkg/plugin/lib/common/libbpf/_src/bpf.c
+++ b/pkg/plugin/lib/common/libbpf/_src/bpf.c
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 
 /*

--- a/pkg/plugin/lib/common/libbpf/_src/bpf_prog_linfo.c
+++ b/pkg/plugin/lib/common/libbpf/_src/bpf_prog_linfo.c
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 /* Copyright (c) 2018 Facebook */
 

--- a/pkg/plugin/lib/common/libbpf/_src/btf.c
+++ b/pkg/plugin/lib/common/libbpf/_src/btf.c
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 /* Copyright (c) 2018 Facebook */
 

--- a/pkg/plugin/lib/common/libbpf/_src/btf_dump.c
+++ b/pkg/plugin/lib/common/libbpf/_src/btf_dump.c
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 
 /*

--- a/pkg/plugin/lib/common/libbpf/_src/btf_iter.c
+++ b/pkg/plugin/lib/common/libbpf/_src/btf_iter.c
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 /* Copyright (c) 2021 Facebook */
 /* Copyright (c) 2024, Oracle and/or its affiliates. */

--- a/pkg/plugin/lib/common/libbpf/_src/btf_relocate.c
+++ b/pkg/plugin/lib/common/libbpf/_src/btf_relocate.c
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // SPDX-License-Identifier: GPL-2.0
 /* Copyright (c) 2024, Oracle and/or its affiliates. */
 

--- a/pkg/plugin/lib/common/libbpf/_src/elf.c
+++ b/pkg/plugin/lib/common/libbpf/_src/elf.c
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 
 #ifndef _GNU_SOURCE

--- a/pkg/plugin/lib/common/libbpf/_src/features.c
+++ b/pkg/plugin/lib/common/libbpf/_src/features.c
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 /* Copyright (c) 2023 Meta Platforms, Inc. and affiliates. */
 #include <linux/kernel.h>

--- a/pkg/plugin/lib/common/libbpf/_src/gen_loader.c
+++ b/pkg/plugin/lib/common/libbpf/_src/gen_loader.c
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 /* Copyright (c) 2021 Facebook */
 #include <stdio.h>

--- a/pkg/plugin/lib/common/libbpf/_src/hashmap.c
+++ b/pkg/plugin/lib/common/libbpf/_src/hashmap.c
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 
 /*

--- a/pkg/plugin/lib/common/libbpf/_src/libbpf.c
+++ b/pkg/plugin/lib/common/libbpf/_src/libbpf.c
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 
 /*

--- a/pkg/plugin/lib/common/libbpf/_src/libbpf_errno.c
+++ b/pkg/plugin/lib/common/libbpf/_src/libbpf_errno.c
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 
 /*

--- a/pkg/plugin/lib/common/libbpf/_src/libbpf_probes.c
+++ b/pkg/plugin/lib/common/libbpf/_src/libbpf_probes.c
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 /* Copyright (c) 2019 Netronome Systems, Inc. */
 

--- a/pkg/plugin/lib/common/libbpf/_src/linker.c
+++ b/pkg/plugin/lib/common/libbpf/_src/linker.c
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 /*
  * BPF static linker

--- a/pkg/plugin/lib/common/libbpf/_src/netlink.c
+++ b/pkg/plugin/lib/common/libbpf/_src/netlink.c
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 /* Copyright (c) 2018 Facebook */
 

--- a/pkg/plugin/lib/common/libbpf/_src/nlattr.c
+++ b/pkg/plugin/lib/common/libbpf/_src/nlattr.c
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 
 /*

--- a/pkg/plugin/lib/common/libbpf/_src/relo_core.c
+++ b/pkg/plugin/lib/common/libbpf/_src/relo_core.c
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 /* Copyright (c) 2019 Facebook */
 

--- a/pkg/plugin/lib/common/libbpf/_src/ringbuf.c
+++ b/pkg/plugin/lib/common/libbpf/_src/ringbuf.c
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 /*
  * Ring buffer operations.

--- a/pkg/plugin/lib/common/libbpf/_src/str_error.c
+++ b/pkg/plugin/lib/common/libbpf/_src/str_error.c
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 #undef _GNU_SOURCE
 #include <string.h>

--- a/pkg/plugin/lib/common/libbpf/_src/strset.c
+++ b/pkg/plugin/lib/common/libbpf/_src/strset.c
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 /* Copyright (c) 2021 Facebook */
 #include <stdint.h>

--- a/pkg/plugin/lib/common/libbpf/_src/usdt.c
+++ b/pkg/plugin/lib/common/libbpf/_src/usdt.c
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 /* Copyright (c) 2022 Meta Platforms, Inc. and affiliates. */
 #include <ctype.h>

--- a/pkg/plugin/lib/common/libbpf/_src/xsk.c
+++ b/pkg/plugin/lib/common/libbpf/_src/xsk.c
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 
 /*

--- a/pkg/plugin/lib/common/libbpf/_src/zip.c
+++ b/pkg/plugin/lib/common/libbpf/_src/zip.c
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
 /*
  * Routines for dealing with .zip archives.

--- a/pkg/plugin/packetforward/_cprog/packetforward.c
+++ b/pkg/plugin/packetforward/_cprog/packetforward.c
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 

--- a/pkg/plugin/packetparser/_cprog/packetparser.c
+++ b/pkg/plugin/packetparser/_cprog/packetparser.c
@@ -1,3 +1,5 @@
+//go:build ignore
+
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 


### PR DESCRIPTION
It will soon become necessary to enable CGO in builds in order to use the MS Go distribution. Disabling CGO was always somewhat of a hack since we didn't need it anyway for eBPF. Now that we do, another solution is necessary. This uses the `//go:build ignore` directive to exclude all C source files from the Go toolchain. This is necessary even within C source files even though these C source files exist within an underscore-prefixed directory. Go's behavior here is likely erroneous, and an issue has been filed for its repair:
https://github.com/golang/go/issues/69639