### PR TITLE
fix: update e2e test command to target specific test file

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -42,4 +42,5 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          go test -v ./test/e2e/. -timeout 60m -tags=e2e -count=1  -args -image-tag=$(make version) -image-registry=${{vars.ACR_NAME}} -image-namespace=${{github.repository}}
+          go test -v ./test/e2e/retina_e2e_test.go -timeout 60m -tags=e2e -count=1  -args -image-tag=$(make version) -image-registry=${{vars.ACR_NAME}} -image-namespace=${{github.repository}}
+


### PR DESCRIPTION
# Description

This pull request includes a small change to the `.github/workflows/e2e.yaml` file. The change modifies the `go test` command to run a specific test file instead of the entire test suite.

* [`.github/workflows/e2e.yaml`](diffhunk://#diff-a2de7550554c0198ac7f959c78a19ee0996921c98034411de47a7dd49b0c209bL45-R46): Changed the `go test` command to run the `retina_e2e_test.go` file instead of all tests in the `./test/e2e/` directory.

## Checklist

- [X] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [X] I have correctly attributed the author(s) of the code.
- [X] I have tested the changes locally.
- [X] I have followed the project's style guidelines.
- [X] I have updated the documentation, if necessary.
- [X] I have added tests, if applicable.

## Additional Notes

Merging this PR will unblock addition of new tests through #772 

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
