### PR TITLE
fix: add kubectl-retina manifest

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -275,7 +275,7 @@ jobs:
 
     strategy:
       matrix:
-        components: ["retina", "operator", "shell"]
+        components: ["retina", "operator", "shell", "kubectl-retina"]
 
     steps:
       - name: Checkout code

--- a/.pipelines/cg-pipeline.yaml
+++ b/.pipelines/cg-pipeline.yaml
@@ -166,6 +166,47 @@ stages:
               pathtoPublish: "$(Build.ArtifactStagingDirectory)"
             condition: succeeded()
 
+      - job: kubectlretinaimages
+        displayName: Build Kubectl Retina Images
+        pool:
+          name: "$(BUILD_POOL_NAME_DEFAULT)"
+        strategy:
+          matrix:
+            kubectl-linux-arm:
+              platform: "linux"
+              arch: "arm64"
+
+            kubectl-linux-amd64:
+              platform: "linux"
+              arch: "amd64"
+
+        steps:
+          - checkout: self
+            fetchTags: true
+          - script: |
+              set -euo pipefail
+              echo "VERSION=$(make version)"
+              export VERSION=$(make version)
+              mkdir -p ./output/images/$(platform)/$(arch)/$(year)
+              make kubectl-retina-image \
+                TAG=$(make version) \
+                IMAGE_NAMESPACE=retina \
+                PLATFORM=$(platform)/$(arch) \
+                IMAGE_REGISTRY=ghcr.io/microsoft  \
+                BUILDX_ACTION="-o type=docker,dest=./output/images/$(platform)/$(arch)/kubectl-retina-$VERSION-$(platform)-$(arch).tar"
+            displayName: "Build Kubectl Retina Linux Images"
+
+          - bash: |
+              mkdir -p $(Build.ArtifactStagingDirectory)
+              cp -r output/* $(Build.ArtifactStagingDirectory)
+            displayName: "Copy binaries to the binaries artifact folder"
+
+          - task: PublishBuildArtifacts@1
+            inputs:
+              artifactName: output
+              pathtoPublish: "$(Build.ArtifactStagingDirectory)"
+            condition: succeeded()
+
       - job: windowsnative
         displayName: Build Retina Windows Images (native)
         pool:


### PR DESCRIPTION
# Description

Following https://github.com/microsoft/retina/pull/972, I add kubectl-retina image build into cg-pipleline, and expect this image can be published into MCR.

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Run the script locally, and the image build succeeded.

![image](https://github.com/user-attachments/assets/c221d65d-2112-4d3b-a8e8-20993af6f315)

![image](https://github.com/user-attachments/assets/e8117ce4-ab0b-4663-b2bb-26f967b7d351)


## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
