### PR TITLE
fix(makefile): add missing escape_dot function to properly handle secret key names with dots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ image-metadata-*.json
 *results*.json
 netperf-*.json
 netperf-*.csv
+
+.certs/

--- a/Makefile
+++ b/Makefile
@@ -549,6 +549,9 @@ get-certs:
 	hubble config set tls true
 	hubble config set tls-server-name instance.hubble-relay.cilium.io
 
+# Replaces every '.' in $(1) with '\.'
+escape_dot = $(subst .,\.,$(1))
+
 .PHONY: clean-certs
 clean-certs:
 	rm -rf $(CERT_DIR)


### PR DESCRIPTION
# Description

This PR adds the `escape_dot` function to the Makefile so that secret keys containing dots (e.g., `tls.crt`) are correctly escaped when forming Kubernetes JSONPath expressions. Previously, the lack of an escape function caused the JSONPath to parse `tls.crt` as nested fields, leading to empty certificate files.

## Related Issue
https://github.com/microsoft/retina/issues/601 
`[hubble] make get-certs not working`


## Checklist

- [X] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [X] I have correctly attributed the author(s) of the code.
- [X] I have tested the changes locally.
- [X] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes
 Changes: 
- Implement `escape_dot` using `$(subst .,\\.,$(1))` in the Makefile
- Update the `get-certs` target to call `escape_dot` when retrieving secrets
- Fix empty cert issue caused by incorrect JSONPath queries
---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
