### PR TITLE
fix: name flag dereference

### DIFF
--- a/cli/cmd/capture/capture.go
+++ b/cli/cmd/capture/capture.go
@@ -12,7 +12,9 @@ import (
 var opts = struct {
 	genericclioptions.ConfigFlags
 	Name *string
-}{}
+}{
+	Name: new(string),
+}
 
 const defaultName = "retina-capture"
 

--- a/cli/cmd_test.go
+++ b/cli/cmd_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/microsoft/retina/cli/cmd"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func ExecuteInTest(cmd *cobra.Command, args []string) (stdout string, stderr string, err error) {
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.SetArgs(args)
+	cmd.SetOut(&stdoutBuf)
+	cmd.SetErr(&stderrBuf)
+	defer func() {
+		cmd.SetArgs(nil)
+		cmd.SetOut(nil)
+		cmd.SetErr(nil)
+	}()
+
+	err = cmd.Execute()
+	return stdoutBuf.String(), stderrBuf.String(), err
+}
+
+func TestCLICmd(t *testing.T) {
+	stdout, stderr, err := ExecuteInTest(cmd.Retina, []string{"-h"})
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "kubectl-retina")
+	assert.Equal(t, stderr, "")
+}


### PR DESCRIPTION
# Description

Fixes NPE related to uninstantiated `Name` pointer 

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
