### PR TITLE
chore: update retina-shell image to azlinux 3.0.20241203

### DIFF
--- a/docs/06-Troubleshooting/shell.md
+++ b/docs/06-Troubleshooting/shell.md
@@ -82,7 +82,7 @@ table ip filter {
 
 **If you see the error "Operation not permitted (you must be root)", check that your `kubectl retina shell` command sets `--capabilities NET_RAW,NET_ADMIN`.**
 
-`iptables` in the shell image uses `iptables-legacy`, which may or may not match the configuration on the node. For example, Ubuntu maps `iptables` to `iptables-nft`. To use the exact same `iptables` binary as installed on the node, you will need to `chroot` into the host filesystem (see below).
+`iptables` in the shell image uses `iptables-nft`, which may or may not match the configuration on the node. For example, Azure Linux 2 maps `iptables` to `iptables-legacy`. To use the exact same `iptables` binary as installed on the node, you will need to `chroot` into the host filesystem (see below).
 
 ## Accessing the host filesystem
 

--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -1,11 +1,6 @@
-# mcr.microsoft.com/azurelinux/base/core:3.0.20241005
-FROM mcr.microsoft.com/azurelinux/base/core@sha256:7ec490b605aac8a44aed0b0695b0ee6ae976ec898afd9ac8d5613d7f3ce2b07b
+# mcr.microsoft.com/azurelinux/base/core:3.0.20241203
+FROM mcr.microsoft.com/azurelinux/base/core@sha256:07540f424a12aa58f0de61aab38e9670c82f16b35a2ba3e449309596d422109b
 
-# There are a two known issues with Azure Linux 3.0.20241005 that affect this image:
-# 1. `iptables-nft` binary is not yet installed, but will be fixed by https://github.com/microsoft/azurelinux/pull/10786
-#    Until then, use `nft` to view nftables rules.
-# 2. `nslookup` and `bind` print an error "Algorithm not supported by SCOSSL" (but still complete successfully).
-#    This will be fixed by https://github.com/microsoft/SymCrypt-OpenSSL/pull/92
 RUN tdnf install -y \
 	bind-utils \
 	conntrack \


### PR DESCRIPTION
# Description

Azure Linux 3.0.20241203 now supports iptables-nft and resolves the SymCrypt warning.

## Related Issue

N/A

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

<img width="450" alt="image" src="https://github.com/user-attachments/assets/4cea50c7-9202-4744-b7b3-415bf9261c2d">


## Additional Notes

N/A