### PR TITLE
fix(ethtool): enable filtering out non-err/drop stats

### DIFF
--- a/pkg/plugin/linuxutil/linuxutil_linux.go
+++ b/pkg/plugin/linuxutil/linuxutil_linux.go
@@ -87,7 +87,7 @@ func (lu *linuxUtil) run(ctx context.Context) error {
 			}()
 
 			ethtoolOpts := &EthtoolOpts{
-				errOrDropKeysOnly: false,
+				errOrDropKeysOnly: true,
 				addZeroVal:        false,
 				limit:             defaultLimit,
 			}


### PR DESCRIPTION
Reduce cardinality of `interface_stats` by only keeping stats with "err" or "drop" in the name.