### PR TITLE
test: Run e2e tests in both arm64 and amd64 arch. 

### DIFF
--- a/test/e2e/common/common.go
+++ b/test/e2e/common/common.go
@@ -26,6 +26,7 @@ const (
 
 var (
 	AzureLocations = []string{"eastus2", "northeurope", "uksouth", "centralindia", "westus2"}
+	Architectures  = []string{"amd64", "arm64"}
 	CreateInfra    = flag.Bool("create-infra", true, "create a Resource group, vNET and AKS cluster for testing")
 	DeleteInfra    = flag.Bool("delete-infra", true, "delete a Resource group, vNET and AKS cluster for testing")
 )

--- a/test/e2e/framework/kubernetes/create-agnhost-statefulset.go
+++ b/test/e2e/framework/kubernetes/create-agnhost-statefulset.go
@@ -50,14 +50,14 @@ func (c *CreateAgnhostStatefulSet) Run() error {
 		c.AgnhostArch = AgnhostArchAmd64
 	}
 
-	agnhostStatefulest := c.getAgnhostDeployment(c.AgnhostArch)
+	agnhostStatefulSet := c.getAgnhostDeployment(c.AgnhostArch)
 
-	err = CreateResource(ctx, agnhostStatefulest, clientset)
+	err = CreateResource(ctx, agnhostStatefulSet, clientset)
 	if err != nil {
 		return fmt.Errorf("error agnhost component: %w", err)
 	}
 
-	selector, exists := agnhostStatefulest.Spec.Selector.MatchLabels["app"]
+	selector, exists := agnhostStatefulSet.Spec.Selector.MatchLabels["app"]
 	if !exists {
 		return fmt.Errorf("missing label \"app=%s\" from agnhost statefulset: %w", c.AgnhostName, ErrLabelMissingFromPod)
 	}
@@ -98,7 +98,6 @@ func (c *CreateAgnhostStatefulSet) getAgnhostDeployment(arch string) *appsv1.Sta
 				},
 			},
 		}
