### PR TITLE
chore: revert: use mariner core base image for kubectl-retina

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -21,8 +21,8 @@ RUN --mount=type=cache,target="/root/.cache/go-build" \
     -X "github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID"="$APP_INSIGHTS_ID"" \
     -a -o kubectl-retina cli/main.go
 
-# mcr.microsoft.com/cbl-mariner/base/core:2.0
-FROM --platform=$TARGETPLATFORM mcr.microsoft.com/cbl-mariner/base/core@sha256:77651116f2e83cf50fddd8a0316945499f8ce6521ff8e94e67539180d1e5975a
+# mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/cbl-mariner/distroless/minimal@sha256:db87903c5d4d9d6760e86a274914efd6a3bb5914c0b5a6c6b35350ec297fea4f
 WORKDIR /
 COPY --from=builder /workspace/kubectl-retina .
 


### PR DESCRIPTION
Reverts microsoft/retina#1027