### PR TITLE
fix(ethtool): ignore lxc and azv interfaces

### DIFF
--- a/pkg/plugin/linuxutil/ethtool_stats_linux.go
+++ b/pkg/plugin/linuxutil/ethtool_stats_linux.go
@@ -64,8 +64,11 @@ func (er *EthtoolReader) readInterfaceStats() error {
 	}
 
 	for _, i := range ifaces {
-		// exclude loopback interface and bridge network interface
-		if strings.Contains(i.Name, "lo") || strings.Contains(i.Name, "cbr0") {
+		// exclude lo (loopback interface), cbr0 (bridge network interface), lxc (Linux containers interface), and azv (virtual interface)
+		if strings.Contains(i.Name, "lo") ||
+			strings.Contains(i.Name, "cbr0") ||
+			strings.Contains(i.Name, "lxc") ||
+			strings.Contains(i.Name, "azv") {
 			continue
 		}
 


### PR DESCRIPTION
Reduce metric cardinality of `networkobservability_interface_stats` by ignoring lxc and azv virtual interfaces.