### PR TITLE
feat: add ethtool to retina-shell image

### DIFF
--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -11,6 +11,7 @@ RUN tdnf install -y \
 	conntrack \
 	curl \
 	ebtables-legacy \
+	ethtool \
 	iperf3 \
 	iproute \
 	ipset \


### PR DESCRIPTION
# Description

Add ethtool to retina-shell image. Useful for querying/modifying network driver settings.

## Related Issue

#910 

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

<img width="1112" alt="image" src="https://github.com/user-attachments/assets/c9c5f640-e32d-4db3-98b0-5a14fe817d4c">

## Additional Notes

N/A

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
