### PR TITLE
fix(doc): Add missing --version for Hubble chart install

### DIFF
--- a/docs/02-Installation/01-Setup.md
+++ b/docs/02-Installation/01-Setup.md
@@ -97,6 +97,7 @@ helm upgrade --install retina oci://ghcr.io/microsoft/retina/charts/retina \
 ```shell
 VERSION=$( curl -sL https://api.github.com/repos/microsoft/retina/releases/latest | jq -r .name)
 helm upgrade --install retina oci://ghcr.io/microsoft/retina/charts/retina-hubble \
+        --version $VERSION \
         --namespace kube-system \
         --set os.windows=true \
         --set operator.enabled=true \


### PR DESCRIPTION
# Description

Add missing `--version` flag to the documentation for installing the Hubble chart.

## Related PR

#1223

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

![image](https://github.com/user-attachments/assets/a2c8be16-1db1-45f1-b74b-e7b56201f58d)

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
