### PR TITLE
test: automate scale test execution

### DIFF
--- a/.github/workflows/daily-scale-test.yaml
+++ b/.github/workflows/daily-scale-test.yaml
@@ -1,0 +1,24 @@
+name: Daily Scale Test
+
+on:
+  push:
+    branches:
+      - alexcastilio/scale-test-workflow
+  schedule:
+    - cron: "0 0 * * *"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  call-scale-test:
+    uses: ./.github/workflows/scale-test.yaml
+    with: 
+      num_deployments: 1000
+      num_replicas: 20
+        # TODO: Fix values
+      num_netpol: 0
+      num_nodes: 1000
+      cleanup: false
+    secrets: inherit

--- a/.github/workflows/daily-scale-test.yaml
+++ b/.github/workflows/daily-scale-test.yaml
@@ -1,6 +1,9 @@
 name: Daily Scale Test
 
 on:
+  push:
+    branches:
+      - alexcastilio/scale-test-workflow
   schedule:
     - cron: "0 0 * * *"
 
@@ -16,5 +19,6 @@ jobs:
       num_replicas: 20
       num_netpol: 0
       num_nodes: 1000
-      cleanup: true
+      # TODO: Change to true after checking cluster
+      cleanup: false
     secrets: inherit

--- a/.github/workflows/daily-scale-test.yaml
+++ b/.github/workflows/daily-scale-test.yaml
@@ -1,9 +1,6 @@
 name: Daily Scale Test
 
 on:
-  push:
-    branches:
-      - alexcastilio/scale-test-workflow
   schedule:
     - cron: "0 0 * * *"
 
@@ -17,8 +14,7 @@ jobs:
     with: 
       num_deployments: 1000
       num_replicas: 20
-        # TODO: Fix values
       num_netpol: 0
       num_nodes: 1000
-      cleanup: false
+      cleanup: true
     secrets: inherit

--- a/.github/workflows/daily-scale-test.yaml
+++ b/.github/workflows/daily-scale-test.yaml
@@ -1,9 +1,6 @@
 name: Daily Scale Test
 
 on:
-  push:
-    branches:
-      - alexcastilio/scale-test-workflow
   schedule:
     - cron: "0 0 * * *"
 
@@ -19,6 +16,5 @@ jobs:
       num_replicas: 20
       num_netpol: 0
       num_nodes: 1000
-      # TODO: Change to true after checking cluster
-      cleanup: false
+      cleanup: true
     secrets: inherit

--- a/.github/workflows/scale-test.yaml
+++ b/.github/workflows/scale-test.yaml
@@ -15,7 +15,7 @@ on:
         description: "Image Namespace (if not set, default namespace will be used)"
         type: string
       image_tag:
-        description: "Image Tag (if not set, default for this commit will be used)"
+        description: "Image Tag (if not set, latest commit from 'main' will be used)"
         type: string
       num_deployments:
         description: "Number of Traffic Deployments"
@@ -36,25 +36,21 @@ on:
 
   workflow_call:
     inputs:
-      resource_group:
-        description: "Azure Resource Group"
-        required: true
-        type: string
-      cluster_name:
-        description: "AKS Cluster Name"
-        required: true
-        type: string
       num_deployments:
         description: "Number of Traffic Deployments"
-        default: 1000
+        default: 100
         type: number
       num_replicas:
         description: "Number of Traffic Replicas per Deployment"
-        default: 40
+        default: 10
         type: number
       num_netpol: 
         description: "Number of Network Policies"
-        default: 1000
+        default: 100
+        type: number
+      num_nodes:
+        description: "Number of nodes per pool"
+        default: 100
         type: number
       cleanup: 
         description: "Clean up environment after test"
@@ -100,8 +96,10 @@ jobs:
           IMAGE_NAMESPACE: ${{ inputs.image_namespace == '' && github.repository || inputs.image_namespace }}
           TAG: ${{ inputs.image_tag }}
           AZURE_APP_INSIGHTS_KEY: ${{ secrets.AZURE_APP_INSIGHTS_KEY }}
+          NODES: ${{ inputs.num_nodes }}
+          CREATE_INFRA: ${{ github.event_name != 'workflow_dispatch' }}
         shell: bash
         run: |
           set -euo pipefail
