### PR TITLE
feat(dynamic-exporter): Add dynamic flow exporter support for hubble

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,11 @@ CERT_FILES := tls.crt:tls-client-cert-file \
               tls.key:tls-client-key-file \
               ca.crt:tls-ca-cert-files
 
+##################
+# Dynamic Export #
+##################
+ENABLE_DYNAMIC_EXPORT ?= false
+
 # TAG is OS and platform agonstic, which can be used for binary version and image manifest tag,
 # while RETINA_PLATFORM_TAG is platform specific, which can be used for image built for specific platforms.
 RETINA_PLATFORM_TAG        ?= $(TAG)-$(subst /,-,$(PLATFORM))
@@ -518,6 +523,7 @@ helm-install-hubble:
 		--set agent.init.repository=$(IMAGE_REGISTRY)/$(RETINA_INIT_IMAGE) \
 		--set agent.init.tag=$(HELM_IMAGE_TAG) \
 		--set logLevel=info \
+		--set hubble.export.dynamic.enabled=$(ENABLE_DYNAMIC_EXPORT) \
 		--set hubble.tls.enabled=$(ENABLE_TLS) \
 		--set hubble.relay.tls.server.enabled=$(ENABLE_TLS) \
 		--set hubble.tls.auto.enabled=$(ENABLE_TLS) \
@@ -578,6 +584,7 @@ quick-deploy:
 quick-deploy-hubble:
 	$(MAKE) helm-uninstall || true
 	$(MAKE) helm-install-without-tls HELM_IMAGE_TAG=$(TAG)-linux-amd64
+# $(MAKE) helm-install-without-tls HELM_IMAGE_TAG=$(TAG)-linux-amd64 ENABLE_DYNAMIC_EXPORT=true
 
 
 .PHONY: simplify-dashboards

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -116,8 +116,8 @@ ENTRYPOINT ["./retina/initretina"]
 
 
 # agent final image
-# mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
-# mcr.microsoft.com/cbl-mariner/distroless/minimal@sha256:63a0a70ceaa1320bc6eb98b81106667d43e46b674731ea8d28e4de1b87e0747f
+# For debug: mcr.microsoft.com/cbl-mariner/distroless/debug:2.0
+# k exec -it ds/retina-agent -- busybox tail -f /var/run/retina/hubble/events.log
 FROM mariner-distroless AS agent
 COPY --from=tools /lib/ /lib
 COPY --from=tools /usr/lib/ /usr/lib

--- a/deploy/hubble/manifests/controller/helm/retina/templates/agent/daemonset.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/agent/daemonset.yaml
@@ -112,6 +112,11 @@ spec:
               mountPath: /var/lib/cilium/tls/hubble
               readOnly: true
           {{- end }}
+          {{- if .Values.hubble.export.dynamic.enabled }}
+            - name: hubble-flowlog-config
+              mountPath: /flowlog-config
+              readOnly: true
+          {{- end }}
         {{- end }}
       terminationGracePeriodSeconds: 90 # Allow for retina to cleanup plugin resources.
       volumes:
@@ -141,6 +146,12 @@ spec:
                     path: server.key
                   - key: ca.crt
                     path: client-ca.crt
+      {{- end }}
+      {{- if .Values.hubble.export.dynamic.enabled }}
+      - name: hubble-flowlog-config
+        configMap:
+          name: {{ .Values.hubble.export.dynamic.config.configMapName }}
+          optional: true
       {{- end }}
 {{- end }}
 ---

--- a/deploy/hubble/manifests/controller/helm/retina/templates/agent/flowlog-configmap.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/agent/flowlog-configmap.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.hubble.export.dynamic.enabled .Values.hubble.export.dynamic.config.createConfigMap }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.hubble.export.dynamic.config.configMapName }}
+  namespace: {{ .Release.Namespace }}
+data:
+  flowlogs.yaml: |
+    flowLogs:
+{{ .Values.hubble.export.dynamic.config.content | toYaml | indent 4 }}
+{{- end }}

--- a/deploy/hubble/manifests/controller/helm/retina/values.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/values.yaml
@@ -821,10 +821,10 @@ hubble:
     # --- Dynamic exporters configuration.
     # Dynamic exporters may be reconfigured without a need of agent restarts.
     dynamic:
