### PR TITLE
feat: update the digest for golang and mariner-distroless

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -3,13 +3,13 @@ ARG OS_VERSION
 # pinned base images
 
 # mcr.microsoft.com/oss/go/microsoft/golang:1.23.1-cbl-mariner2.0
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:dcd95cadab21a855894c599c9e26bfb2179aa08e7d7f99c0e8546167712ba6ef AS golang
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:8ac5373de7fde69d08c52e4a1ba40e976a543b3e93196f7fe07c3f91853865f3 AS golang
 
 # mcr.microsoft.com/cbl-mariner/base/core:2.0
 FROM --platform=$TARGETPLATFORM mcr.microsoft.com/cbl-mariner/base/core@sha256:77651116f2e83cf50fddd8a0316945499f8ce6521ff8e94e67539180d1e5975a AS mariner-core
 
 # mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
-FROM --platform=$TARGETPLATFORM mcr.microsoft.com/cbl-mariner/distroless/minimal@sha256:63a0a70ceaa1320bc6eb98b81106667d43e46b674731ea8d28e4de1b87e0747f AS mariner-distroless
+FROM --platform=$TARGETPLATFORM mcr.microsoft.com/cbl-mariner/distroless/minimal@sha256:db87903c5d4d9d6760e86a274914efd6a3bb5914c0b5a6c6b35350ec297fea4f AS mariner-distroless
 
 # mcr.microsoft.com/windows/servercore:ltsc2019 
 FROM --platform=$TARGETPLATFORM mcr.microsoft.com/windows/servercore@sha256:6fdf140282a2f809dae9b13fe441635867f0a27c33a438771673b8da8f3348a4 AS ltsc2019

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,5 +1,5 @@
 # mcr.microsoft.com/oss/go/microsoft/golang:1.23.1-cbl-mariner2.0
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:dcd95cadab21a855894c599c9e26bfb2179aa08e7d7f99c0e8546167712ba6ef AS builder
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:8ac5373de7fde69d08c52e4a1ba40e976a543b3e93196f7fe07c3f91853865f3 AS builder
 
 
 ARG VERSION

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -24,7 +24,7 @@ RUN --mount=type=cache,target="/root/.cache/go-build" \
 
 ##################### controller #######################
 # mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/cbl-mariner/distroless/minimal@sha256:63a0a70ceaa1320bc6eb98b81106667d43e46b674731ea8d28e4de1b87e0747f
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/cbl-mariner/distroless/minimal@sha256:db87903c5d4d9d6760e86a274914efd6a3bb5914c0b5a6c6b35350ec297fea4f
 WORKDIR /
 COPY --from=builder /workspace/retina-operator .
 USER 65532:65532


### PR DESCRIPTION
# Description

This pull request includes updates to the base images used in the `controller/Dockerfile`. The changes involve updating the SHA256 digests for several images to ensure the use of the latest versions.

Updates to base images:

* Updated the SHA256 digest for the `golang` image to `8ac5373de7fde69d08c52e4a1ba40e976a543b3e93196f7fe07c3f91853865f3`. (`[controller/DockerfileL6-R12](diffhunk://#diff-df234eb86d676bd9233f232e9dc9af4895969477a6a9ff9161e32621f6ce76d1L6-R12)`)
* Updated the SHA256 digest for the `mariner-distroless` image to `db87903c5d4d9d6760e86a274914efd6a3bb5914c0b5a6c6b35350ec297fea4f`. (`[controller/DockerfileL6-R12](diffhunk://#diff-df234eb86d676bd9233f232e9dc9af4895969477a6a9ff9161e32621f6ce76d1L6-R12)`)

## Related Issue

Address Issue #989

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
