### PR TITLE
fix(netstat): curate stats for tcp connections

### DIFF
--- a/pkg/plugin/linuxutil/linuxutil_linux.go
+++ b/pkg/plugin/linuxutil/linuxutil_linux.go
@@ -67,7 +67,7 @@ func (lu *linuxUtil) run(ctx context.Context) error {
 			return nil
 		case <-ticker.C:
 			opts := &NetstatOpts{
-				CuratedKeys:      false,
+				CuratedKeys:      true,
 				AddZeroVal:       false,
 				ListenSock:       false,
 				PrevTCPSockStats: lu.prevTCPSockStats,

--- a/pkg/plugin/linuxutil/types_linux.go
+++ b/pkg/plugin/linuxutil/types_linux.go
@@ -35,6 +35,9 @@ var netstatCuratedKeys = map[string]struct{}{
 	"DataCsumErr":        {},
 	"AddAddrDrop":        {},
 	"RmAddrDrop":         {},
+	"TCPTimeouts": 	      {},
+	"TCPLossProbes":      {},
+	"TCPLostRetransmit":  {},
 }
 
 type ConnectionStats struct {


### PR DESCRIPTION
Reduce cardinality of `tcp_connection_stats` by only keeping curated stats. Updates curated stats to include:
- timeouts
- loss probes
- loss retransmit

There were already several curated stats for drops and errors.