-          [[ $TAG == "" ]] && TAG=$(make version)
-          go test -v ./test/e2e/. -timeout 300m -tags=scale -count=1  -args -create-infra=false -delete-infra=false 
+          [[ $TAG == "" ]] && TAG=$(curl -s https://api.github.com/repos/microsoft/retina/commits | jq -r '.[0].sha' | cut -c1-7)
+          go test -v ./test/e2e/. -timeout 300m -tags=scale -count=1  -args -create-infra=$(echo $CREATE_INFRA) -delete-infra=$(echo $CREATE_INFRA)

--- a/.github/workflows/scale-test.yaml
+++ b/.github/workflows/scale-test.yaml
@@ -46,10 +46,10 @@ on:
         type: number
       num_netpol: 
         description: "Number of Network Policies"
-        default: 100
+        default: 0
         type: number
       num_nodes:
-        description: "Number of nodes per pool"
+        description: "Number of nodes"
         default: 100
         type: number
       cleanup: 
@@ -102,4 +102,4 @@ jobs:
         run: |
           set -euo pipefail
           [[ $TAG == "" ]] && TAG=$(curl -s https://api.github.com/repos/microsoft/retina/commits | jq -r '.[0].sha' | cut -c1-7)
-          go test -v ./test/e2e/. -timeout 300m -tags=scale -count=1  -args -create-infra=$(echo $CREATE_INFRA) -delete-infra=$(echo $CREATE_INFRA)
+          go test -v ./test/e2e/. -timeout 300m -tags=scale -count=1  -args -create-infra=$(echo $CREATE_INFRA) -delete-infra=$(echo $CLEANUP)

--- a/.github/workflows/scale-test.yaml
+++ b/.github/workflows/scale-test.yaml
@@ -102,4 +102,4 @@ jobs:
         run: |
           set -euo pipefail
           [[ $TAG == "" ]] && TAG=$(curl -s https://api.github.com/repos/microsoft/retina/commits | jq -r '.[0].sha' | cut -c1-7)
-          go test -v ./test/e2e/. -timeout 300m -tags=scale -count=1  -args -create-infra=$(echo $CREATE_INFRA) -delete-infra=$(echo $CLEANUP)
+          exec go test -v ./test/e2e/. -timeout 300m -tags=scale -count=1  -args -create-infra=$(echo $CREATE_INFRA) -delete-infra=$(echo $CLEANUP)

--- a/test/e2e/framework/azure/create-cluster.go
+++ b/test/e2e/framework/azure/create-cluster.go
@@ -3,6 +3,7 @@ package azure
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
@@ -23,6 +24,24 @@ type CreateCluster struct {
 	ResourceGroupName string
 	Location          string
 	ClusterName       string
+	podCidr           string
+	vmSize            string
+	networkPluginMode string
+	Nodes             int32
+}
+
+func (c *CreateCluster) SetPodCidr(podCidr string) *CreateCluster {
+	c.podCidr = podCidr
+	return c
+}
+
+func (c *CreateCluster) SetVMSize(vmSize string) *CreateCluster {
+	c.vmSize = vmSize
+	return c
+}
+func (c *CreateCluster) SetNetworkPluginMode(networkPluginMode string) *CreateCluster {
+	c.networkPluginMode = networkPluginMode
+	return c
 }
 
 func (c *CreateCluster) Run() error {
@@ -36,8 +55,30 @@ func (c *CreateCluster) Run() error {
 	if err != nil {
 		return fmt.Errorf("failed to create client: %w", err)
 	}
+	if c.Nodes == 0 {
+		c.Nodes = MaxNumberOfNodes
+	}
 
-	poller, err := clientFactory.NewManagedClustersClient().BeginCreateOrUpdate(ctx, c.ResourceGroupName, c.ClusterName, GetStarterClusterTemplate(c.Location), nil)
+	template := GetStarterClusterTemplate(c.Location)
+
+	if c.Nodes > 0 {
+		template.Properties.AgentPoolProfiles[0].Count = to.Ptr(c.Nodes)
+	}
+
+	if c.podCidr != "" {
+		template.Properties.NetworkProfile.PodCidr = to.Ptr(c.podCidr)
+	}
+
+	if c.vmSize != "" {
+		template.Properties.AgentPoolProfiles[0].VMSize = to.Ptr(c.vmSize)
+	}
+
+	if c.networkPluginMode != "" {
+		template.Properties.NetworkProfile.NetworkPluginMode = to.Ptr(armcontainerservice.NetworkPluginMode(c.networkPluginMode))
+	}
+
+	log.Printf("creating cluster %s in location %s...", c.ClusterName, c.Location)
+	poller, err := clientFactory.NewManagedClustersClient().BeginCreateOrUpdate(ctx, c.ResourceGroupName, c.ClusterName, template, nil)
 	if err != nil {
 		return fmt.Errorf("failed to finish the create cluster request: %w", err)
 	}
@@ -45,6 +86,7 @@ func (c *CreateCluster) Run() error {
 	if err != nil {
 		return fmt.Errorf("failed to pull the create cluster result: %w", err)
 	}
+	log.Printf("cluster created %s in location %s...", c.ClusterName, c.Location)
 
 	return nil
 }

--- a/test/e2e/framework/azure/create-cluster.go
+++ b/test/e2e/framework/azure/create-cluster.go
@@ -50,8 +50,7 @@ func (c *CreateCluster) Run() error {
 	if err != nil {
 		return fmt.Errorf("failed to obtain a credential: %w", err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), defaultClusterCreateTimeout)
-	defer cancel()
+	ctx := context.TODO()
 	clientFactory, err := armcontainerservice.NewClientFactory(c.SubscriptionID, cred, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create client: %w", err)

--- a/test/e2e/framework/azure/create-cluster.go
+++ b/test/e2e/framework/azure/create-cluster.go
@@ -39,6 +39,7 @@ func (c *CreateCluster) SetVMSize(vmSize string) *CreateCluster {
 	c.vmSize = vmSize
 	return c
 }
+
 func (c *CreateCluster) SetNetworkPluginMode(networkPluginMode string) *CreateCluster {
 	c.networkPluginMode = networkPluginMode
 	return c

--- a/test/e2e/framework/helpers/helpers.go
+++ b/test/e2e/framework/helpers/helpers.go
@@ -2,6 +2,8 @@ package helpers
 
 import (
 	"context"
+	"os/signal"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -20,5 +22,8 @@ func Context(t *testing.T) (context.Context, context.CancelFunc) {
 	// Subtract a minute from the deadline to ensure we have time to cleanup
 	deadline = deadline.Add(-time.Minute)
 
-	return context.WithDeadline(context.Background(), deadline)
+	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	ctx, cancel = signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
+
+	return ctx, cancel
 }

--- a/test/e2e/framework/helpers/helpers.go
+++ b/test/e2e/framework/helpers/helpers.go
@@ -22,7 +22,7 @@ func Context(t *testing.T) (context.Context, context.CancelFunc) {
 	// Subtract a minute from the deadline to ensure we have time to cleanup
 	deadline = deadline.Add(-time.Minute)
 
-	ctx, cancel := context.WithDeadline(context.Background(), deadline) //nolint: ineffassign // cancel is reassigned in next line
+	ctx, cancel := context.WithDeadline(context.Background(), deadline) //nolint:all // cancel is reassigned in next line
 	ctx, cancel = signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 
 	return ctx, cancel

--- a/test/e2e/framework/helpers/helpers.go
+++ b/test/e2e/framework/helpers/helpers.go
@@ -22,7 +22,7 @@ func Context(t *testing.T) (context.Context, context.CancelFunc) {
 	// Subtract a minute from the deadline to ensure we have time to cleanup
 	deadline = deadline.Add(-time.Minute)
 
-	ctx, cancel := context.WithDeadline(context.Background(), deadline)
+	ctx, cancel := context.WithDeadline(context.Background(), deadline) //nolint: ineffassign // cancel is reassigned in next line
 	ctx, cancel = signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
 
 	return ctx, cancel

--- a/test/e2e/framework/kubernetes/check-pod-status.go
+++ b/test/e2e/framework/kubernetes/check-pod-status.go
@@ -14,14 +14,14 @@ import (
 )
 
 const (
-	RetryTimeoutPodsReady     = 5 * time.Minute
-	RetryIntervalPodsReady    = 5 * time.Second
-	timeoutWaitForPodsSeconds = 1200
+	RetryTimeoutPodsReady  = 5 * time.Minute
+	RetryIntervalPodsReady = 5 * time.Second
 
 	printInterval = 5 // print to stdout every 5 iterations
 )
 
 type WaitPodsReady struct {
+	Ctx                context.Context
 	KubeConfigFilePath string
 	Namespace          string
 	LabelSelector      string
@@ -49,10 +49,7 @@ func (w *WaitPodsReady) Run() error {
 		return fmt.Errorf("error creating Kubernetes client: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeoutWaitForPodsSeconds*time.Second)
-	defer cancel()
-
-	return WaitForPodReady(ctx, clientset, w.Namespace, w.LabelSelector)
+	return WaitForPodReady(w.Ctx, clientset, w.Namespace, w.LabelSelector)
 }
 
 // Require for background steps

--- a/test/e2e/framework/kubernetes/check-pod-status.go
+++ b/test/e2e/framework/kubernetes/check-pod-status.go
@@ -14,9 +14,8 @@ import (
 )
 
 const (
-	RetryTimeoutPodsReady     = 5 * time.Minute
-	RetryIntervalPodsReady    = 5 * time.Second
-	timeoutWaitForPodsSeconds = 1200
+	RetryTimeoutPodsReady  = 5 * time.Minute
+	RetryIntervalPodsReady = 5 * time.Second
 
 	printInterval = 5 // print to stdout every 5 iterations
 )
@@ -49,8 +48,7 @@ func (w *WaitPodsReady) Run() error {
 		return fmt.Errorf("error creating Kubernetes client: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeoutWaitForPodsSeconds*time.Second)
-	defer cancel()
+	ctx := context.TODO()
 
 	return WaitForPodReady(ctx, clientset, w.Namespace, w.LabelSelector)
 }

--- a/test/e2e/framework/kubernetes/check-pod-status.go
+++ b/test/e2e/framework/kubernetes/check-pod-status.go
@@ -14,14 +14,14 @@ import (
 )
 
 const (
-	RetryTimeoutPodsReady  = 5 * time.Minute
-	RetryIntervalPodsReady = 5 * time.Second
+	RetryTimeoutPodsReady     = 5 * time.Minute
+	RetryIntervalPodsReady    = 5 * time.Second
+	timeoutWaitForPodsSeconds = 1200
 
 	printInterval = 5 // print to stdout every 5 iterations
 )
 
 type WaitPodsReady struct {
-	Ctx                context.Context
 	KubeConfigFilePath string
 	Namespace          string
 	LabelSelector      string
@@ -49,7 +49,10 @@ func (w *WaitPodsReady) Run() error {
 		return fmt.Errorf("error creating Kubernetes client: %w", err)
 	}
 
-	return WaitForPodReady(w.Ctx, clientset, w.Namespace, w.LabelSelector)
+	ctx, cancel := context.WithTimeout(context.Background(), timeoutWaitForPodsSeconds*time.Second)
+	defer cancel()
+
+	return WaitForPodReady(ctx, clientset, w.Namespace, w.LabelSelector)
 }
 
 // Require for background steps

--- a/test/e2e/framework/kubernetes/create-kapinger-deployment.go
+++ b/test/e2e/framework/kubernetes/create-kapinger-deployment.go
@@ -138,7 +138,7 @@ func (c *CreateKapingerDeployment) GetKapingerDeployment() *appsv1.Deployment {
 									"memory": resource.MustParse("20Mi"),
 								},
 								Limits: v1.ResourceList{
-									"memory": resource.MustParse("100Mi"),
+									"memory": resource.MustParse("20Mi"),
 								},
 							},
 							Ports: []v1.ContainerPort{

--- a/test/e2e/framework/kubernetes/create-kapinger-deployment.go
+++ b/test/e2e/framework/kubernetes/create-kapinger-deployment.go
@@ -132,7 +132,7 @@ func (c *CreateKapingerDeployment) GetKapingerDeployment() *appsv1.Deployment {
 					Containers: []v1.Container{
 						{
 							Name:  "kapinger",
-							Image: "acnpublic.azurecr.io/kapinger:20241014.7",
+							Image: "acnpublic.azurecr.io/kapinger:v0.0.23-9-g23ef222",
 							Resources: v1.ResourceRequirements{
 								Requests: v1.ResourceList{
 									"memory": resource.MustParse("20Mi"),

--- a/test/e2e/framework/kubernetes/create-kapinger-deployment.go
+++ b/test/e2e/framework/kubernetes/create-kapinger-deployment.go
@@ -138,7 +138,7 @@ func (c *CreateKapingerDeployment) GetKapingerDeployment() *appsv1.Deployment {
 									"memory": resource.MustParse("20Mi"),
 								},
 								Limits: v1.ResourceList{
-									"memory": resource.MustParse("20Mi"),
+									"memory": resource.MustParse("40Mi"),
 								},
 							},
 							Ports: []v1.ContainerPort{

--- a/test/e2e/framework/kubernetes/create-namespace.go
+++ b/test/e2e/framework/kubernetes/create-namespace.go
@@ -3,7 +3,6 @@ package kubernetes
 import (
 	"context"
 	"fmt"
-	"time"
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -52,8 +51,7 @@ func CreateNamespaceFn(kubeconfigpath, namespace string) error {
 		return fmt.Errorf("error creating Kubernetes client: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeoutSeconds*time.Second)
-	defer cancel()
+	ctx := context.TODO()
 
 	_, err = clientset.CoreV1().Namespaces().Create(ctx, &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/framework/kubernetes/delete-namespace.go
+++ b/test/e2e/framework/kubernetes/delete-namespace.go
@@ -30,8 +30,7 @@ func (d *DeleteNamespace) Run() error {
 		return fmt.Errorf("error creating Kubernetes client: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1200*time.Second)
-	defer cancel()
+	ctx := context.TODO()
 
 	err = clientset.CoreV1().Namespaces().Delete(ctx, d.Namespace, metaV1.DeleteOptions{})
 	if err != nil {

--- a/test/e2e/framework/kubernetes/label-nodes.go
+++ b/test/e2e/framework/kubernetes/label-nodes.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"time"
 
 	retry "github.com/microsoft/retina/test/retry"
 	corev1 "k8s.io/api/core/v1"
@@ -41,8 +40,7 @@ func (l *LabelNodes) Run() error {
 		return fmt.Errorf("error creating Kubernetes client: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
-	defer cancel()
+	ctx := context.TODO()
 
 	var nodes *corev1.NodeList
 

--- a/test/e2e/framework/kubernetes/label-nodes.go
+++ b/test/e2e/framework/kubernetes/label-nodes.go
@@ -47,7 +47,7 @@ func (l *LabelNodes) Run() error {
 	var nodes *corev1.NodeList
 
 	retrier := retry.Retrier{Attempts: defaultRetryAttempts, Delay: defaultRetryDelay}
-	retrier.Do(ctx, func() error {
+	err = retrier.Do(ctx, func() error {
 		nodes, err = clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to get nodes: %w", err)
@@ -73,7 +73,7 @@ func (l *LabelNodes) Run() error {
 
 	for i := range nodes.Items {
 		log.Println("Labeling node", nodes.Items[i].Name)
-		retrier.Do(ctx, func() error {
+		err = retrier.Do(ctx, func() error {
 			_, err = clientset.CoreV1().Nodes().Patch(ctx, nodes.Items[i].Name, types.JSONPatchType, b, metav1.PatchOptions{})
 			if err != nil {
 				return fmt.Errorf("failed to patch pod: %w", err)

--- a/test/e2e/framework/kubernetes/label-nodes.go
+++ b/test/e2e/framework/kubernetes/label-nodes.go
@@ -41,7 +41,7 @@ func (l *LabelNodes) Run() error {
 		return fmt.Errorf("error creating Kubernetes client: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeoutSeconds*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
 	var nodes *corev1.NodeList

--- a/test/e2e/framework/kubernetes/label-nodes.go
+++ b/test/e2e/framework/kubernetes/label-nodes.go
@@ -1,0 +1,76 @@
+package kubernetes
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type patchStringValue struct {
+	Op    string `json:"op"`
+	Path  string `json:"path"`
+	Value string `json:"value"`
+}
+
+type LabelNodes struct {
+	KubeConfigFilePath string
+	Labels             map[string]string
+}
+
+func (l *LabelNodes) Prevalidate() error {
+	return nil
+}
+
+func (l *LabelNodes) Run() error {
+	config, err := clientcmd.BuildConfigFromFlags("", l.KubeConfigFilePath)
+	if err != nil {
+		return fmt.Errorf("error building kubeconfig: %w", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("error creating Kubernetes client: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeoutSeconds*time.Second)
+	defer cancel()
+
+	nodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to get nodes: %w", err)
+	}
+
+	patch := []patchStringValue{}
+	for k, v := range l.Labels {
+		patch = append(patch, patchStringValue{
+			Op:    "add",
+			Path:  "/metadata/labels/" + k,
+			Value: v,
+		})
+	}
+	b, err := json.Marshal(patch)
+	if err != nil {
+		return fmt.Errorf("failed to marshal patch: %w", err)
+	}
+
+	for i := range nodes.Items {
+		log.Println("Labeling node", nodes.Items[i].Name)
+		_, err = clientset.CoreV1().Nodes().Patch(ctx, nodes.Items[i].Name, types.JSONPatchType, b, metav1.PatchOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to patch pod: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (l *LabelNodes) Stop() error {
+	return nil
+}

--- a/test/e2e/framework/params/params.go
+++ b/test/e2e/framework/params/params.go
@@ -1,0 +1,17 @@
+package params
+
+import (
+	"os"
+)
+
+var (
+	Location           = os.Getenv("LOCATION")
+	SubscriptionID     = os.Getenv("AZURE_SUBSCRIPTION_ID")
+	ResourceGroup      = os.Getenv("AZURE_RESOURCE_GROUP")
+	ClusterName        = os.Getenv("CLUSTER_NAME")
+	Nodes              = os.Getenv("NODES")
+	NumDeployments     = os.Getenv("NUM_DEPLOYMENTS")
+	NumReplicas        = os.Getenv("NUM_REPLICAS")
+	NumNetworkPolicies = os.Getenv("NUM_NET_POL")
+	CleanUp            = os.Getenv("CLEANUP")
+)

--- a/test/e2e/framework/scaletest/add-shared-labels.go
+++ b/test/e2e/framework/scaletest/add-shared-labels.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -51,8 +50,7 @@ func (a *AddSharedLabelsToAllPods) Run() error {
 		return fmt.Errorf("error creating Kubernetes client: %w", err)
 	}
 
-	ctx, cancel := contextToLabelAllPods()
-	defer cancel()
+	ctx := context.TODO()
 
 	resources, err := clientset.CoreV1().Pods(a.Namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -108,8 +106,4 @@ func getSharedLabelsPatch(numLabels int) ([]byte, error) {
 	}
 
 	return b, nil
-}
-
-func contextToLabelAllPods() (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.Background(), 120*time.Minute)
 }

--- a/test/e2e/framework/scaletest/add-shared-labels.go
+++ b/test/e2e/framework/scaletest/add-shared-labels.go
@@ -53,6 +53,9 @@ func (a *AddSharedLabelsToAllPods) Run() error {
 	}
 
 	resources, err := clientset.CoreV1().Pods(a.Namespace).List(a.Ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list pods: %w", err)
+	}
 
 	patchBytes, err := getSharedLabelsPatch(a.NumSharedLabelsPerPod)
 	if err != nil {

--- a/test/e2e/framework/scaletest/add-unique-labels.go
+++ b/test/e2e/framework/scaletest/add-unique-labels.go
@@ -44,6 +44,9 @@ func (a *AddUniqueLabelsToAllPods) Run() error {
 	}
 
 	resources, err := clientset.CoreV1().Pods(a.Namespace).List(a.Ctx, metav1.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list pods: %w", err)
+	}
 
 	count := 0
 

--- a/test/e2e/framework/scaletest/add-unique-labels.go
+++ b/test/e2e/framework/scaletest/add-unique-labels.go
@@ -1,6 +1,7 @@
 package scaletest
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -41,8 +42,7 @@ func (a *AddUniqueLabelsToAllPods) Run() error {
 		return fmt.Errorf("error creating Kubernetes client: %w", err)
 	}
 
-	ctx, cancel := contextToLabelAllPods()
-	defer cancel()
+	ctx := context.TODO()
 
 	resources, err := clientset.CoreV1().Pods(a.Namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {

--- a/test/e2e/framework/scaletest/add-unique-labels.go
+++ b/test/e2e/framework/scaletest/add-unique-labels.go
@@ -1,6 +1,7 @@
 package scaletest
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -10,6 +11,7 @@ import (
 )
 
 type AddUniqueLabelsToAllPods struct {
+	Ctx                   context.Context
 	KubeConfigFilePath    string
 	NumUniqueLabelsPerPod int
 	Namespace             string
@@ -41,10 +43,7 @@ func (a *AddUniqueLabelsToAllPods) Run() error {
 		return fmt.Errorf("error creating Kubernetes client: %w", err)
 	}
 
-	ctx, cancel := contextToLabelAllPods()
-	defer cancel()
-
-	resources, err := clientset.CoreV1().Pods(a.Namespace).List(ctx, metav1.ListOptions{})
+	resources, err := clientset.CoreV1().Pods(a.Namespace).List(a.Ctx, metav1.ListOptions{})
 
 	count := 0
 
@@ -64,7 +63,7 @@ func (a *AddUniqueLabelsToAllPods) Run() error {
 			return fmt.Errorf("failed to marshal patch: %w", err)
 		}
 
-		err = patchLabel(ctx, clientset, a.Namespace, resource.Name, patchBytes)
+		err = patchLabel(a.Ctx, clientset, a.Namespace, resource.Name, patchBytes)
 		if err != nil {
 			return fmt.Errorf("error adding unique label to pod: %w", err)
 		}

--- a/test/e2e/framework/scaletest/create-network-policies.go
+++ b/test/e2e/framework/scaletest/create-network-policies.go
@@ -16,6 +16,7 @@ import (
 )
 
 type CreateNetworkPolicies struct {
+	Ctx                         context.Context
 	KubeConfigFilePath          string
 	Namespace                   string
 	NumNetworkPolicies          int
@@ -45,7 +46,7 @@ func (c *CreateNetworkPolicies) Run() error {
 		return fmt.Errorf("error creating Kubernetes client: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeoutSeconds*time.Second)
+	ctx, cancel := context.WithTimeout(c.Ctx, defaultTimeoutSeconds*time.Second)
 	defer cancel()
 
 	networkPolicies := c.generateNetworkPolicies(c.NumNetworkPolicies)

--- a/test/e2e/framework/scaletest/create-network-policies.go
+++ b/test/e2e/framework/scaletest/create-network-policies.go
@@ -16,7 +16,6 @@ import (
 )
 
 type CreateNetworkPolicies struct {
-	Ctx                         context.Context
 	KubeConfigFilePath          string
 	Namespace                   string
 	NumNetworkPolicies          int
@@ -46,7 +45,7 @@ func (c *CreateNetworkPolicies) Run() error {
 		return fmt.Errorf("error creating Kubernetes client: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(c.Ctx, defaultTimeoutSeconds*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeoutSeconds*time.Second)
 	defer cancel()
 
 	networkPolicies := c.generateNetworkPolicies(c.NumNetworkPolicies)

--- a/test/e2e/framework/scaletest/create-network-policies.go
+++ b/test/e2e/framework/scaletest/create-network-policies.go
@@ -3,7 +3,6 @@ package scaletest
 import (
 	"context"
 	"fmt"
-	"time"
 
 	e2ekubernetes "github.com/microsoft/retina/test/e2e/framework/kubernetes"
 
@@ -45,8 +44,7 @@ func (c *CreateNetworkPolicies) Run() error {
 		return fmt.Errorf("error creating Kubernetes client: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeoutSeconds*time.Second)
-	defer cancel()
+	ctx := context.TODO()
 
 	networkPolicies := c.generateNetworkPolicies(c.NumNetworkPolicies)
 

--- a/test/e2e/framework/scaletest/create-resources.go
+++ b/test/e2e/framework/scaletest/create-resources.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"time"
 
 	e2ekubernetes "github.com/microsoft/retina/test/e2e/framework/kubernetes"
 	"github.com/microsoft/retina/test/retry"
@@ -14,6 +13,7 @@ import (
 )
 
 type CreateResources struct {
+	Ctx                          context.Context
 	Namespace                    string
 	KubeConfigFilePath           string
 	NumKwokDeployments           int
@@ -49,14 +49,11 @@ func (c *CreateResources) Run() error {
 		return fmt.Errorf("error creating Kubernetes client: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1800*time.Second)
-	defer cancel()
-
 	retrier := retry.Retrier{Attempts: defaultRetryAttempts, Delay: defaultRetryDelay}
 
 	for _, resource := range resources {
-		err := retrier.Do(ctx, func() error {
-			return e2ekubernetes.CreateResource(ctx, resource, clientset)
+		err := retrier.Do(c.Ctx, func() error {
+			return e2ekubernetes.CreateResource(c.Ctx, resource, clientset)
 		})
 		if err != nil {
 			return fmt.Errorf("error creating resource: %w", err)

--- a/test/e2e/framework/scaletest/create-resources.go
+++ b/test/e2e/framework/scaletest/create-resources.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"time"
 
 	e2ekubernetes "github.com/microsoft/retina/test/e2e/framework/kubernetes"
 	"github.com/microsoft/retina/test/retry"
@@ -49,8 +48,7 @@ func (c *CreateResources) Run() error {
 		return fmt.Errorf("error creating Kubernetes client: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1800*time.Second)
-	defer cancel()
+	ctx := context.TODO()
 
 	retrier := retry.Retrier{Attempts: defaultRetryAttempts, Delay: defaultRetryDelay}
 

--- a/test/e2e/framework/scaletest/create-resources.go
+++ b/test/e2e/framework/scaletest/create-resources.go
@@ -49,7 +49,7 @@ func (c *CreateResources) Run() error {
 		return fmt.Errorf("error creating Kubernetes client: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1200*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 1800*time.Second)
 	defer cancel()
 
 	retrier := retry.Retrier{Attempts: defaultRetryAttempts, Delay: defaultRetryDelay}

--- a/test/e2e/framework/scaletest/delete-and-re-add-labels.go
+++ b/test/e2e/framework/scaletest/delete-and-re-add-labels.go
@@ -35,7 +35,6 @@ func (d *DeleteAndReAddLabels) Prevalidate() error {
 // Primary step where test logic is executed
 // Returning an error will cause the test to fail
 func (d *DeleteAndReAddLabels) Run() error {
-
 	if d.NumSharedLabelsPerPod <= 2 || !d.DeleteLabels {
 		return nil
 	}
@@ -60,7 +59,7 @@ func (d *DeleteAndReAddLabels) Run() error {
 
 	retrier := retry.Retrier{Attempts: defaultRetryAttempts, Delay: defaultRetryDelay}
 
-	retrier.Do(ctx, func() error {
+	err = retrier.Do(ctx, func() error {
 		pods, err = clientset.CoreV1().Pods(d.Namespace).List(ctx, metav1.ListOptions{})
 		if err != nil {
 			return fmt.Errorf("failed to list pods: %w", err)
@@ -101,7 +100,6 @@ func (d *DeleteAndReAddLabels) Run() error {
 }
 
 func (d *DeleteAndReAddLabels) addLabels(ctx context.Context, clientset *kubernetes.Clientset, pods *corev1.PodList, patch string) error {
-
 	for _, pod := range pods.Items {
 		log.Println("Labeling Pod", pod.Name)
 
@@ -113,7 +111,6 @@ func (d *DeleteAndReAddLabels) addLabels(ctx context.Context, clientset *kuberne
 			}
 			return nil
 		})
-
 		if err != nil {
 			return fmt.Errorf("could not patch pod: %w", err)
 		}
@@ -135,7 +132,6 @@ func (d *DeleteAndReAddLabels) deleteLabels(ctx context.Context, clientset *kube
 			}
 			return nil
 		})
-
 		if err != nil {
 			return fmt.Errorf("could not patch pod: %w", err)
 		}

--- a/test/e2e/framework/scaletest/delete-and-re-add-labels.go
+++ b/test/e2e/framework/scaletest/delete-and-re-add-labels.go
@@ -48,8 +48,7 @@ func (d *DeleteAndReAddLabels) Run() error {
 		return fmt.Errorf("error creating Kubernetes client: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+	ctx := context.TODO()
 
 	labelsToDelete := `"shared-lab-00000": null, "shared-lab-00001": null, "shared-lab-00002": null`
 	labelsToAdd := `"shared-lab-00000": "val", "shared-lab-00001": "val", "shared-lab-00002": "val"`
@@ -74,9 +73,6 @@ func (d *DeleteAndReAddLabels) Run() error {
 
 		patch := fmt.Sprintf(`{"metadata": {"labels": {%s}}}`, labelsToDelete)
 
-		ctx, cancel = contextToLabelAllPods()
-		defer cancel()
-
 		err = d.deleteLabels(ctx, clientset, pods, patch)
 		if err != nil {
 			return fmt.Errorf("error deleting labels: %w", err)
@@ -88,9 +84,6 @@ func (d *DeleteAndReAddLabels) Run() error {
 		log.Printf("Re-adding labels. Round %d/%d", i+1, d.DeleteLabelsTimes)
 
 		patch = fmt.Sprintf(`{"metadata": {"labels": {%s}}}`, labelsToAdd)
-
-		ctx, cancel = contextToLabelAllPods()
-		defer cancel()
 
 		err = d.addLabels(ctx, clientset, pods, patch)
 		if err != nil {

--- a/test/e2e/framework/scaletest/delete-and-re-add-labels.go
+++ b/test/e2e/framework/scaletest/delete-and-re-add-labels.go
@@ -15,6 +15,7 @@ import (
 )
 
 type DeleteAndReAddLabels struct {
+	Ctx                   context.Context
 	KubeConfigFilePath    string
 	NumSharedLabelsPerPod int
 	DeleteLabels          bool
@@ -49,7 +50,7 @@ func (d *DeleteAndReAddLabels) Run() error {
 		return fmt.Errorf("error creating Kubernetes client: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(d.Ctx, 10*time.Second)
 	defer cancel()
 
 	labelsToDelete := `"shared-lab-00000": null, "shared-lab-00001": null, "shared-lab-00002": null`
@@ -75,10 +76,7 @@ func (d *DeleteAndReAddLabels) Run() error {
 
 		patch := fmt.Sprintf(`{"metadata": {"labels": {%s}}}`, labelsToDelete)
 
-		ctx, cancel = contextToLabelAllPods()
-		defer cancel()
-
-		err = d.deleteLabels(ctx, clientset, pods, patch)
+		err = d.deleteLabels(d.Ctx, clientset, pods, patch)
 		if err != nil {
 			return fmt.Errorf("error deleting labels: %w", err)
 		}
@@ -90,10 +88,7 @@ func (d *DeleteAndReAddLabels) Run() error {
 
 		patch = fmt.Sprintf(`{"metadata": {"labels": {%s}}}`, labelsToAdd)
 
-		ctx, cancel = contextToLabelAllPods()
-		defer cancel()
-
-		err = d.addLabels(ctx, clientset, pods, patch)
+		err = d.addLabels(d.Ctx, clientset, pods, patch)
 		if err != nil {
 			return fmt.Errorf("error adding labels: %w", err)
 		}

--- a/test/e2e/framework/scaletest/get-publish-metrics.go
+++ b/test/e2e/framework/scaletest/get-publish-metrics.go
@@ -31,7 +31,6 @@ const (
 )
 
 type GetAndPublishMetrics struct {
-	Ctx                         context.Context
 	KubeConfigFilePath          string
 	AdditionalTelemetryProperty map[string]string
 	Labels                      map[string]string
@@ -137,7 +136,7 @@ func (g *GetAndPublishMetrics) Prevalidate() error {
 
 func (g *GetAndPublishMetrics) getAndPublishMetrics() error {
 
-	ctx, cancel := context.WithTimeout(g.Ctx, defaultTimeoutSeconds*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeoutSeconds*time.Second)
 	defer cancel()
 
 	labelSelector := labels.Set(g.Labels).String()

--- a/test/e2e/framework/scaletest/get-publish-metrics.go
+++ b/test/e2e/framework/scaletest/get-publish-metrics.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	defaultRetryAttempts = 10
-	defaultRetryDelay    = 500 * time.Millisecond
+	defaultRetryDelay    = 3 * time.Second
 	defaultInterval      = 2 * time.Minute
 )
 

--- a/test/e2e/framework/scaletest/get-publish-metrics.go
+++ b/test/e2e/framework/scaletest/get-publish-metrics.go
@@ -136,8 +136,7 @@ func (g *GetAndPublishMetrics) Prevalidate() error {
 
 func (g *GetAndPublishMetrics) getAndPublishMetrics() error {
 
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeoutSeconds*time.Second)
-	defer cancel()
+	ctx := context.TODO()
 
 	labelSelector := labels.Set(g.Labels).String()
 

--- a/test/e2e/framework/scaletest/get-publish-metrics.go
+++ b/test/e2e/framework/scaletest/get-publish-metrics.go
@@ -31,6 +31,7 @@ const (
 )
 
 type GetAndPublishMetrics struct {
+	Ctx                         context.Context
 	KubeConfigFilePath          string
 	AdditionalTelemetryProperty map[string]string
 	Labels                      map[string]string
@@ -136,7 +137,7 @@ func (g *GetAndPublishMetrics) Prevalidate() error {
 
 func (g *GetAndPublishMetrics) getAndPublishMetrics() error {
 
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeoutSeconds*time.Second)
+	ctx, cancel := context.WithTimeout(g.Ctx, defaultTimeoutSeconds*time.Second)
 	defer cancel()
 
 	labelSelector := labels.Set(g.Labels).String()

--- a/test/e2e/framework/scaletest/options.go
+++ b/test/e2e/framework/scaletest/options.go
@@ -1,13 +1,9 @@
 package scaletest
 
-import (
-	"context"
-	"time"
-)
+import "time"
 
 // Options holds parameters for the scale test
 type Options struct {
-	Ctx                           context.Context
 	Namespace                     string
 	MaxKwokPodsPerNode            int
 	NumKwokDeployments            int

--- a/test/e2e/framework/scaletest/options.go
+++ b/test/e2e/framework/scaletest/options.go
@@ -1,9 +1,13 @@
 package scaletest
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // Options holds parameters for the scale test
 type Options struct {
+	Ctx                           context.Context
 	Namespace                     string
 	MaxKwokPodsPerNode            int
 	NumKwokDeployments            int

--- a/test/e2e/framework/scaletest/validate-nodes.go
+++ b/test/e2e/framework/scaletest/validate-nodes.go
@@ -3,17 +3,12 @@ package scaletest
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
-)
-
-const (
-	defaultTimeoutSeconds = 300
 )
 
 type ValidateNumOfNodes struct {
@@ -43,8 +38,7 @@ func (v *ValidateNumOfNodes) Run() error {
 		return fmt.Errorf("error creating Kubernetes client: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeoutSeconds*time.Second)
-	defer cancel()
+	ctx := context.TODO()
 
 	labelSelector := labels.Set(v.Label).String()
 	nodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{LabelSelector: labelSelector})

--- a/test/e2e/framework/types/runner.go
+++ b/test/e2e/framework/types/runner.go
@@ -33,7 +33,7 @@ func (r *Runner) Run(ctx context.Context) {
 	}()
 	select {
 	case <-ctx.Done():
-		r.t.Fatal("Test deadline exceeded. If more time is needed, set -timeout flag to a higher value")
+		r.t.Fatal("Failed to complete execution:", ctx.Err())
 	case err := <-runComplete:
 		require.NoError(r.t, err)
 	}

--- a/test/e2e/jobs/scale.go
+++ b/test/e2e/jobs/scale.go
@@ -59,7 +59,7 @@ func GetScaleTestInfra(subID, rg, clusterName, location, kubeConfigFilePath stri
 
 		job.AddStep((&azure.CreateCluster{
 			ClusterName: clusterName,
-			Nodes: nodes,
+			Nodes:       nodes,
 		}).
 			SetPodCidr("100.64.0.0/10").
 			SetVMSize("Standard_D4_v3").

--- a/test/e2e/jobs/scale.go
+++ b/test/e2e/jobs/scale.go
@@ -59,7 +59,7 @@ func GetScaleTestInfra(subID, rg, clusterName, location, kubeConfigFilePath stri
 
 		job.AddStep((&azure.CreateCluster{
 			ClusterName: clusterName,
-			Nodes:       nodes,
+			Nodes: nodes,
 		}).
 			SetPodCidr("100.64.0.0/10").
 			SetVMSize("Standard_D4_v3").
@@ -115,7 +115,6 @@ func ScaleTest(opt *scaletest.Options) *types.Job {
 	// There's a known limitation on leaving empty fields in Steps.
 	// Set methods are used to set private fields and keep environment variables accessed within jobs, rather then spread through steps.
 	job.AddStep((&scaletest.GetAndPublishMetrics{
-		Ctx:                         opt.Ctx,
 		Labels:                      opt.LabelsToGetMetrics,
 		AdditionalTelemetryProperty: opt.AdditionalTelemetryProperty,
 	}).
@@ -127,7 +126,6 @@ func ScaleTest(opt *scaletest.Options) *types.Job {
 		})
 
 	job.AddStep(&scaletest.CreateResources{
-		Ctx:                          opt.Ctx,
 		NumKwokDeployments:           opt.NumKwokDeployments,
 		NumKwokReplicas:              opt.NumKwokReplicas,
 		RealPodType:                  opt.RealPodType,
@@ -138,29 +136,24 @@ func ScaleTest(opt *scaletest.Options) *types.Job {
 	}, nil)
 
 	job.AddStep(&scaletest.AddSharedLabelsToAllPods{
-		Ctx:                   opt.Ctx,
 		NumSharedLabelsPerPod: opt.NumSharedLabelsPerPod,
 	}, nil)
 
 	job.AddStep(&scaletest.AddUniqueLabelsToAllPods{
-		Ctx:                   opt.Ctx,
 		NumUniqueLabelsPerPod: opt.NumUniqueLabelsPerPod,
 	}, nil)
 
 	// Apply network policies (applied and unapplied)
 	job.AddStep(&scaletest.CreateNetworkPolicies{
-		Ctx:                   opt.Ctx,
 		NumNetworkPolicies:    opt.NumNetworkPolicies,
 		NumSharedLabelsPerPod: opt.NumSharedLabelsPerPod,
 	}, nil)
 
 	job.AddStep(&kubernetes.WaitPodsReady{
-		Ctx:           opt.Ctx,
 		LabelSelector: "is-real=true",
 	}, nil)
 
 	job.AddStep(&scaletest.DeleteAndReAddLabels{
-		Ctx:                   opt.Ctx,
 		DeleteLabels:          opt.DeleteLabels,
 		DeleteLabelsInterval:  opt.DeleteLabelsInterval,
 		DeleteLabelsTimes:     opt.DeleteLabelsTimes,

--- a/test/e2e/jobs/scale.go
+++ b/test/e2e/jobs/scale.go
@@ -59,7 +59,7 @@ func GetScaleTestInfra(subID, rg, clusterName, location, kubeConfigFilePath stri
 
 		job.AddStep((&azure.CreateCluster{
 			ClusterName: clusterName,
-			Nodes: nodes,
+			Nodes:       nodes,
 		}).
 			SetPodCidr("100.64.0.0/10").
 			SetVMSize("Standard_D4_v3").
@@ -115,6 +115,7 @@ func ScaleTest(opt *scaletest.Options) *types.Job {
 	// There's a known limitation on leaving empty fields in Steps.
 	// Set methods are used to set private fields and keep environment variables accessed within jobs, rather then spread through steps.
 	job.AddStep((&scaletest.GetAndPublishMetrics{
+		Ctx:                         opt.Ctx,
 		Labels:                      opt.LabelsToGetMetrics,
 		AdditionalTelemetryProperty: opt.AdditionalTelemetryProperty,
 	}).
@@ -126,6 +127,7 @@ func ScaleTest(opt *scaletest.Options) *types.Job {
 		})
 
 	job.AddStep(&scaletest.CreateResources{
+		Ctx:                          opt.Ctx,
 		NumKwokDeployments:           opt.NumKwokDeployments,
 		NumKwokReplicas:              opt.NumKwokReplicas,
 		RealPodType:                  opt.RealPodType,
@@ -136,24 +138,29 @@ func ScaleTest(opt *scaletest.Options) *types.Job {
 	}, nil)
 
 	job.AddStep(&scaletest.AddSharedLabelsToAllPods{
+		Ctx:                   opt.Ctx,
 		NumSharedLabelsPerPod: opt.NumSharedLabelsPerPod,
 	}, nil)
 
 	job.AddStep(&scaletest.AddUniqueLabelsToAllPods{
+		Ctx:                   opt.Ctx,
 		NumUniqueLabelsPerPod: opt.NumUniqueLabelsPerPod,
 	}, nil)
 
 	// Apply network policies (applied and unapplied)
 	job.AddStep(&scaletest.CreateNetworkPolicies{
+		Ctx:                   opt.Ctx,
 		NumNetworkPolicies:    opt.NumNetworkPolicies,
 		NumSharedLabelsPerPod: opt.NumSharedLabelsPerPod,
 	}, nil)
 
 	job.AddStep(&kubernetes.WaitPodsReady{
+		Ctx:           opt.Ctx,
 		LabelSelector: "is-real=true",
 	}, nil)
 
 	job.AddStep(&scaletest.DeleteAndReAddLabels{
+		Ctx:                   opt.Ctx,
 		DeleteLabels:          opt.DeleteLabels,
 		DeleteLabelsInterval:  opt.DeleteLabelsInterval,
 		DeleteLabelsTimes:     opt.DeleteLabelsTimes,

--- a/test/e2e/scale_test.go
+++ b/test/e2e/scale_test.go
@@ -42,7 +42,6 @@ func TestE2ERetina_Scale(t *testing.T) {
 	// Scale test parameters
 	opt := jobs.DefaultScaleTestOptions()
 	opt.KubeconfigPath = common.KubeConfigFilePath(rootDir)
-	opt.Ctx = ctx
 
 	NumDeployments := params.NumDeployments
 	NumReplicas := params.NumReplicas

--- a/test/e2e/scale_test.go
+++ b/test/e2e/scale_test.go
@@ -42,6 +42,7 @@ func TestE2ERetina_Scale(t *testing.T) {
 	// Scale test parameters
 	opt := jobs.DefaultScaleTestOptions()
 	opt.KubeconfigPath = common.KubeConfigFilePath(rootDir)
+	opt.Ctx = ctx
 
 	NumDeployments := params.NumDeployments
 	NumReplicas := params.NumReplicas


### PR DESCRIPTION
# Description

Create automation workflow to run scale test automatically. Initially to keep it simpler, it will be executed daily with latest commit from main. In future it can be changed to run at merge if desired.
Current Scale test configuration is 1000 deployments of 20 replicas of kapinger pods running on a cluster of 1000 nodes. The cluster will be created and deleted at each automatic execution.

Changes in this PR:
* Creation of workflow for daily execution
* Add code to create Scale Test cluster
* Simplify environment variables handling by doing it in `params` package 
* Update kapinger version
* Update kapinger memory limit
* Update context handling in scale test steps (improve flakiness of test)
* Notify test job's root ctx of os signals (SIGINT and SIGTERM) to allow proper cleanup in case of interruption

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Workflow execution was tested by triggering it on push in PR branch. Workflow: https://github.com/microsoft/retina/actions/workflows/daily-scale-test.yaml
![image](https://github.com/user-attachments/assets/979ca6ae-3f8d-48ad-a9fa-57fdceeb72d9)


## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
