### PR TITLE
fix: filtermanager cache and cache test races

### DIFF
--- a/pkg/managers/filtermanager/cache.go
+++ b/pkg/managers/filtermanager/cache.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 )
 
-var fc *filterCache
+var fc = &filterCache{data: make(map[string]requests)}
 
 // requests maps a requestor to a list of request metadata.
 // Nested maps
@@ -24,10 +24,7 @@ type filterCache struct {
 	data map[string]requests
 }
 
-func newCache() *filterCache {
-	if fc == nil {
-		fc = &filterCache{data: make(map[string]requests)}
-	}
+func getCache() *filterCache {
 	return fc
 }
 

--- a/pkg/managers/filtermanager/manager_linux.go
+++ b/pkg/managers/filtermanager/manager_linux.go
@@ -53,7 +53,7 @@ func Init(retry int) (*FilterManager, error) {
 		f.l = log.Logger().Named("filter-manager")
 	}
 	if f.c == nil {
-		f.c = newCache()
+		f.c = getCache()
 	}
 	f.fm, err = filter.Init()
 	return f, errors.Wrapf(err, "failed to initialize filter map")


### PR DESCRIPTION
# Description

Cache had a TOCTOU initialization race.
Cache tests had data races.

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
