### PR TITLE
fix: fixed failing network perf measurement gh action

### DIFF
--- a/.github/workflows/perf.yaml
+++ b/.github/workflows/perf.yaml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   perf_test:
-    if: ${{ github.event != 'workflow_run' || github.event_name == 'merge_group' }}
+    if: ${{ github.event_name != 'workflow_run' || github.event_name == 'merge_group' }}
     name: Retina Performance Test
     runs-on: ubuntu-latest
 
@@ -40,6 +40,9 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION }}
+        
+      - id: fetch-latest-github-release
+        uses: cityoflosangeles/fetch-latest-github-release@v2.0.4
 
       - name: Run performance measurement for Retina
         env:
@@ -49,11 +52,11 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ "${{ github.event }}" == "workflow_dispatch" ]; then
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             TAG=${{ github.event.inputs.tag }}
           elif [ "${{ github.event_name }}" == "merge_group" ]; then
             TAG=$(make version)
           else
-            TAG=$(git describe --tags `git rev-list --tags --max-count=1`)
+            TAG=${{ steps.fetch-latest-github-release.outputs.tag_name }}
           fi
           go test -v ./test/e2e/. -timeout 2h -tags=perf -count=1 -args -image-tag=$TAG -image-registry=${{ vars.ACR_NAME }} -image-namespace=${{ github.repository }}

--- a/.github/workflows/perf.yaml
+++ b/.github/workflows/perf.yaml
@@ -40,9 +40,6 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION }}
-        
-      - id: fetch-latest-github-release
-        uses: cityoflosangeles/fetch-latest-github-release@v2.0.4
 
       - name: Run performance measurement for Retina
         env:
@@ -57,6 +54,6 @@ jobs:
           elif [ "${{ github.event_name }}" == "merge_group" ]; then
             TAG=$(make version)
           else
-            TAG=${{ steps.fetch-latest-github-release.outputs.tag_name }}
+            TAG=$(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r .tag_name)
           fi
           go test -v ./test/e2e/. -timeout 2h -tags=perf -count=1 -args -image-tag=$TAG -image-registry=${{ vars.ACR_NAME }} -image-namespace=${{ github.repository }}


### PR DESCRIPTION
# Description

This pull request includes updates to the `.github/workflows/perf.yaml` file to correct the conditions for running the performance tests and to improve the process of retrieving the latest tag for the tests.

Changes to workflow conditions and tag retrieval:

* Updated the condition for running the performance test to use `github.event_name` instead of `github.event`. (`.github/workflows/perf.yaml`: [.github/workflows/perf.yamlL23-R23](diffhunk://#diff-1aa140a875fcb7cae6b4ada7e6e973c4d55179ad046f56465f9f0ec592f283caL23-R23))
* Modified the script to retrieve the latest tag using the GitHub API instead of the `git describe` command, ensuring the latest release tag is fetched correctly. (`.github/workflows/perf.yaml`: [.github/workflows/perf.yamlL52-R57](diffhunk://#diff-1aa140a875fcb7cae6b4ada7e6e973c4d55179ad046f56465f9f0ec592f283caL52-R57))

## Checklist

- [X] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [X] I have correctly attributed the author(s) of the code.
- [X] I have tested the changes locally.
- [X] I have followed the project's style guidelines.
- [X] I have updated the documentation, if necessary.
- [X] I have added tests, if applicable.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
