### PR TITLE
fix: add retraction for v0.10.0 via v0.10.1 in go mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 
 retract (
 	v0.10.0 // Published accidentally.
-    v0.10.1 // Contains retractions only.
+	v0.10.1 // Contains retractions only.
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,10 @@ require (
 	sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader v0.0.20
 )
 
-retract v0.10.0 // published accidentally
+retract (
+	v0.10.0 // Published accidentally.
+    v0.10.1 // Contains retractions only.
+)
 
 require (
 	cel.dev/expr v0.15.0 // indirect


### PR DESCRIPTION
# Description

The version is doing the retraction should be higher than the version we want to retract. We will tag the version v0.10.1 with just this change, and then it will retract itself as well.
## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
