### PR TITLE
build(images): Reverting 32ead63

### DIFF
--- a/.pipelines/cg-pipeline.yaml
+++ b/.pipelines/cg-pipeline.yaml
@@ -215,12 +215,27 @@ stages:
           - checkout: self
             fetchTags: true
 
-          - task: Docker@2
-            displayName: Docker Login
+          - task: DownloadPipelineArtifact@2
             inputs:
-              containerRegistry: $(WINDOWS_BUILDER_REGISTRY)
-              command: "login"
-              addPipelineData: false
+              buildType: "specific"
+              project: $(BUILDER_ADO_PROECT)
+              definition: $(BUILDER_ADO_DEFINITION_ID) # Replace with your build definition ID
+              buildId: $(BUILDER_ADO_BUILD_ID)
+              artifactName: $(BUILDER_ADO_ARTIFACTE_NAME) # Replace with your artifact name
+              itemPattern: "**/*builder*.tar"
+              downloadPath: '$(Pipeline.Workspace)\artifacts'
+              
+          - task: PowerShell@2
+            displayName: "Load Builder Image"
+            inputs:
+              targetType: "inline"
+              script: |
+                $rootDir = "$(Pipeline.Workspace)\artifacts"
+                $dockerImages = Get-ChildItem -Path $rootDir -Recurse -Filter *.tar
+                foreach ($image in $dockerImages) {
+                    Write-Host "Loading Docker image: $($image.FullName)"
+                    docker load -i $image.FullName
+                }
 
           - task: PowerShell@2
             displayName: "Build Retina Windows Image (LTSC2022)"


### PR DESCRIPTION
# Description

Reverting 32ead63 since acndev.azurecr.io represents a vulnerability. The pipeline dependency will be addressed at a future stage using acnprod.azurecr.io instead.

## Checklist

- [X] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [X] I have correctly attributed the author(s) of the code.
- [X] I have tested the changes locally.
- [X] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.


---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
