### PR TITLE
fix: Fix retina capture download failing due to empty BLOB_URL

### DIFF
--- a/cli/cmd/capture/download.go
+++ b/cli/cmd/capture/download.go
@@ -18,12 +18,13 @@ import (
 
 const BlobURL = "BLOB_URL"
 
-var ErrEmptyBlobURL = errors.New("BLOB_URL must be set/exported")
+var ErrEmptyBlobURL = errors.Errorf("%s environment variable is empty. It must be set/exported", BlobURL)
 
 var downloadCapture = &cobra.Command{
 	Use:   "download",
 	Short: "Download Retina Captures",
 	RunE: func(*cobra.Command, []string) error {
+		viper.AutomaticEnv()
 		blobURL := viper.GetString(BlobURL)
 		if blobURL == "" {
 			return ErrEmptyBlobURL


### PR DESCRIPTION
# Description

Prior to this PR, exporting a `BLOB_URL` variable and running `retina capture download` would throw an error. This was due to Viper (the config manager package) not picking up the value correctly. This PR adds a change that corrects this behaviour.

I also added a little bit of context to the error message to make it more explicit.

## Related Issue

https://github.com/microsoft/retina/issues/899

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Current behaviour - valid token, but not recognised
![image](https://github.com/user-attachments/assets/0095f8fd-953b-4460-8da8-a707092dee0d)

Empty BLOB_URL
![{2DCCFD6C-29C6-48BE-AE58-546099C92307}](https://github.com/user-attachments/assets/5fae2bdb-3225-47a8-a915-a66b22bba052)

Valid BLOB_URL
![image](https://github.com/user-attachments/assets/1dfad7ca-1163-44e8-89b3-ef0de6e6f00a)


## Additional Notes

Testing was done on my personal blob storage account.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