-
 	} else {
 		affinity = &v1.Affinity{
 			PodAntiAffinity: &v1.PodAntiAffinity{

--- a/test/e2e/framework/kubernetes/create-agnhost-statefulset.go
+++ b/test/e2e/framework/kubernetes/create-agnhost-statefulset.go
@@ -17,8 +17,10 @@ import (
 var ErrLabelMissingFromPod = fmt.Errorf("label missing from pod")
 
 const (
-	AgnhostHTTPPort = 80
-	AgnhostReplicas = 1
+	AgnhostHTTPPort  = 80
+	AgnhostReplicas  = 1
+	AgnhostArchAmd64 = "amd64"
+	AgnhostArchArm64 = "arm64"
 )
 
 type CreateAgnhostStatefulSet struct {
@@ -26,6 +28,7 @@ type CreateAgnhostStatefulSet struct {
 	AgnhostNamespace   string
 	ScheduleOnSameNode bool
 	KubeConfigFilePath string
+	AgnhostArch        string
 }
 
 func (c *CreateAgnhostStatefulSet) Run() error {
@@ -42,7 +45,12 @@ func (c *CreateAgnhostStatefulSet) Run() error {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeoutSeconds*time.Second)
 	defer cancel()
 
-	agnhostStatefulest := c.getAgnhostDeployment()
+	// set default arch to amd64
+	if c.AgnhostArch == "" {
+		c.AgnhostArch = AgnhostArchAmd64
+	}
+
+	agnhostStatefulest := c.getAgnhostDeployment(c.AgnhostArch)
 
 	err = CreateResource(ctx, agnhostStatefulest, clientset)
 	if err != nil {
@@ -71,7 +79,7 @@ func (c *CreateAgnhostStatefulSet) Stop() error {
 	return nil
 }
 
-func (c *CreateAgnhostStatefulSet) getAgnhostDeployment() *appsv1.StatefulSet {
+func (c *CreateAgnhostStatefulSet) getAgnhostDeployment(arch string) *appsv1.StatefulSet {
 	reps := int32(AgnhostReplicas)
 
 	var affinity *v1.Affinity
@@ -141,12 +149,13 @@ func (c *CreateAgnhostStatefulSet) getAgnhostDeployment() *appsv1.StatefulSet {
 				Spec: v1.PodSpec{
 					Affinity: affinity,
 					NodeSelector: map[string]string{
-						"kubernetes.io/os": "linux",
+						"kubernetes.io/os":   "linux",
+						"kubernetes.io/arch": arch,
 					},
 					Containers: []v1.Container{
 						{
 							Name:  c.AgnhostName,
-							Image: "acnpublic.azurecr.io/agnhost:2.40",
+							Image: "registry.k8s.io/e2e-test-images/agnhost:2.40",
 							Resources: v1.ResourceRequirements{
 								Requests: v1.ResourceList{
 									"memory": resource.MustParse("20Mi"),

--- a/test/e2e/framework/kubernetes/create-network-policy.go
+++ b/test/e2e/framework/kubernetes/create-network-policy.go
@@ -36,8 +36,8 @@ func (c *CreateDenyAllNetworkPolicy) Run() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	agnhostStatefulest := getNetworkPolicy(c.NetworkPolicyNamespace, c.DenyAllLabelSelector)
-	err = CreateResource(ctx, agnhostStatefulest, clientset)
+	agnhostStatefulSet := getNetworkPolicy(c.NetworkPolicyNamespace, c.DenyAllLabelSelector)
+	err = CreateResource(ctx, agnhostStatefulSet, clientset)
 	if err != nil {
 		return fmt.Errorf("error creating simple deny-all network policy: %w", err)
 	}
@@ -96,8 +96,8 @@ func (d *DeleteDenyAllNetworkPolicy) Run() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	agnhostStatefulest := getNetworkPolicy(d.NetworkPolicyNamespace, d.DenyAllLabelSelector)
-	err = DeleteResource(ctx, agnhostStatefulest, clientset)
+	agnhostStatefulSet := getNetworkPolicy(d.NetworkPolicyNamespace, d.DenyAllLabelSelector)
+	err = DeleteResource(ctx, agnhostStatefulSet, clientset)
 	if err != nil {
 		return fmt.Errorf("error creating simple deny-all network policy: %w", err)
 	}

--- a/test/e2e/jobs/jobs.go
+++ b/test/e2e/jobs/jobs.go
@@ -265,6 +265,12 @@ func ValidateHubble(kubeConfigFilePath, chartPath string, testPodNamespace strin
 
 	job.AddScenario(hubble.ValidateHubbleUIService(kubeConfigFilePath))
 
+	job.AddStep(&kubernetes.EnsureStableComponent{
+		PodNamespace:           common.KubeSystemNamespace,
+		LabelSelector:          "k8s-app=retina",
+		IgnoreContainerRestart: false,
+	}, nil)
+
 	return job
 }
 

--- a/test/e2e/scenarios/dns/scenarios.go
+++ b/test/e2e/scenarios/dns/scenarios.go
@@ -36,7 +36,7 @@ type ResponseValidationParams struct {
 }
 
 // ValidateBasicDNSMetrics validates basic DNS metrics present in the metrics endpoint
-func ValidateBasicDNSMetrics(scenarioName string, req *RequestValidationParams, resp *ResponseValidationParams, namespace string) *types.Scenario {
+func ValidateBasicDNSMetrics(scenarioName string, req *RequestValidationParams, resp *ResponseValidationParams, namespace, arch string) *types.Scenario {
 	// generate a random ID using rand
 	id := fmt.Sprintf("basic-dns-port-forward-%d", rand.Int()) // nolint:gosec // fine to use math/rand here
 	agnhostName := "agnhost-" + id
@@ -46,6 +46,7 @@ func ValidateBasicDNSMetrics(scenarioName string, req *RequestValidationParams, 
 			Step: &kubernetes.CreateAgnhostStatefulSet{
 				AgnhostName:      agnhostName,
 				AgnhostNamespace: namespace,
+				AgnhostArch:      arch,
 			},
 		},
 		// Need this delay to guarantee that the pods will have bpf program attached
@@ -149,7 +150,7 @@ func ValidateBasicDNSMetrics(scenarioName string, req *RequestValidationParams, 
 }
 
 // ValidateAdvancedDNSMetrics validates the advanced DNS metrics present in the metrics endpoint
-func ValidateAdvancedDNSMetrics(scenarioName string, req *RequestValidationParams, resp *ResponseValidationParams, kubeConfigFilePath string, namespace string) *types.Scenario {
+func ValidateAdvancedDNSMetrics(scenarioName string, req *RequestValidationParams, resp *ResponseValidationParams, kubeConfigFilePath string, namespace, arch string) *types.Scenario {
 	// random ID
 	id := fmt.Sprintf("adv-dns-port-forward-%d", rand.Int()) // nolint:gosec // fine to use math/rand here
 	agnhostName := "agnhost-" + id
@@ -159,6 +160,7 @@ func ValidateAdvancedDNSMetrics(scenarioName string, req *RequestValidationParam
 			Step: &kubernetes.CreateAgnhostStatefulSet{
 				AgnhostName:      agnhostName,
 				AgnhostNamespace: namespace,
+				AgnhostArch:      arch,
 			},
 		},
 		// Need this delay to guarantee that the pods will have bpf program attached

--- a/test/e2e/scenarios/dns/scenarios.go
+++ b/test/e2e/scenarios/dns/scenarios.go
@@ -36,7 +36,7 @@ type ResponseValidationParams struct {
 }
 
 // ValidateBasicDNSMetrics validates basic DNS metrics present in the metrics endpoint
-func ValidateBasicDNSMetrics(scenarioName string, req *RequestValidationParams, resp *ResponseValidationParams, kubeConfigFilePath, namespace, arch string) *types.Scenario {
+func ValidateBasicDNSMetrics(scenarioName string, req *RequestValidationParams, resp *ResponseValidationParams, namespace, arch string) *types.Scenario {
 	// generate a random ID using rand
 	id := fmt.Sprintf("basic-dns-port-forward-%d", rand.Int()) // nolint:gosec // fine to use math/rand here
 	agnhostName := "agnhost-" + id
@@ -150,7 +150,7 @@ func ValidateBasicDNSMetrics(scenarioName string, req *RequestValidationParams, 
 }
 
 // ValidateAdvancedDNSMetrics validates the advanced DNS metrics present in the metrics endpoint
-func ValidateAdvancedDNSMetrics(scenarioName string, req *RequestValidationParams, resp *ResponseValidationParams, kubeConfigFilePath string, namespace, arch string) *types.Scenario {
+func ValidateAdvancedDNSMetrics(scenarioName string, req *RequestValidationParams, resp *ResponseValidationParams, kubeConfigFilePath, namespace, arch string) *types.Scenario {
 	// random ID
 	id := fmt.Sprintf("adv-dns-port-forward-%d", rand.Int()) // nolint:gosec // fine to use math/rand here
 	agnhostName := "agnhost-" + id

--- a/test/e2e/scenarios/dns/scenarios.go
+++ b/test/e2e/scenarios/dns/scenarios.go
@@ -36,7 +36,7 @@ type ResponseValidationParams struct {
 }
 
 // ValidateBasicDNSMetrics validates basic DNS metrics present in the metrics endpoint
-func ValidateBasicDNSMetrics(scenarioName string, req *RequestValidationParams, resp *ResponseValidationParams, namespace, arch string) *types.Scenario {
+func ValidateBasicDNSMetrics(scenarioName string, req *RequestValidationParams, resp *ResponseValidationParams, kubeConfigFilePath, namespace, arch string) *types.Scenario {
 	// generate a random ID using rand
 	id := fmt.Sprintf("basic-dns-port-forward-%d", rand.Int()) // nolint:gosec // fine to use math/rand here
 	agnhostName := "agnhost-" + id


### PR DESCRIPTION
# Description

This PR allows us to run plugin e2e in both arm64 and amd64 arch.
It also replaces agnhost image with the standard one hosted in `registry.k8s.io/e2e-test-images`instead of the fork in `acnpublic`, as it is multi-arch and good practice.

The test sets up agnhost in different args, and check plugin metrics on retina-agent on both amd64 and arm64.

![image](https://github.com/user-attachments/assets/065ee0f4-a3db-4c07-9c61-1526fc832e1f)

![image](https://github.com/user-attachments/assets/24176641-2e1b-4000-a46f-ef50cc3ace61)



## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

[#450](https://github.com/microsoft/retina/issues/450)

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