-      enabled: false
+      enabled: true
       config:
         # ---- Name of configmap with configuration that may be altered to reconfigure exporters within a running agents.
-        configMapName: cilium-flowlog-config
+        configMapName: retina-flowlog-config
         # ---- True if helm installer should create config map.
         # Switch to false if you want to self maintain the file content.
         createConfigMap: true
@@ -834,7 +834,7 @@ hubble:
             fieldMask: []
             includeFilters: []
             excludeFilters: []
-            filePath: "/var/run/cilium/hubble/events.log"
+            filePath: "/var/run/retina/hubble/events.log"
         #- name: "test002"
         #  filePath: "/var/log/network/flow-log/pa/test002.log"
         #  fieldMask: ["source.namespace", "source.pod_name", "destination.namespace", "destination.pod_name", "verdict"]


### PR DESCRIPTION
# Description

Adding support for dynamic flow exporter in Hubble.
Read more about dynamic flow exporter [here](https://github.com/cilium/cilium/blob/42632319ec752ba246881ed3dd14bc1d0516e4de/Documentation/observability/hubble/configuration/export.rst).

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

```bash
$ kno aks-nodepool1-10725549-vmss000000
root@aks-nodepool1-10725549-vmss000000:/# tail -f /var/run/retina/hubble/events.log
...
{"flow":{"time":"2024-11-19T22:35:33.343220551Z","verdict":"FORWARDED","IP":{"source":"192.168.2.38","destination":"10.224.0.4","ipVersion":"IPv4"},"l4":{"TCP":{"source_port":46518,"destination_port":10250,"flags":{"ACK":true}}},"source":{"ID":31432,"identity":31432,"namespace":"kube-system","pod_name":"konnectivity-agent-7d494c7d79-7pm4z"},"destination":{"ID":1,"identity":1,"labels":["reserved:host"]},"Type":"L3_L4","event_type":{"type":4,"sub_type":3},"traffic_direction":"EGRESS","trace_observation_point":"TO_STACK","is_reply":false,"Summary":"TCP Flags: ACK:true","extensions":{"@type":"type.googleapis.com/utils.RetinaMetadata","bytes":66}},"time":"2024-11-19T22:35:33.343220551Z"}
{"flow":{"time":"2024-11-19T22:35:33.343337550Z","verdict":"FORWARDED","IP":{"source":"192.168.2.38","destination":"10.224.0.4","ipVersion":"IPv4"},"l4":{"TCP":{"source_port":46518,"destination_port":10250,"flags":{"ACK":true}}},"source":{"ID":31432,"identity":31432,"namespace":"kube-system","pod_name":"konnectivity-agent-7d494c7d79-7pm4z"},"destination":{"ID":1,"identity":1,"labels":["reserved:host"]},"Type":"L3_L4","event_type":{"type":4,"sub_type":3},"traffic_direction":"EGRESS","trace_observation_point":"TO_STACK","is_reply":false,"Summary":"TCP Flags: ACK:true","extensions":{"@type":"type.googleapis.com/utils.RetinaMetadata","bytes":66}},"time":"2024-11-19T22:35:33.343337550Z"}
root@aks-nodepool1-10725549-vmss000000:/# ls -la /var/run/retina/hubble
total 51480
drwxr-xr-x 2 root root      160 Nov 19 22:35 .
drwxr-xr-x 3 root root       60 Nov 19 01:53 ..
-rw-r--r-- 1 root root 10485267 Nov 19 16:32 events-2024-11-19T16-32-15.656.log
-rw-r--r-- 1 root root 10485050 Nov 19 16:49 events-2024-11-19T16-49-23.125.log
-rw-r--r-- 1 root root 10485079 Nov 19 17:06 events-2024-11-19T17-06-33.124.log
-rw-r--r-- 1 root root 10485306 Nov 19 17:23 events-2024-11-19T17-23-47.045.log
-rw-r--r-- 1 root root 10485271 Nov 19 22:35 events-2024-11-19T22-35-48.976.log
-rw-r--r-- 1 root root   284620 Nov 19 22:36 events.log
root@aks-nodepool1-10725549-vmss000000:/#
```

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
