### PR TITLE
feat: build and publish kubectl-retina image

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -211,11 +211,67 @@ jobs:
         env:
           IS_MERGE_GROUP: ${{ github.event_name == 'merge_group' }}
 
+  kubectl-retina-images:
+    name: Build Kubectl Retina Images
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        platform: ["linux"]
+        arch: ["amd64", "arm64"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: go version
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Az CLI login
+        uses: azure/login@v2
+        if: ${{ github.event_name == 'merge_group' }}
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION }}
+
+      - name: Build Images
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "TAG=$(make version)" >> $GITHUB_ENV
+          if [ "$IS_MERGE_GROUP" == "true" ]; then
+            az acr login -n ${{ vars.ACR_NAME }}
+            make kubectl-retina-image \
+              IMAGE_NAMESPACE=${{ github.repository }} \
+              PLATFORM=${{ matrix.platform }}/${{ matrix.arch }} \
+              IMAGE_REGISTRY=${{ vars.ACR_NAME }}  \
+              BUILDX_ACTION=--push
+          else
+            make kubectl-retina-image \
+              IMAGE_NAMESPACE=${{ github.repository }} \
+              PLATFORM=${{ matrix.platform }}/${{ matrix.arch }}
+          fi
+        env:
+          IS_MERGE_GROUP: ${{ github.event_name == 'merge_group' }}
+
   manifests:
     if: ${{ github.event_name == 'merge_group' && success('retina-images') && success('retina-win-images') && success('operator-images') && success('retina-shell-images')}}
     name: Generate Manifests
     runs-on: ubuntu-latest
-    needs: [retina-images, retina-win-images, operator-images, retina-shell-images]
+    needs:
+      [
+        retina-images,
+        retina-win-images,
+        operator-images,
+        retina-shell-images,
+        kubectl-retina-images,
+      ]
 
     strategy:
       matrix:

--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -193,14 +193,64 @@ jobs:
           DIGEST=$(jq -r '.["containerimage.digest"]' image-metadata-retina-shell-$TAG-${{ matrix.platform }}-${{ matrix.arch }}.json)
           cosign sign --yes ${IMAGE_PATH}@${DIGEST}
 
-  manifests:
-    name: Generate Manifests
+  kubectl-retina-images:
+    name: Build Kubectl Retina Images
     runs-on: ubuntu-latest
-    needs: [retina-images, retina-win-images, operator-images, retina-shell-images]
 
     strategy:
       matrix:
