### PR TITLE
fix: ensure jq is installed and add coverage generation in GitHub Actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,7 @@ jobs:
 
       - name: Generate coverage
         run: |
+          pwd && ls -la
           make coverage
 
       - name: Upload Artifacts

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,13 +35,8 @@ jobs:
         run: |
           make test-image IMAGE_NAMESPACE=${{ github.repository }} PLATFORM=linux/amd64
 
-      - name: Generate coverage
-        run: |
-          pwd && ls -la
-          make coverage
-
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: coverage-files
-          path: ./coverage*
+          path: ./output/coverage*

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
+
 permissions:
   actions: read
   contents: read
@@ -15,6 +16,7 @@ permissions:
   pull-requests: write
   security-events: write
   issues: write
+
 jobs:
   test-image:
     runs-on: ubuntu-latest
@@ -32,6 +34,11 @@ jobs:
           PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           make test-image IMAGE_NAMESPACE=${{ github.repository }} PLATFORM=linux/amd64
+
+      - name: Generate coverage
+        run: |
+          make coverage
+
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -241,6 +241,7 @@ container-docker: buildx # util target to build container images using docker bu
 	image_metadata_filename="image-metadata-$$image_name-$(TAG).json"; \
 	touch $$image_metadata_filename; \
 	echo "Building $$image_name for $$os/$$arch "; \
+	mkdir -p $(OUTPUT_DIR); \
 	docker buildx build \
 		--platform $(PLATFORM) \
 		--metadata-file=$$image_metadata_filename \
@@ -253,6 +254,7 @@ container-docker: buildx # util target to build container images using docker bu
 		--build-arg VERSION=$(VERSION) $(EXTRA_BUILD_ARGS) \
 		--target=$(TARGET) \
 		-t $(IMAGE_REGISTRY)/$(IMAGE):$(TAG) \
+		--output type=local,dest=$(OUTPUT_DIR) \
 		$(BUILDX_ACTION) \
 		$(CONTEXT_DIR) 
 

--- a/test/image/Dockerfile
+++ b/test/image/Dockerfile
@@ -4,7 +4,7 @@ FROM mcr.microsoft.com/oss/go/microsoft/golang@sha256:88225e171f29fe5f1f6ffca8eb
 ENV CGO_ENABLED=0
 COPY . /go/src/github.com/microsoft/retina 
 WORKDIR /go/src/github.com/microsoft/retina
-RUN tdnf install -y clang16 lld16 bpftool libbpf-devel make git
+RUN tdnf install -y clang16 lld16 bpftool libbpf-devel make git jq
 RUN go generate /go/src/github.com/microsoft/retina/pkg/plugin/...
 # RUN go mod edit -module retina
 # RUN make all generate


### PR DESCRIPTION
# Description

This PR addresses two issues:
1. Ensuring that `jq` is installed before using it in the Makefile.
2. Adding a `make coverage` step in the GitHub Actions workflow to generate coverage files prior to uploading artifacts.

## Related Issue

https://github.com/microsoft/retina/issues/688 
`ci: minor bugs in "Test Retina Image" pipeline`

## Checklist

- [X] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [X] I have correctly attributed the author(s) of the code.
- [X] I have tested the changes locally.
- [X] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Changes
- Add a check in the Makefile to fail early if `jq` is not found on the system.
- Update the GitHub Actions workflow to run `make coverage` before the coverage artifacts are uploaded.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
