### PR TITLE
fix(log): add custom error handler for Kubernetes API errors

### DIFF
--- a/pkg/controllers/operator/cilium-crds/endpoint/endpoint_controller.go
+++ b/pkg/controllers/operator/cilium-crds/endpoint/endpoint_controller.go
@@ -533,7 +533,7 @@ func (r *endpointReconciler) handlePodUpsert(ctx context.Context, newPEP *PodEnd
 		// May end up getting another endpoint ID below if we try to create the CEP below.
 		// No downside to this.
 
-		if !k8serrors.IsNotFound(err) && err != nil {
+		if !k8serrors.IsNotFound(err) {
 			r.l.WithError(err).WithFields(logrus.Fields{
 				"podKey": newPEP.key.String(),
 				"pep":    newPEP,

--- a/pkg/k8s/error_handler.go
+++ b/pkg/k8s/error_handler.go
@@ -1,0 +1,26 @@
+package k8s
+
+import (
+	"strings"
+
+	"github.com/cilium/cilium/pkg/k8s"
+)
+
+// RetinaK8sErrorHandler is a wrapper around the k8s.K8sErrorHandler function
+// that allows Retina to handle k8s errors that are more related to the usecase of this package.
+func RetinaK8sErrorHandler(e error) {
+	errStr := e.Error()
+	switch {
+	case strings.Contains(errStr, "Failed to watch *v1.Node"):
+		logger.WithField("actualError", errStr).Error("Potentially Network Error coming from K8s API Server failing to watch Nodes")
+	case strings.Contains(errStr, "Failed to watch *v2.CiliumEndpoint"):
+		logger.WithField("actualError", errStr).Error("Potentially Network Error coming from K8s API Server failing to watch CiliumEndpoints")
+	case strings.Contains(errStr, "Failed to watch *v1.Service"):
+		logger.WithField("actualError", errStr).Error("Potentially Network Error coming from K8s API Server failing to watch Services")
+	case strings.Contains(errStr, "Failed to watch *v2.CiliumNode"):
+		logger.WithField("actualError", errStr).Error("Potentially Network Error coming from K8s API Server failing to watch CiliumNodes")
+
+	default:
+		k8s.K8sErrorHandler(e)
+	}
+}

--- a/pkg/k8s/watcher_linux.go
+++ b/pkg/k8s/watcher_linux.go
@@ -5,6 +5,8 @@ import (
 	"sync"
 	"time"
 
+	"k8s.io/apimachinery/pkg/util/runtime"
+
 	agentK8s "github.com/cilium/cilium/daemon/k8s"
 	"github.com/cilium/cilium/pkg/hive/cell"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -16,6 +18,13 @@ import (
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/option"
 )
+
+func init() {
+	// Register custom error handler for the watcher
+	runtime.ErrorHandlers = []func(error){
+		RetinaK8sErrorHandler,
+	}
+}
 
 const (
 	K8sAPIGroupCiliumEndpointV2 = "cilium/v2::CiliumEndpoint"


### PR DESCRIPTION
# Description

This pull request includes changes to improve error handling and simplify conditional checks in the `cilium-crds` package. The most important changes include the addition of a custom Kubernetes error handler, the registration of this handler, and the simplification of a conditional check in the `endpoint_controller.go` file.

Enhancements to error handling:

* [`pkg/k8s/error_handler.go`](diffhunk://#diff-7b02578e07043bbeaf557490d89ddfc676cef85c95f61560c5d83b173cfcb2bcR1-R26): Introduced `RetinaK8sErrorHandler`, a wrapper around the existing Kubernetes error handler to provide more specific error messages for different Kubernetes watch failures.
* [`pkg/k8s/watcher_linux.go`](diffhunk://#diff-1769e0320129167654a2a0d5f382b63fb459aadf221d3ba04df1f1a56188f6d2R22-R28): Registered the custom error handler `RetinaK8sErrorHandler` to handle runtime errors during the watcher initialization.

Code simplification:

* [`pkg/controllers/operator/cilium-crds/endpoint/endpoint_controller.go`](diffhunk://#diff-0a6e7a396be9617c3c31afb9cf9f740b75e645a533833d049726db8321d13df9L536-R536): Simplified the conditional check in the `handlePodUpsert` method by removing the redundant `err != nil` check.

Dependency updates:

* [`pkg/k8s/watcher_linux.go`](diffhunk://#diff-1769e0320129167654a2a0d5f382b63fb459aadf221d3ba04df1f1a56188f6d2R8-R9): Added the `k8s.io/apimachinery/pkg/util/runtime` package to the imports to support the custom error handler registration

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
