### PR TITLE
Fix `kubectl-retina version`

### DIFF
--- a/cli/cmd/version.go
+++ b/cli/cmd/version.go
@@ -5,17 +5,47 @@ package cmd
 
 import (
 	"fmt"
-
-	"github.com/spf13/cobra"
+	"runtime/debug"
 
 	"github.com/microsoft/retina/internal/buildinfo"
+	"github.com/spf13/cobra"
 )
 
 var version = &cobra.Command{
 	Use:   "version",
 	Short: "Show version",
-	Run: func(*cobra.Command, []string) {
-		fmt.Println(buildinfo.Version)
+	Run: func(cmd *cobra.Command, args []string) {
+		// Version is fetched from buildinfo package.
+		if buildinfo.Version != "" {
+			fmt.Println(buildinfo.Version)
+			return
+		}
+
+		// Fetch version from Build Settings.
+		const baseLine = "buildinfo.Version is not set successfully"
+
+		info, ok := debug.ReadBuildInfo()
+		if !ok {
+			fmt.Printf("%s, and BuildInfo is not available\n", baseLine)
+			return
+		}
+
+		var revision string
+		for _, setting := range info.Settings {
+			if setting.Key == "vcs.revision" {
+				revision = setting.Value
+				break
+			}
+		}
+
+		// If revision is available, show it.
+		if revision != "" {
+			fmt.Printf("%s, showing vcs.revision: %s\n", baseLine, revision)
+			return
+		}
+
+		// Revision is not available, raise error.
+		fmt.Printf("%s, and vcs.revision is not available\n", baseLine)
 	},
 }
 


### PR DESCRIPTION
# Description

Since `v0.0.17`, `kubectl-retina version` will only show a empty line, demonstrated in #1013 

## Related Issue

#1013 

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

None

## Additional Notes

None

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
