### PR TITLE
fix: Remove mockgen from go generate step

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -35,7 +35,7 @@ COPY ./pkg/plugin /go/src/github.com/microsoft/retina/pkg/plugin
 WORKDIR /go/src/github.com/microsoft/retina
 RUN if [ "$GOOS" = "linux" ] ; then \
       go mod init github.com/microsoft/retina; \
-      go generate -x /go/src/github.com/microsoft/retina/pkg/plugin/...; \
+      go generate -skip "mockgen" -x /go/src/github.com/microsoft/retina/pkg/plugin/...; \
       tar czf /gen.tar.gz ./pkg/plugin; \
       rm go.mod; \
     fi


### PR DESCRIPTION
We don't need to generate mocks when building images, since they're not even in the final build products and it is a waste of compute. Having it in here causes spurious errors since we run `go generate` with a throwaway go.mod. This is to improve Docker caching.

Closes #970 