### PR TITLE
fix: skip transient grpc errors in pktmon

### DIFF
--- a/pkg/plugin/pktmon/pktmon_grpc_windows.go
+++ b/pkg/plugin/pktmon/pktmon_grpc_windows.go
@@ -1,0 +1,163 @@
+package pktmon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/pkg/errors"
+
+	observerv1 "github.com/cilium/cilium/api/v1/observer"
+	"github.com/microsoft/retina/pkg/log"
+	"github.com/microsoft/retina/pkg/utils"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapio"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+var (
+	ErrNilStream = errors.New("stream is nil")
+)
+
+type GRPCManager interface {
+	SetupStream() error
+	StartStream(ctx context.Context) error
+	ReceiveFromStream() (*observerv1.GetFlowsResponse, error)
+
+	RunPktMonServer(ctx context.Context) error
+	Stop() error
+}
+
+type PktmonGRPCManager struct {
+	grpcClient *GRPCClient
+	stream     observerv1.Observer_GetFlowsClient
+	l          *log.ZapLogger
+
+	pktmonCmd *exec.Cmd
+	stdWriter *zapio.Writer
+	errWriter *zapio.Writer
+}
+
+func (p *PktmonGRPCManager) SetupStream() error {
+	var err error
+	fn := func() error {
+		p.l.Info("creating pktmon client")
+		p.grpcClient, err = newGRPCClient()
+		if err != nil {
+			return errors.Wrapf(err, "failed to create pktmon client before getting flows")
+		}
+
+		return nil
+	}
+	err = utils.Retry(fn, connectionRetryAttempts)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create pktmon client")
+	}
+
+	return nil
+}
+
+func (p *PktmonGRPCManager) StartStream(ctx context.Context) error {
+	if p.grpcClient == nil {
+		return errors.Wrapf(ErrNilGrpcClient, "unable to start stream")
+	}
+
+	var err error
+	fn := func() error {
+		p.stream, err = p.grpcClient.GetFlows(ctx, &observerv1.GetFlowsRequest{})
+		if err != nil {
+			return errors.Wrapf(err, "failed to open pktmon stream")
+		}
+		return nil
+	}
+	err = utils.Retry(fn, connectionRetryAttempts)
+	if err != nil {
+		return errors.Wrapf(err, "failed to create pktmon client")
+	}
+
+	return nil
+}
+
+func (p *PktmonGRPCManager) ReceiveFromStream() (*observerv1.GetFlowsResponse, error) {
+	if p.stream == nil {
+		return nil, errors.Wrapf(ErrNilStream, "unable to receive from stream")
+	}
+
+	return p.stream.Recv()
+}
+
+func newGRPCClient() (*GRPCClient, error) {
+	retryPolicy := map[string]any{
+		"methodConfig": []map[string]any{
+			{
+				"waitForReady": true,
+				"retryPolicy": map[string]any{
+					"MaxAttempts":          connectionRetryAttempts,
+					"InitialBackoff":       ".01s",
+					"MaxBackoff":           ".01s",
+					"BackoffMultiplier":    1.0,
+					"RetryableStatusCodes": []string{"UNAVAILABLE"},
+				},
+			},
+		},
+	}
+
+	bytes, err := json.Marshal(retryPolicy)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to marshal retry policy")
+	}
+
+	retryPolicyStr := string(bytes)
+
+	conn, err := grpc.Dial(fmt.Sprintf("%s:%s", "unix", socket), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithDefaultServiceConfig(retryPolicyStr))
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to dial pktmon server:")
+	}
+
+	return &GRPCClient{observerv1.NewObserverClient(conn)}, nil
+}
+
+func (p *PktmonGRPCManager) RunPktMonServer(ctx context.Context) error {
+	p.stdWriter = &zapio.Writer{Log: p.l.Logger, Level: zap.InfoLevel}
+	defer p.stdWriter.Close()
+	p.errWriter = &zapio.Writer{Log: p.l.Logger, Level: zap.ErrorLevel}
+	defer p.errWriter.Close()
+
+	pwd, err := os.Getwd()
+	if err != nil {
+		return errors.Wrapf(err, "failed to get current working directory for pktmon")
+	}
+
+	cmd := pwd + "\\" + "controller-pktmon.exe"
+
+	p.pktmonCmd = exec.CommandContext(ctx, cmd)
+	p.pktmonCmd.Dir = pwd
+	p.pktmonCmd.Args = append(p.pktmonCmd.Args, "--socketpath", socket)
+	p.pktmonCmd.Env = os.Environ()
+	p.pktmonCmd.Stdout = p.stdWriter
+	p.pktmonCmd.Stderr = p.errWriter
+
+	p.l.Info("calling start on pktmon stream server", zap.String("cmd", p.pktmonCmd.String()))
+
+	// block this thread, and should it ever return, it's a problem
+	err = p.pktmonCmd.Run()
+	if err != nil {
+		return errors.Wrapf(err, "pktmon server exited when it should not have")
+	}
+
+	// we never want to return happy from this
+	return errors.Wrapf(ErrUnexpectedExit, "pktmon server exited unexpectedly")
+}
+
+func (p *PktmonGRPCManager) Stop() error {
+	if p.pktmonCmd != nil {
+		err := p.pktmonCmd.Process.Kill()
+		if err != nil {
+			return errors.Wrapf(err, "failed to kill pktmon server during stop")
+		}
+	}
+	return nil
+}

