### PR TITLE
feat: automate Hubble version bump

### DIFF
--- a/.github/workflows/update-hubble.yaml
+++ b/.github/workflows/update-hubble.yaml
@@ -1,0 +1,74 @@
+on:
+  schedule:
+    - cron: '0 0 * * *' # Runs daily at midnight
+  workflow_dispatch:
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get latest Hubble version
+        id: get_version
+        run: |
+          latest_version=$(curl -s https://api.github.com/repos/cilium/hubble/releases/latest | jq -r .tag_name)
+          echo "Latest Hubble version: $latest_version"
+          echo "::set-output name=version::$latest_version"
+
+      - name: Get current Hubble version from Dockerfile
+        id: get_current_version
+        run: |
+          current_version=$(grep -oP '(?<=ARG HUBBLE_VERSION=).*' controller/Dockerfile)
+          echo "Current Hubble version: $current_version"
+          echo "::set-output name=version::$current_version"
+
+      - name: Check if update is needed
+        id: check_update
+        run: |
+          if [ "${{ steps.get_version.outputs.version }}" == "${{ steps.get_current_version.outputs.version }}" ]; then
+            echo "Hubble version is up to date. No update needed."
+            echo "::set-output name=update_needed::false"
+          else
+            echo "Hubble version needs to be updated."
+            echo "::set-output name=update_needed::true"
+          fi
+
+      - name: Update Dockerfile and Makefile with latest Hubble version
+        if: steps.check_update.outputs.update_needed == 'true'
+        run: |
+          latest_version=${{ steps.get_version.outputs.version }}
+          sed -i "s/^ARG HUBBLE_VERSION=.*/ARG HUBBLE_VERSION=${latest_version}/" controller/Dockerfile
+          sed -i "s/^ENV HUBBLE_VERSION=.*/ENV HUBBLE_VERSION=${latest_version}/" controller/Dockerfile
+          sed -i "s/^HUBBLE_VERSION=.*/HUBBLE_VERSION=${latest_version}/" Makefile
+
+      - name: Create new branch
+        if: steps.check_update.outputs.update_needed == 'true'
+        run: |
+          git checkout -b bump-hubble-version-${{ steps.get_version.outputs.version }}
+
+      - name: Commit and push changes
+        if: steps.check_update.outputs.update_needed == 'true'
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+          git add controller/Dockerfile Makefile
+          git commit -m "Bump Hubble version to ${{ steps.get_version.outputs.version }}"
+          git push --set-upstream origin bump-hubble-version-${{ steps.get_version.outputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create pull request
+        if: steps.check_update.outputs.update_needed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: bump-hubble-version-${{ steps.get_version.outputs.version }}
+          title: "deps: bump Hubble version to ${{ steps.get_version.outputs.version }}"
+          body: "This PR bumps the Hubble version to ${{ steps.get_version.outputs.version }}."
+          labels: "area/dependencies"
+          sign-commits: true
+          signoff: true
+  

--- a/.github/workflows/update-hubble.yaml
+++ b/.github/workflows/update-hubble.yaml
@@ -1,10 +1,13 @@
+name: Update Hubble
+
 on:
   schedule:
     - cron: '0 0 * * *' # Runs daily at midnight
   workflow_dispatch:
 
 jobs:
-  bump-version:
+  update-hubble:
+    name: Update Hubble to latest version
     runs-on: ubuntu-latest
 
     steps:
@@ -16,59 +19,42 @@ jobs:
         run: |
           latest_version=$(curl -s https://api.github.com/repos/cilium/hubble/releases/latest | jq -r .tag_name)
           echo "Latest Hubble version: $latest_version"
-          echo "::set-output name=version::$latest_version"
+          echo "version=$latest_version" >> $GITHUB_ENV
 
       - name: Get current Hubble version from Dockerfile
         id: get_current_version
         run: |
           current_version=$(grep -oP '(?<=ARG HUBBLE_VERSION=).*' controller/Dockerfile)
           echo "Current Hubble version: $current_version"
-          echo "::set-output name=version::$current_version"
+          echo "current_version=$current_version" >> $GITHUB_ENV
 
       - name: Check if update is needed
         id: check_update
         run: |
-          if [ "${{ steps.get_version.outputs.version }}" == "${{ steps.get_current_version.outputs.version }}" ]; then
+          if [ "${{ env.version }}" == "${{ env.current_version }}" ]; then
             echo "Hubble version is up to date. No update needed."
-            echo "::set-output name=update_needed::false"
+            echo "update_needed=false" >> $GITHUB_ENV
           else
             echo "Hubble version needs to be updated."
-            echo "::set-output name=update_needed::true"
+            echo "update_needed=true" >> $GITHUB_ENV
           fi
 
       - name: Update Dockerfile and Makefile with latest Hubble version
-        if: steps.check_update.outputs.update_needed == 'true'
+        if: env.update_needed == 'true'
         run: |
-          latest_version=${{ steps.get_version.outputs.version }}
-          sed -i "s/^ARG HUBBLE_VERSION=.*/ARG HUBBLE_VERSION=${latest_version}/" controller/Dockerfile
-          sed -i "s/^ENV HUBBLE_VERSION=.*/ENV HUBBLE_VERSION=${latest_version}/" controller/Dockerfile
-          sed -i "s/^HUBBLE_VERSION=.*/HUBBLE_VERSION=${latest_version}/" Makefile
-
-      - name: Create new branch
-        if: steps.check_update.outputs.update_needed == 'true'
-        run: |
-          git checkout -b bump-hubble-version-${{ steps.get_version.outputs.version }}
-
-      - name: Commit and push changes
-        if: steps.check_update.outputs.update_needed == 'true'
-        run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git add controller/Dockerfile Makefile
-          git commit -m "Bump Hubble version to ${{ steps.get_version.outputs.version }}"
-          git push --set-upstream origin bump-hubble-version-${{ steps.get_version.outputs.version }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          sed -i "s/^ARG HUBBLE_VERSION=.*/ARG HUBBLE_VERSION=${{ env.version }}/" controller/Dockerfile
+          sed -i "s/^HUBBLE_VERSION ?=.*/HUBBLE_VERSION ?= ${{ env.version }}/" Makefile
 
       - name: Create pull request
-        if: steps.check_update.outputs.update_needed == 'true'
+        if: env.update_needed == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: bump-hubble-version-${{ steps.get_version.outputs.version }}
-          title: "deps: bump Hubble version to ${{ steps.get_version.outputs.version }}"
-          body: "This PR bumps the Hubble version to ${{ steps.get_version.outputs.version }}."
+          branch: deps/update-hubble-to-${{ env.version }}
+          title: "deps: bump Hubble version from ${{ env.current_version }} to ${{ env.version }}"
+          body: "This PR bumps the Hubble version from ${{ env.current_version }} to ${{ env.version }}."
+          commit-message: "deps: bump Hubble version from ${{ env.current_version }} to ${{ env.version }}"
           labels: "area/dependencies"
           sign-commits: true
           signoff: true
-  
+          delete-branch: true

--- a/.github/workflows/update-hubble.yaml
+++ b/.github/workflows/update-hubble.yaml
@@ -5,6 +5,10 @@ on:
     - cron: '0 0 * * *' # Runs daily at midnight
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   update-hubble:
     name: Update Hubble to latest version

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ PLATFORM		?= $(OS)/$(ARCH)
 PLATFORMS		?= linux/amd64 linux/arm64 windows/amd64
 OS_VERSION		?= ltsc2019
 
-HUBBLE_VERSION ?= v1.16.3
+HUBBLE_VERSION ?= v1.16.3 # This may be modified via the update-hubble GitHub Action
 
 CONTAINER_BUILDER ?= docker
 CONTAINER_RUNTIME ?= docker

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -98,6 +98,7 @@ RUN arr="clang tcpdump ip ss iptables-legacy iptables-legacy-save iptables-nft i
 # Download Hubble
 ARG GOARCH=amd64
 ENV HUBBLE_ARCH=${GOARCH}
+# ARG HUBBLE_VERSION may be modified via the update-hubble GitHub Action
 ARG HUBBLE_VERSION=v1.16.3
 ENV HUBBLE_VERSION=${HUBBLE_VERSION}
 RUN echo "Hubble version: $HUBBLE_VERSION" && \


### PR DESCRIPTION
# Description

Introduce a new Github Action workflow that will check for new Hubble version and bumping it if neccesary

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Sample PR and Workflow run 
https://github.com/nddq/retina/pull/9
https://github.com/nddq/retina/actions/runs/12438751428

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
