### PR TITLE
fix(ci): rename GitHub Actions output folder to artifacts

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,4 +39,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage-files
-          path: ./output/coverage*
+          path: ./artifacts/coverage*

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ ifndef TAG
 	TAG ?= $(shell git describe --tags --always)
 endif
 OUTPUT_DIR = $(REPO_ROOT)/output
+ARTIFACTS_DIR = $(REPO_ROOT)/artifacts
 BUILD_DIR = $(OUTPUT_DIR)/$(GOOS)_$(GOARCH)
 RETINA_BUILD_DIR = $(BUILD_DIR)/retina
 RETINA_DIR = $(REPO_ROOT)/controller
@@ -241,7 +242,7 @@ container-docker: buildx # util target to build container images using docker bu
 	image_metadata_filename="image-metadata-$$image_name-$(TAG).json"; \
 	touch $$image_metadata_filename; \
 	echo "Building $$image_name for $$os/$$arch "; \
-	mkdir -p $(OUTPUT_DIR); \
+	mkdir -p $(ARTIFACTS_DIR); \
 	docker buildx build \
 		--platform $(PLATFORM) \
 		--metadata-file=$$image_metadata_filename \
@@ -254,7 +255,7 @@ container-docker: buildx # util target to build container images using docker bu
 		--build-arg VERSION=$(VERSION) $(EXTRA_BUILD_ARGS) \
 		--target=$(TARGET) \
 		-t $(IMAGE_REGISTRY)/$(IMAGE):$(TAG) \
-		--output type=local,dest=$(OUTPUT_DIR) \
+		--output type=local,dest=$(ARTIFACTS_DIR) \
 		$(BUILDX_ACTION) \
 		$(CONTEXT_DIR) 
 


### PR DESCRIPTION
# Description

After fixing the artifact upload in GitHub Actions, we discovered a conflict with Azure Pipelines as both systems were using the ./output directory. This was causing issues with Azure Pipeline builds.

## Related Issue
[ci: rename GitHub Actions output folder to artifacts #1254](https://github.com/microsoft/retina/issues/1254)

## Checklist

- [X] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [X] I have correctly attributed the author(s) of the code.
- [X] I have tested the changes locally.
- [X] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

This change resolves the pipeline conflicts while maintaining all existing functionality. It provides better separation between different CI systems.
---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