--- a/pkg/plugin/pktmon/pktmon_windows.go
+++ b/pkg/plugin/pktmon/pktmon_windows.go
@@ -53,7 +53,7 @@ func New(*kcfg.Config) registry.Plugin {
 }
 
 func (p *Plugin) Init() error {
-	p.grpcManager = &PktmonGRPCManager{
+	p.grpcManager = &WindowsGRPCManager{
 		l: p.l,
 	}
 	return nil

--- a/pkg/plugin/pktmon/pktmon_windows_test.go
+++ b/pkg/plugin/pktmon/pktmon_windows_test.go
@@ -1,0 +1,22 @@
+package pktmon
+
+import (
+	"context"
+	"testing"
+
+	"github.com/microsoft/retina/pkg/config"
+)
+
+func TestStart(t *testing.T) {
+	// TestStart tests the Start function.
+	t.Run("TestStart", func(t *testing.T) {
+		// Create a new Plugin.
+		p := New(&config.Config{})
+		// Start the Plugin.
+		err := p.Start(context.Background())
+		// Check if the error is nil.
+		if err != nil {
+			t.Errorf("got %v, want nil", err)
+		}
+	})
+}

--- a/pkg/plugin/pktmon/pktmon_windows_test.go
+++ b/pkg/plugin/pktmon/pktmon_windows_test.go
@@ -6,6 +6,7 @@ import (
 
 	observerv1 "github.com/cilium/cilium/api/v1/observer"
 	"github.com/microsoft/retina/pkg/log"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -24,7 +25,7 @@ func (p *TestGRPCManager) RunPktMonServer(ctx context.Context) error {
 	return nil
 }
 
-func (p *TestGRPCManager) StartStream(ctx context.Context) error {
+func (p *TestGRPCManager) StartStream(_ context.Context) error {
 	return nil
 }
 
@@ -40,7 +41,9 @@ func (p *TestGRPCManager) Stop() error {
 
 func TestStart(t *testing.T) {
 	opts := log.GetDefaultLogOpts()
-	log.SetupZapLogger(opts)
+	_, err := log.SetupZapLogger(opts)
+	require.NoError(t, err)
+
 	p := &Plugin{
 		l: log.Logger().Named("test"),
 	}
@@ -60,7 +63,7 @@ func TestStart(t *testing.T) {
 	}
 
 	// Start the Plugin.
-	err := p.Start(ctx)
+	err = p.Start(ctx)
 	// Check if the error is nil.
 	if stat, ok := status.FromError(err); ok {
 		if stat.Code() != codes.Canceled {


### PR DESCRIPTION
# Description

There are known transient issues that show up running gRPC on windows in hostnetworking, a few of these don't need restart the client/server. The goal here is to accommodate those transient errors while preserving restart behavior for critical errors.

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
