### PR TITLE
chore: Remove yarn from documentation

### DIFF
--- a/docs/07-Contributing/developing.md
+++ b/docs/07-Contributing/developing.md
@@ -9,7 +9,7 @@ The easiest way to set up your Development Environment is to use the provided Gi
 ## Environment Config
 
 - [Go](https://go.dev/doc/install)
-- Docker
+- [Docker](https://docs.docker.com/engine/install/)
 - [Helm](https://helm.sh/docs/intro/install)
 - jq: `sudo apt install jq`
 - Fork the repository

--- a/site/README.md
+++ b/site/README.md
@@ -6,48 +6,4 @@ This website is built using [Docusaurus 2](https://docusaurus.io/), a modern sta
 
 When adding a new doc, make sure to add it to /site/sidebars.js
 
-To test, run `make docs` to spin up local webserver and view changes with hot reload
-
-## Using Yarn
-
-### Installation
-
-Install `yarn` (e.g. for Ubuntu, try [this guide](https://www.linuxcapable.com/how-to-install-yarn-on-ubuntu-linux/#install-yarn-on-ubuntu-2204-or-2004-via-nodesource)).
-
-In this directory (*retina/site/*), run:
-
-```bash
-yarn
-```
-
-### Local Development
-
-```bash
-yarn start
-```
-
-This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
-
-### Build
-
-```bash
-yarn build
-```
-
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
-
-## Deployment
-
-Using SSH:
-
-```bash
-USE_SSH=true yarn deploy
-```
-
-Not using SSH:
-
-```bash
-GIT_USER=<Your GitHub username> yarn deploy
-```
-
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+To test, run `make docs` to spin up local webserver and view changes with hot reload.

--- a/site/README.md
+++ b/site/README.md
@@ -4,6 +4,8 @@ This website is built using [Docusaurus 2](https://docusaurus.io/), a modern sta
 
 ## Development
 
-When adding a new doc, make sure to add it to /site/sidebars.js
+When adding a new doc, make sure to add it to `/site/sidebars.js` to display it in the sidebar.
 
-To test, run `make docs` to spin up local webserver and view changes with hot reload.
+> Prerequisite: [Docker](https://docs.docker.com/engine/install/)
+
+To test your changes, run `make docs` from the root directory to spin up local webserver and view changes with hot reload.


### PR DESCRIPTION
# Description

Removing mention of Yarn from building docs, since npm is used instead.

## Related Issue

https://github.com/microsoft/retina/issues/988

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
