### PR TITLE
fix: update performance test conditions in workflow

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
     "ghcr.io/devcontainers/features/go:1": {},
     "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {},
     "ghcr.io/devcontainers-contrib/features/kind:1": {},
-    "ghcr.io/devcontainers-contrib/features/azure-cli:1": {}
+    "ghcr.io/devcontainers/features/azure-cli:1": {}
   },
   "postCreateCommand": "bash .devcontainer/installMoreTools.sh && kind create cluster",
   "customizations": {

--- a/.github/workflows/perf.yaml
+++ b/.github/workflows/perf.yaml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   perf_test:
-    if: ${{ github.event_name == 'merge_group' }}
+    if: ${{ github.event != 'workflow_run' || github.event_name == 'merge_group' }}
     name: Retina Performance Test
     runs-on: ubuntu-latest
 
@@ -49,11 +49,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ -n "${{ github.event.inputs.tag }}" ]; then
+          if [ "${{ github.event }}" == "workflow_dispatch" ]; then
             TAG=${{ github.event.inputs.tag }}
           elif [ "${{ github.event_name }}" == "merge_group" ]; then
-            TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+            TAG=$(make version)
           else
-            TAG="default-version"
+            TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
           fi
           go test -v ./test/e2e/. -timeout 2h -tags=perf -count=1 -args -image-tag=$TAG -image-registry=${{ vars.ACR_NAME }} -image-namespace=${{ github.repository }}


### PR DESCRIPTION
# Description

This pull request includes several changes to improve the configuration and workflow for the development environment and performance testing. The most important changes involve updating the Azure CLI feature reference, modifying the conditions for running performance tests, and adjusting the tagging logic for test runs.

Improvements to development environment configuration:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L11-R11): Updated the Azure CLI feature reference from `ghcr.io/devcontainers-contrib/features/azure-cli:1` to `ghcr.io/devcontainers/features/azure-cli:1`.

Enhancements to performance testing workflow:

* [`.github/workflows/perf.yaml`](diffhunk://#diff-1aa140a875fcb7cae6b4ada7e6e973c4d55179ad046f56465f9f0ec592f283caL23-R23): Modified the condition for running the `perf_test` job to exclude events triggered by `workflow_run` unless the event name is `merge_group`.
* [`.github/workflows/perf.yaml`](diffhunk://#diff-1aa140a875fcb7cae6b4ada7e6e973c4d55179ad046f56465f9f0ec592f283caL52-R57): Adjusted the logic for setting the `TAG` variable to use `make version` for `merge_group` events and to handle `workflow_dispatch` events correctly.

## Checklist

- [X] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [X] I have correctly attributed the author(s) of the code.
- [X] I have tested the changes locally.
- [X] I have followed the project's style guidelines.
- [X] I have updated the documentation, if necessary.
- [X] I have added tests, if applicable.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
