### PR TITLE
chore: use mariner core base image for kubectl-retina

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -21,8 +21,8 @@ RUN --mount=type=cache,target="/root/.cache/go-build" \
     -X "github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID"="$APP_INSIGHTS_ID"" \
     -a -o kubectl-retina cli/main.go
 
-# mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/cbl-mariner/distroless/minimal@sha256:db87903c5d4d9d6760e86a274914efd6a3bb5914c0b5a6c6b35350ec297fea4f
+# mcr.microsoft.com/cbl-mariner/base/core:2.0
+FROM --platform=$TARGETPLATFORM mcr.microsoft.com/cbl-mariner/base/core@sha256:77651116f2e83cf50fddd8a0316945499f8ce6521ff8e94e67539180d1e5975a
 WORKDIR /
 COPY --from=builder /workspace/kubectl-retina .
 


### PR DESCRIPTION
# Description
mariner distroless minimal provides no support to copy the kubectl-retina image from the container. We need more powerful base image to provide command like 
```
          command:
          - sh
          - -c
          - cp -L /kubectl-retina /opt/tools/bin
```
## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
