### PR TITLE
feat: build retina-shell image in .pipelines/cg-pipeline.yaml

### DIFF
--- a/.pipelines/cg-pipeline.yaml
+++ b/.pipelines/cg-pipeline.yaml
@@ -125,6 +125,47 @@ stages:
               pathtoPublish: "$(Build.ArtifactStagingDirectory)"
             condition: succeeded()
 
+      - job: retinashellimages
+        displayName: Build Retina Shell Images
+        pool:
+          name: "$(BUILD_POOL_NAME_DEFAULT)"
+        strategy:
+          matrix:
+            shell-linux-arm:
+              platform: "linux"
+              arch: "arm64"
+
+            shell-linux-amd64:
+              platform: "linux"
+              arch: "amd64"
+
+        steps:
+          - checkout: self
+            fetchTags: true
+          - script: |
+              set -euo pipefail
+              echo "VERSION=$(make version)"
+              export VERSION=$(make version)
+              mkdir -p ./output/images/$(platform)/$(arch)/$(year)
+              make retina-shell-image \
+                TAG=$(make version) \
+                IMAGE_NAMESPACE=retina \
+                PLATFORM=$(platform)/$(arch) \
+                IMAGE_REGISTRY=ghcr.io/microsoft  \
+                BUILDX_ACTION="-o type=docker,dest=./output/images/$(platform)/$(arch)/retina-shell-$VERSION-$(platform)-$(arch).tar"
+            displayName: "Build Retina Shell Linux Images"
+
+          - bash: |
+              mkdir -p $(Build.ArtifactStagingDirectory)
+              cp -r output/* $(Build.ArtifactStagingDirectory)
+            displayName: "Copy binaries to the binaries artifact folder"
+
+          - task: PublishBuildArtifacts@1
+            inputs:
+              artifactName: output
+              pathtoPublish: "$(Build.ArtifactStagingDirectory)"
+            condition: succeeded()
+
       - job: windowsnative
         displayName: Build Retina Windows Images (native)
         pool:


### PR DESCRIPTION
# Description

Build retina-shell image in .pipelines/cg-pipeline.yaml, which is used to publish to acnpublic.azurecr.io/containernetworking/retina-shell

## Related Issue

#910 

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

N/A

## Additional Notes

Untested, but follows the same pattern as other release jobs.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
