### PR TITLE
chore: add exemptions to stale workflow

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -23,6 +23,8 @@ jobs:
           days-before-pr-close: 7
           days-before-pr-stale: 30
           delete-branch: true
+          exempt-draft-pr: true
+          exempt-pr-labels: "meta/preserve"
           stale-issue-label: "meta/waiting-for-author"
           stale-pr-label: "meta/waiting-for-author"
           operations-per-run: 100


### PR DESCRIPTION
# Description
Ignores draft PRs and adds a label to preserve PRs so they don't become stale

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
