### PR TITLE
fix: Remove gomnd from golangci linters

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,12 +7,10 @@ issues:
     - path: pkg/metrics/types_windows.go
       linters:
         - revive
-        - mnd
         - var-naming
     - path: pkg/metrics/types_linux.go
       linters:
         - revive
-        - mnd
         - var-naming
 linters:
   presets: 
@@ -31,7 +29,6 @@ linters:
   - gocritic
   - gocyclo
   - gofmt
-  - mnd
   - goprintffuncname
   - gosimple
   - lll


### PR DESCRIPTION
This linter causes more harm than good, encouraging practices that actively obfuscate simple values whose meaning could be derived from context. Since it has no context-awareness, it flags everything from file modes, to obvious iteration counters as "magic numbers." This determination is fairly straightforward for a reviewer to make by hand, and it comes up relatively infrequently. The best course of action, until a better (probably LLM-based) magic number detector can be found.