-        component: ["retina", "operator", "shell"]
+        platform: ["linux"]
+        arch: ["amd64", "arm64"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: go version
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.7.0
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Log in to registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+
+      - name: Build/Push Images
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "TAG=$(make version)" >> $GITHUB_ENV
+          make kubectl-retina-image \
+            IMAGE_NAMESPACE=${{ github.repository }} \
+            PLATFORM=${{ matrix.platform }}/${{ matrix.arch }} \
+            BUILDX_ACTION=--push
+
+      - name: Sign container image
+        run: |
+          IMAGE_PATH="ghcr.io/${{ github.repository }}/kubectl-retina:$TAG-${{ matrix.platform }}-${{ matrix.arch }}"
+          DIGEST=$(jq -r '.["containerimage.digest"]' image-metadata-kubectl-retina-$TAG-${{ matrix.platform }}-${{ matrix.arch }}.json)
+          cosign sign --yes ${IMAGE_PATH}@${DIGEST}
+
+  manifests:
+    name: Generate Manifests
+    runs-on: ubuntu-latest
+    needs:
+      [
+        retina-images,
+        retina-win-images,
+        operator-images,
+        retina-shell-images,
+        kubectl-retina-images,
+      ]
+
+    strategy:
+      matrix:
+        component: ["retina", "operator", "shell", "kubectl-retina"]
 
     steps:
       - name: Checkout code
@@ -231,6 +281,8 @@ jobs:
             images=("retina-operator")
           elif [[ ${{ matrix.component }} == "shell" ]]; then
             images=("retina-shell")
+          elif [[ ${{ matrix.component }} == "kubectl-retina" ]]; then
+            images=("kubectl-retina")
           fi
           for image in "${images[@]}"; do
             IMAGE_PATH="ghcr.io/${{ github.repository }}/$image:$TAG"

--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,7 @@ RETINA_IMAGE 					= $(IMAGE_NAMESPACE)/retina-agent
 RETINA_INIT_IMAGE				= $(IMAGE_NAMESPACE)/retina-init
 RETINA_OPERATOR_IMAGE			= $(IMAGE_NAMESPACE)/retina-operator
 RETINA_SHELL_IMAGE				= $(IMAGE_NAMESPACE)/retina-shell
+KUBECTL_RETINA_IMAGE			= $(IMAGE_NAMESPACE)/kubectl-retina
 RETINA_INTEGRATION_TEST_IMAGE	= $(IMAGE_NAMESPACE)/retina-integration-test
 RETINA_PROTO_IMAGE				= $(IMAGE_NAMESPACE)/retina-proto-gen
 RETINA_GO_GEN_IMAGE				= $(IMAGE_NAMESPACE)/retina-go-gen
@@ -320,6 +321,18 @@ retina-shell-image:
 			TAG=$(RETINA_PLATFORM_TAG) \
 			CONTEXT_DIR=$(REPO_ROOT)
 
+kubectl-retina-image:
+	echo "Building for $(PLATFORM)"
+	set -e ; \
+	$(MAKE) container-$(CONTAINER_BUILDER) \
+			PLATFORM=$(PLATFORM) \
+			DOCKERFILE=cli/Dockerfile \
+			REGISTRY=$(IMAGE_REGISTRY) \
+			IMAGE=$(KUBECTL_RETINA_IMAGE) \
+			VERSION=$(TAG) \
+			TAG=$(RETINA_PLATFORM_TAG) \
+			CONTEXT_DIR=$(REPO_ROOT)
+
 kapinger-image: 
 	docker buildx build --builder retina --platform windows/amd64 --target windows-amd64 -t $(IMAGE_REGISTRY)/$(KAPINGER_IMAGE):$(TAG)-windows-amd64  ./hack/tools/kapinger/ --push
 	docker buildx build --builder retina --platform linux/amd64 --target linux-amd64 -t $(IMAGE_REGISTRY)/$(KAPINGER_IMAGE):$(TAG)-linux-amd64  ./hack/tools/kapinger/ --push
@@ -364,6 +377,10 @@ manifest-shell-image:
 	$(eval FULL_IMAGE_NAME=$(IMAGE_REGISTRY)/$(RETINA_SHELL_IMAGE):$(TAG))
 	docker buildx imagetools create -t $(FULL_IMAGE_NAME) $(foreach platform,linux/amd64 linux/arm64, $(FULL_IMAGE_NAME)-$(subst /,-,$(platform)))
 
+manifest-kubectl-retina-image:
+	$(eval FULL_IMAGE_NAME=$(IMAGE_REGISTRY)/$(KUBECTL_RETINA_IMAGE):$(TAG))
+	docker buildx imagetools create -t $(FULL_IMAGE_NAME) $(foreach platform,linux/amd64 linux/arm64, $(FULL_IMAGE_NAME)-$(subst /,-,$(platform)))
+
 manifest:
 	echo "Building for $(COMPONENT)"
 	if [ "$(COMPONENT)" = "retina" ]; then \
@@ -372,6 +389,8 @@ manifest:
 		$(MAKE) manifest-operator-image; \
 	elif [ "$(COMPONENT)" = "shell" ]; then \
 		$(MAKE) manifest-shell-image; \
+	elif [ "$(COMPONENT)" = "kubectl-retina" ]; then \
+		$(MAKE) manifest-kubectl-retina-image; \
 	fi
 
 ##@ Tests

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,0 +1,30 @@
+# mcr.microsoft.com/oss/go/microsoft/golang:1.23.1-cbl-mariner2.0
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:dcd95cadab21a855894c599c9e26bfb2179aa08e7d7f99c0e8546167712ba6ef AS builder
+
+
+ARG VERSION
+ARG APP_INSIGHTS_ID
+
+WORKDIR /workspace
+COPY . .
+
+# Default linux/architecture.
+ARG GOOS=linux
+ENV GOOS=${GOOS}
+
+ARG GOARCH=amd64
+ENV GOARCH=${GOARCH}
+
+RUN --mount=type=cache,target="/root/.cache/go-build" \
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+    -ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version="$VERSION" \
+    -X "github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID"="$APP_INSIGHTS_ID"" \
+    -a -o kubectl-retina cli/main.go
+
+##################### controller #######################
+# mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/cbl-mariner/distroless/minimal@sha256:63a0a70ceaa1320bc6eb98b81106667d43e46b674731ea8d28e4de1b87e0747f
+WORKDIR /
+COPY --from=builder /workspace/kubectl-retina .
+USER 65532:65532
+

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -21,10 +21,8 @@ RUN --mount=type=cache,target="/root/.cache/go-build" \
     -X "github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID"="$APP_INSIGHTS_ID"" \
     -a -o kubectl-retina cli/main.go
 
-##################### controller #######################
 # mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/cbl-mariner/distroless/minimal@sha256:63a0a70ceaa1320bc6eb98b81106667d43e46b674731ea8d28e4de1b87e0747f
 WORKDIR /
 COPY --from=builder /workspace/kubectl-retina .
-USER 65532:65532
 

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,5 +1,5 @@
 # mcr.microsoft.com/oss/go/microsoft/golang:1.23.1-cbl-mariner2.0
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:dcd95cadab21a855894c599c9e26bfb2179aa08e7d7f99c0e8546167712ba6ef AS builder
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:8ac5373de7fde69d08c52e4a1ba40e976a543b3e93196f7fe07c3f91853865f3 AS builder
 
 
 ARG VERSION
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target="/root/.cache/go-build" \
     -a -o kubectl-retina cli/main.go
 
 # mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/cbl-mariner/distroless/minimal@sha256:63a0a70ceaa1320bc6eb98b81106667d43e46b674731ea8d28e4de1b87e0747f
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/cbl-mariner/distroless/minimal@sha256:db87903c5d4d9d6760e86a274914efd6a3bb5914c0b5a6c6b35350ec297fea4f
 WORKDIR /
 COPY --from=builder /workspace/kubectl-retina .
 

--- a/cli/cmd/capture/create.go
+++ b/cli/cmd/capture/create.go
@@ -9,12 +9,6 @@ import (
 	"strings"
 	"time"
 
-	retinacmd "github.com/microsoft/retina/cli/cmd"
-	retinav1alpha1 "github.com/microsoft/retina/crd/api/v1alpha1"
-	pkgcapture "github.com/microsoft/retina/pkg/capture"
-	captureConstants "github.com/microsoft/retina/pkg/capture/constants"
-	captureUtils "github.com/microsoft/retina/pkg/capture/utils"
-	"github.com/microsoft/retina/pkg/config"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -27,6 +21,14 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
+
+	retinacmd "github.com/microsoft/retina/cli/cmd"
+	retinav1alpha1 "github.com/microsoft/retina/crd/api/v1alpha1"
+	"github.com/microsoft/retina/internal/buildinfo"
+	pkgcapture "github.com/microsoft/retina/pkg/capture"
+	captureConstants "github.com/microsoft/retina/pkg/capture/constants"
+	captureUtils "github.com/microsoft/retina/pkg/capture/utils"
+	"github.com/microsoft/retina/pkg/config"
 )
 
 var (
@@ -361,7 +363,7 @@ func createCaptureF(kubeClient kubernetes.Interface) (*retinav1alpha1.Capture, e
 
 func getCLICaptureConfig() config.CaptureConfig {
 	return config.CaptureConfig{
-		CaptureImageVersion:       retinacmd.Version,
+		CaptureImageVersion:       buildinfo.Version,
 		CaptureDebug:              debug,
 		CaptureImageVersionSource: captureUtils.VersionSourceCLIVersion,
 		CaptureJobNumLimit:        jobNumLimit,

--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -7,17 +7,15 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-)
 
-// This variable is used by the "version" command and is set during build.
-// Defaults to a safe value if not set.
-var Version = "v0.0.5"
+	"github.com/microsoft/retina/internal/buildinfo"
+)
 
 var version = &cobra.Command{
 	Use:   "version",
 	Short: "Show version",
 	Run: func(*cobra.Command, []string) {
-		fmt.Println(Version)
+		fmt.Println(buildinfo.Version)
 	},
 }
 


### PR DESCRIPTION
# Description

This changes allow the CI and release pipeline to build and publish kubectl-retina images

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

- build image:

![image](https://github.com/user-attachments/assets/20142d9d-25b7-488b-818c-a085bb7de903)

- image build succeeded
- 
![image](https://github.com/user-attachments/assets/96fedc8e-ab9b-47ca-b218-62c967c2de66)

- create manifest

![image](https://github.com/user-attachments/assets/0c03b4e1-031d-4506-b563-ff4f45f0f3eb)


## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
