### PR TITLE
feat: remove bpftool/bpftrace and add nc/jq to retina-shell image

### DIFF
--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -8,8 +8,6 @@ FROM mcr.microsoft.com/azurelinux/base/core@sha256:7ec490b605aac8a44aed0b0695b0e
 #    This will be fixed by https://github.com/microsoft/SymCrypt-OpenSSL/pull/92
 RUN tdnf install -y \
 	bind-utils \
-	bpftool \
-	bpftrace \
 	conntrack \
 	curl \
 	ebtables-legacy \
@@ -18,10 +16,12 @@ RUN tdnf install -y \
 	ipset \
 	iptables \
 	iputils \
+	jq \
 	ldns-utils \
 	net-tools \
 	nftables \
 	nmap \
+	nmap-ncat \
 	openssh \
 	socat \
 	tcpdump \


### PR DESCRIPTION
# Description

* bpftool/bpftrace don't work from inside the container, so remove them from the image.
* nc is useful for testing TCP connectivity, so add it.
* jq is useful for parsing IMDS output, so add it too.

## Related Issue

#910

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

<img width="962" alt="image" src="https://github.com/user-attachments/assets/9864282f-e31b-43b5-8168-a7988c698b86">
<img width="477" alt="image" src="https://github.com/user-attachments/assets/75fcb8e1-18e6-482a-bd85-07143a093cd8">


## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
