### PR TITLE
fix(goreleaser): update ldflags for building Retina CLI

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 # vim: set ts=2 sw=2 tw=0 fo=cnqoj
 
-version: 1
+version: 2
 
 before:
   hooks:
@@ -22,7 +22,7 @@ builds:
       - windows
       - darwin
     ldflags:
-      - -X github.com/microsoft/retina/cli/cmd.Version=v{{.Version}}
+      - -X github.com/microsoft/retina/internal/buildinfo.Version=v{{.Version}}
     main: cli/main.go
 
 archives:


### PR DESCRIPTION
# Description

When building the Retina CLI locally, `kubectl retina version` showed up normally. After digging around, I found that we haven't update goreleaser with the latest ldflags.
## Related Issue

Fix #1013

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
