### PR TITLE
build(images): Changing external test images to internal ones

### DIFF
--- a/test/goldpinger/deployment.yaml
+++ b/test/goldpinger/deployment.yaml
@@ -73,7 +73,7 @@ spec:
                   fieldPath: status.podIP
             - name: HOSTS_TO_RESOLVE
               value: "1.1.1.1 8.8.8.8 www.bing.com"
-          image: "docker.io/bloomberg/goldpinger:v3.9.0"
+          image: "mcr.microsoft.com/aks/e2e/bloomberg-goldpinger:v3.7.0"
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true

--- a/test/scale/example-deployment.yaml
+++ b/test/scale/example-deployment.yaml
@@ -43,7 +43,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-          image: "docker.io/bloomberg/goldpinger:v3.9.0"
+          image: "mcr.microsoft.com/aks/e2e/bloomberg-goldpinger:v3.7.0"
           imagePullPolicy: Always
           securityContext:
             allowPrivilegeEscalation: false

--- a/test/trafficgen/kapinger.yaml
+++ b/test/trafficgen/kapinger.yaml
@@ -98,7 +98,7 @@ spec:
       serviceAccountName: kapinger-sa
       containers:
         - name: kapinger
-          image: ghcr.io/microsoft/retina/kapinger:latest
+          image: acnpublic.azurecr.io/kapinger:20241009.5
           resources:
             limits:
               memory: 20Mi


### PR DESCRIPTION
# Description

The [Retina OSS CG Pipelines](https://dev.azure.com/msazure/One/_build?definitionId=357560&_a=summary) has been generating warnings because of two images that aren't being pulled from MCR: docker.io/bloomberg/goldpinger:v3.9.0 and ghcr.io/microsoft/retina/kapinger:latest.

The two images have been replaces by internal ones.

Full description of the issue and the solution can be found in [[Spike] Investigate Retina OSS Jobs (All Warnings)](https://msazure.visualstudio.com/One/_workitems/edit/30303687).

## Checklist

- [X] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [X] I have correctly attributed the author(s) of the code.
- [X] I have tested the changes locally.
- [X] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

All warnings have been built successfully and not warning has been flagged.
https://dev.azure.com/msazure/One/_build/results?buildId=111569628&view=results

![image](https://github.com/user-attachments/assets/2057a601-9a14-4f90-8960-2b44cbf3f27f)

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
