### PR TITLE
fix(test): Add custom comparer to ignore timestamps in capture tests

### DIFF
--- a/pkg/capture/crd_to_job_test.go
+++ b/pkg/capture/crd_to_job_test.go
@@ -820,6 +820,10 @@ func Test_CaptureToPodTranslator_ValidateCapture(t *testing.T) {
 	}
 }
 
+func isIgnorableEnvVar(envVar corev1.EnvVar) bool {
+	return envVar.Name == captureConstants.CaptureStartTimestampEnvKey
+}
+
 func Test_CaptureToPodTranslator_TranslateCaptureToJobs(t *testing.T) {
 	captureName := "capture-test"
 	hostPath := "/tmp/capture"
@@ -1736,7 +1740,15 @@ func Test_CaptureToPodTranslator_TranslateCaptureToJobs(t *testing.T) {
 				job.Spec.Template.Spec.Containers[0].Command = []string{captureConstants.CaptureContainerEntrypointWin}
 			}
 
-			cmpOption := cmpopts.SortSlices(func(enVar1, enVar2 corev1.EnvVar) bool { return enVar1.Name < enVar2.Name })
+			cmpOption := cmp.Options{
+				cmpopts.SortSlices(func(enVar1, enVar2 corev1.EnvVar) bool { return enVar1.Name < enVar2.Name }),
+				cmp.Comparer(func(x, y corev1.EnvVar) bool {
+					if isIgnorableEnvVar(x) || isIgnorableEnvVar(y) {
+						return true
+					}
+					return x.Name == y.Name && x.Value == y.Value
+				}),
+			}
 
 			if diff := cmp.Diff([]*batchv1.Job{job}, jobs, cmpOption); diff != "" {
 				t.Errorf("TranslateCaptureToJobs() mismatch (-want, +got):\n%s", diff)

--- a/pkg/capture/crd_to_job_test.go
+++ b/pkg/capture/crd_to_job_test.go
@@ -1723,6 +1723,15 @@ func Test_CaptureToPodTranslator_TranslateCaptureToJobs(t *testing.T) {
 			job.Spec.Template.Spec.Containers[0].VolumeMounts = tt.volumeMounts
 			job.Spec.Template.Spec.Volumes = tt.volumes
 
+			for _, env := range tt.podEnv {
+				if env.Name == captureConstants.CaptureStartTimestampEnvKey {
+					_, err := file.StringToTimestamp(env.Value)
+					if err != nil {
+						t.Errorf("TranslateCaptureToJobs() error with capture timestamp: %v", err)
+					}
+				}
+			}
+
 			if tt.isWindows {
 				containerAdministrator := "NT AUTHORITY\\SYSTEM"
 				useHostProcess := true


### PR DESCRIPTION
# Description

Previously, in [PR 894](https://github.com/microsoft/retina/pull/894), timestamps were introduced to be able to print capture names as their jobs were beginning. 

This PR addresses an oversight in the testing which compared whether the timestamp of the test and the timestamp of the test capture were the same. This was not always the case - particularly if there was some delay between the beginning of the test and the beginning of the capture. The change in this PR adds a custom comparer to the `cmp.Diff` which ignores the timestamp environment variables.

## Related Issue

[1045](https://github.com/microsoft/retina/issues/1045)

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Testing Completed

The tests now succeed regardless of whether a delay occurs or not - causing the timestamps to differ. This was simulated with an artificial delay with `time.Sleep`.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
