### PR TITLE
fix: Remove `go run` from all `go generate` commands

### DIFF
--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -30,6 +30,8 @@ ENV GOOS=${GOOS}
 RUN if [ "$GOOS" = "linux" ] ; then \
       tdnf install -y clang16 lld16 bpftool libbpf-devel; \
     fi
+RUN go install github.com/cilium/ebpf/cmd/bpf2go@v0.16.0; \
+    go install go.uber.org/mock/mockgen@v0.5.0
 COPY ./pkg/plugin /go/src/github.com/microsoft/retina/pkg/plugin
 WORKDIR /go/src/github.com/microsoft/retina
 RUN if [ "$GOOS" = "linux" ] ; then \

--- a/pkg/capture/provider/interface.go
+++ b/pkg/capture/provider/interface.go
@@ -9,7 +9,7 @@ import (
 	"github.com/microsoft/retina/pkg/capture/file"
 )
 
-//go:generate go run go.uber.org/mock/mockgen@v0.4.0 -source=interface.go -destination=mock_network_capture.go -package=provider Interface
+//go:generate mockgen -source=interface.go -destination=mock_network_capture.go -package=provider Interface
 type NetworkCaptureProviderInterface interface {
 	// Setup prepares the provider with folder to store network capture for temporary.
 	Setup(filename file.CaptureFilename) (string, error)

--- a/pkg/controllers/cache/types.go
+++ b/pkg/controllers/cache/types.go
@@ -8,7 +8,7 @@ import (
 	"github.com/microsoft/retina/pkg/common"
 )
 
-//go:generate go run go.uber.org/mock/mockgen@v0.4.0 -destination=mock_cacheinterface.go -copyright_file=../../lib/ignore_headers.txt -package=cache github.com/microsoft/retina/pkg/controllers/cache CacheInterface
+//go:generate mockgen -destination=mock_cacheinterface.go -copyright_file=../../lib/ignore_headers.txt -package=cache github.com/microsoft/retina/pkg/controllers/cache CacheInterface
 type CacheInterface interface {
 	// GetPodByIP returns the retina endpoint for the given IP.
 	GetPodByIP(ip string) *common.RetinaEndpoint

--- a/pkg/enricher/types.go
+++ b/pkg/enricher/types.go
@@ -7,7 +7,7 @@ import (
 	"github.com/cilium/cilium/pkg/hubble/container"
 )
 
-//go:generate go run go.uber.org/mock/mockgen@v0.4.0 -destination=mock_enricherinterface.go  -copyright_file=../lib/ignore_headers.txt -package=enricher github.com/microsoft/retina/pkg/enricher EnricherInterface
+//go:generate mockgen -destination=mock_enricherinterface.go  -copyright_file=../lib/ignore_headers.txt -package=enricher github.com/microsoft/retina/pkg/enricher EnricherInterface
 
 type EnricherInterface interface {
 	Run()

--- a/pkg/hubble/common/decoder_linux.go
+++ b/pkg/hubble/common/decoder_linux.go
@@ -10,7 +10,7 @@ import (
 	"github.com/cilium/cilium/pkg/labels"
 )
 
-//go:generate go run github.com/golang/mock/mockgen@v1.6.0 -source decoder.go -destination=mocks/mock_types.go -package=mocks
+//go:generate mockgen -source decoder.go -destination=mocks/mock_types.go -package=mocks
 
 type EpDecoder interface {
 	Decode(ip netip.Addr) *flow.Endpoint

--- a/pkg/managers/filtermanager/types.go
+++ b/pkg/managers/filtermanager/types.go
@@ -7,7 +7,7 @@ import (
 	"net"
 )
 
-//go:generate go run go.uber.org/mock/mockgen@v0.4.0 -source=types.go -destination=mock_types.go -package=filtermanager
+//go:generate mockgen -source=types.go -destination=mock_types.go -package=filtermanager
 type ICache interface {
 	ips() []net.IP
 	reset()

--- a/pkg/managers/watchermanager/types.go
+++ b/pkg/managers/watchermanager/types.go
@@ -11,7 +11,7 @@ import (
 	"github.com/microsoft/retina/pkg/log"
 )
 
-//go:generate go run go.uber.org/mock/mockgen@v0.4.0 -source=types.go -destination=mocks/mock_types.go -package=mocks .
+//go:generate mockgen -source=types.go -destination=mocks/mock_types.go -package=mocks .
 type IWatcher interface {
 	// Init, Stop, and Refresh should only be called by watchermanager.
 	Init(ctx context.Context) error

--- a/pkg/metrics/interfaces.go
+++ b/pkg/metrics/interfaces.go
@@ -7,7 +7,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 )
 
-//go:generate go run go.uber.org/mock/mockgen@v0.4.0 -source=interfaces.go -destination=mock_types.go -package=metrics
+//go:generate mockgen -source=interfaces.go -destination=mock_types.go -package=metrics
 
 type CounterVec interface {
 	WithLabelValues(lvs ...string) prometheus.Counter

--- a/pkg/module/metrics/types.go
+++ b/pkg/module/metrics/types.go
@@ -59,7 +59,7 @@ const (
 	egress = "egress"
 )
 
-//go:generate go run go.uber.org/mock/mockgen@v0.4.0 -source=types.go -destination=mock_types.go -package=metrics
+//go:generate mockgen -source=types.go -destination=mock_types.go -package=metrics
 type IModule interface {
 	Reconcile(spec *api.MetricsSpec) error
 }

--- a/pkg/module/traces/types.go
+++ b/pkg/module/traces/types.go
@@ -4,7 +4,7 @@ package traces
 
 import api "github.com/microsoft/retina/crd/api/v1alpha1"
 
-//go:generate go run go.uber.org/mock/mockgen@v0.4.0 -destination=mock_moduleinterface.go -copyright_file=../../lib/ignore_headers.txt -package=traces github.com/microsoft/retina/pkg/module/traces ModuleInterface
+//go:generate mockgen -destination=mock_moduleinterface.go -copyright_file=../../lib/ignore_headers.txt -package=traces github.com/microsoft/retina/pkg/module/traces ModuleInterface
 
 type ModuleInterface interface {
 	// Run starts the trace module.

--- a/pkg/plugin/api/types.go
+++ b/pkg/plugin/api/types.go
@@ -10,7 +10,7 @@ import (
 	v1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 )
 
-//go:generate go run go.uber.org/mock/mockgen@v0.4.0 -destination=mock/mock_plugin.go -copyright_file=../../lib/ignore_headers.txt -package=mock github.com/microsoft/retina/pkg/plugin/api Plugin
+//go:generate mockgen -destination=mock/mock_plugin.go -copyright_file=../../lib/ignore_headers.txt -package=mock github.com/microsoft/retina/pkg/plugin/api Plugin
 
 const (
 	Meter       string = "retina-meter"

--- a/pkg/plugin/common/common_linux.go
+++ b/pkg/plugin/common/common_linux.go
@@ -17,7 +17,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-//go:generate go run go.uber.org/mock/mockgen@v0.4.0 -destination=mocks/mock_types.go -package=mocks . ITracer
+//go:generate mockgen -destination=mocks/mock_types.go -package=mocks . ITracer
 
 // Interface for IG tracers.
 // Ref: https://pkg.go.dev/github.com/inspektor-gadget/inspektor-gadget@v0.18.1/pkg/gadgets/trace/dns/tracer#Tracer

--- a/pkg/plugin/conntrack/conntrack_linux.go
+++ b/pkg/plugin/conntrack/conntrack_linux.go
@@ -19,7 +19,7 @@ import (
 	"go.uber.org/zap"
 )
 
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go@master -cflags "-g -O2 -Wall -D__TARGET_ARCH_${GOARCH} -Wall" -target ${GOARCH} -type ct_v4_key conntrack ./_cprog/conntrack.c -- -I../lib/_${GOARCH} -I../lib/common/libbpf/_src -I../lib/common/libbpf/_include/linux -I../lib/common/libbpf/_include/uapi/linux -I../lib/common/libbpf/_include/asm
+//go:generate bpf2go -cflags "-g -O2 -Wall -D__TARGET_ARCH_${GOARCH} -Wall" -target ${GOARCH} -type ct_v4_key conntrack ./_cprog/conntrack.c -- -I../lib/_${GOARCH} -I../lib/common/libbpf/_src -I../lib/common/libbpf/_include/linux -I../lib/common/libbpf/_include/uapi/linux -I../lib/common/libbpf/_include/asm
 
 // Init initializes the conntrack eBPF map in the kernel for the first time.
 // This function should be called in the init container since

--- a/pkg/plugin/dropreason/dropreason_linux.go
+++ b/pkg/plugin/dropreason/dropreason_linux.go
@@ -33,7 +33,7 @@ import (
 	"go.uber.org/zap"
 )
 
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go@master -cflags "-g -O2 -Wall -D__TARGET_ARCH_${GOARCH} -Wall" -target ${GOARCH} -type metrics_map_value -type drop_reason_t -type packet kprobe ./_cprog/drop_reason.c -- -I../lib/_${GOARCH} -I../lib/common/libbpf/_src -I../filter/_cprog/
+//go:generate bpf2go -cflags "-g -O2 -Wall -D__TARGET_ARCH_${GOARCH} -Wall" -target ${GOARCH} -type metrics_map_value -type drop_reason_t -type packet kprobe ./_cprog/drop_reason.c -- -I../lib/_${GOARCH} -I../lib/common/libbpf/_src -I../filter/_cprog/
 const (
 	nfHookSlowFn         = "nf_hook_slow"
 	tcpConnectFn         = "tcp_v4_connect"

--- a/pkg/plugin/dropreason/types_linux.go
+++ b/pkg/plugin/dropreason/types_linux.go
@@ -58,7 +58,7 @@ type (
 // Interface to https://pkg.go.dev/github.com/cilium/ebpf#Map.
 // Added for unit tests.
 //
-//go:generate go run go.uber.org/mock/mockgen@v0.4.0 -source=types_linux.go -destination=mocks/mock_types.go -package=dropreason . IMap IMapIterator IPerfReader
+//go:generate mockgen -source=types_linux.go -destination=mocks/mock_types.go -package=dropreason . IMap IMapIterator IPerfReader
 type IMapIterator interface {
 	Next(keyOut interface{}, valueOut interface{}) bool
 	Err() error

--- a/pkg/plugin/filter/filter_map_linux.go
+++ b/pkg/plugin/filter/filter_map_linux.go
@@ -20,7 +20,7 @@ import (
 	_ "github.com/microsoft/retina/pkg/plugin/filter/_cprog" // nolint
 )
 
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go@master -cflags "-g -O2 -Wall -D__TARGET_ARCH_${GOARCH} -Wall" -target ${GOARCH} -type mapKey filter ./_cprog/retina_filter.c -- -I../lib/_${GOARCH} -I../lib/common/libbpf/_src
+//go:generate bpf2go -cflags "-g -O2 -Wall -D__TARGET_ARCH_${GOARCH} -Wall" -target ${GOARCH} -type mapKey filter ./_cprog/retina_filter.c -- -I../lib/_${GOARCH} -I../lib/common/libbpf/_src
 
 var (
 	f    *FilterMap

--- a/pkg/plugin/filter/types.go
+++ b/pkg/plugin/filter/types.go
@@ -9,7 +9,7 @@ import (
 	"github.com/cilium/ebpf"
 )
 
-//go:generate go run go.uber.org/mock/mockgen@v0.4.0 -source=types.go -destination=mocks/mock_types.go -package=mocks
+//go:generate mockgen -source=types.go -destination=mocks/mock_types.go -package=mocks
 
 /*
 A thin wrapper around the eBPF map that allows adding and deleting IPv4 addresses.

--- a/pkg/plugin/infiniband/types_linux.go
+++ b/pkg/plugin/infiniband/types_linux.go
@@ -14,7 +14,7 @@ const (
 	Name api.PluginName = "infiniband"
 )
 
-//go:generate go run go.uber.org/mock/mockgen@v0.4.0 -source=types_linux.go -destination=infiniband_mock_generated.go -package=infiniband
+//go:generate mockgen -source=types_linux.go -destination=infiniband_mock_generated.go -package=infiniband
 type infiniband struct {
 	cfg       *kcfg.Config
 	l         *log.ZapLogger

--- a/pkg/plugin/linuxutil/types_linux.go
+++ b/pkg/plugin/linuxutil/types_linux.go
@@ -13,7 +13,7 @@ const (
 	Name api.PluginName = "linuxutil"
 )
 
-//go:generate go run go.uber.org/mock/mockgen@v0.4.0 -source=types_linux.go -destination=linuxutil_mock_generated.go -package=linuxutil
+//go:generate mockgen -source=types_linux.go -destination=linuxutil_mock_generated.go -package=linuxutil
 type linuxUtil struct {
 	cfg              *kcfg.Config
 	l                *log.ZapLogger

--- a/pkg/plugin/packetforward/packetforward_linux.go
+++ b/pkg/plugin/packetforward/packetforward_linux.go
@@ -28,7 +28,7 @@ import (
 	_ "github.com/microsoft/retina/pkg/plugin/packetforward/_cprog" // nolint
 )
 
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go@master -cflags "-g -O2 -Wall -D__TARGET_ARCH_${GOARCH} -Wall" -target ${GOARCH} -type metric packetforward ./_cprog/packetforward.c -- -I../lib/_${GOARCH} -I../lib/common/libbpf/_src
+//go:generate bpf2go -cflags "-g -O2 -Wall -D__TARGET_ARCH_${GOARCH} -Wall" -target ${GOARCH} -type metric packetforward ./_cprog/packetforward.c -- -I../lib/_${GOARCH} -I../lib/common/libbpf/_src
 
 // New creates a new packetforward plugin.
 func New(cfg *kcfg.Config) api.Plugin {

--- a/pkg/plugin/packetforward/types_linux.go
+++ b/pkg/plugin/packetforward/types_linux.go
@@ -28,7 +28,7 @@ const (
 // Interface to https://pkg.go.dev/github.com/cilium/ebpf#Map.
 // Added for unit tests.
 //
-//go:generate go run go.uber.org/mock/mockgen@v0.4.0 -destination=mocks/mock_types.go -package=mocks . IMap
+//go:generate mockgen -destination=mocks/mock_types.go -package=mocks . IMap
 type IMap interface {
 	Lookup(key, valueOut interface{}) error
 	Close() error

--- a/pkg/plugin/packetparser/packetparser_linux.go
+++ b/pkg/plugin/packetparser/packetparser_linux.go
@@ -49,7 +49,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-//go:generate go run github.com/cilium/ebpf/cmd/bpf2go@master -cflags "-g -O2 -Wall -D__TARGET_ARCH_${GOARCH} -Wall" -target ${GOARCH} -type packet packetparser ./_cprog/packetparser.c -- -I../lib/_${GOARCH} -I../lib/common/libbpf/_src -I../lib/common/libbpf/_include/linux -I../lib/common/libbpf/_include/uapi/linux -I../lib/common/libbpf/_include/asm -I../filter/_cprog/ -I../conntrack/_cprog/
+//go:generate bpf2go -cflags "-g -O2 -Wall -D__TARGET_ARCH_${GOARCH} -Wall" -target ${GOARCH} -type packet packetparser ./_cprog/packetparser.c -- -I../lib/_${GOARCH} -I../lib/common/libbpf/_src -I../lib/common/libbpf/_include/linux -I../lib/common/libbpf/_include/uapi/linux -I../lib/common/libbpf/_include/asm -I../filter/_cprog/ -I../conntrack/_cprog/
 var errNoOutgoingLinks = errors.New("could not determine any outgoing links")
 
 // New creates a packetparser plugin.

--- a/pkg/plugin/packetparser/types_linux.go
+++ b/pkg/plugin/packetparser/types_linux.go
@@ -80,7 +80,7 @@ type tcValue struct {
 	qdisc *tc.Object
 }
 
-//go:generate go run go.uber.org/mock/mockgen@v0.4.0 -source=types_linux.go -destination=mocks/mock_types.go -package=mocks
+//go:generate mockgen -source=types_linux.go -destination=mocks/mock_types.go -package=mocks
 
 // tc qdisc interface
 type qdisc interface {

--- a/pkg/pubsub/types.go
+++ b/pkg/pubsub/types.go
@@ -4,7 +4,7 @@ package pubsub
 
 type CallBackFunc func(interface{})
 
-//go:generate go run go.uber.org/mock/mockgen@v0.4.0 -destination=mock_pubsubinterface.go  -copyright_file=../lib/ignore_headers.txt -package=pubsub github.com/microsoft/retina/pkg/pubsub PubSubInterface
+//go:generate mockgen -destination=mock_pubsubinterface.go  -copyright_file=../lib/ignore_headers.txt -package=pubsub github.com/microsoft/retina/pkg/pubsub PubSubInterface
 
 // this file defines the interface a simple pubsub implementation should implement
 type PubSubInterface interface {

--- a/pkg/watchers/apiserver/types.go
+++ b/pkg/watchers/apiserver/types.go
@@ -5,7 +5,7 @@ package apiserver
 
 import "context"
 
-//go:generate go run go.uber.org/mock/mockgen@v0.4.0 -source=types.go -destination=mocks/mock_types.go -package=mocks .
+//go:generate mockgen -source=types.go -destination=mocks/mock_types.go -package=mocks .
 type IHostResolver interface {
 	LookupHost(context context.Context, host string) ([]string, error)
 }


### PR DESCRIPTION
Including `go run` in the //go:generate pragmas is never really how `go generate` was intended to be used. While it's a seemingly-useful hack to pin versions of tools, it breaks cross-compilation.

Cross-compilation breaks because if the requested GOARCH differs from the one `go generate` is being run on, `go run` receives the same GOARCH and builds the tool for that platform instead. The tool will never exec correctly because of the platform mismatch.

This removes `go run` from all `//go:generate` pragmas and adds the appropriate installation of these tools to the Dockerfile. Developers are expected to have these tools installed in the same way in their development environment (in the same way as go, clang, etc.).

Fixes: #1046 