### PR TITLE
fix: kapinger use service IP instead of name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,6 +333,7 @@ kubectl-retina-image:
 			CONTEXT_DIR=$(REPO_ROOT)
 
 kapinger-image: 
+	#docker buildx create --name=retina --append
 	docker buildx build --builder retina --platform windows/amd64 --target windows-amd64 -t $(IMAGE_REGISTRY)/$(KAPINGER_IMAGE):$(TAG)-windows-amd64  ./hack/tools/kapinger/ --push
 	docker buildx build --builder retina --platform linux/amd64 --target linux-amd64 -t $(IMAGE_REGISTRY)/$(KAPINGER_IMAGE):$(TAG)-linux-amd64  ./hack/tools/kapinger/ --push
 	docker buildx build --builder retina --platform linux/arm64 --target linux-arm64 -t $(IMAGE_REGISTRY)/$(KAPINGER_IMAGE):$(TAG)-linux-arm64  ./hack/tools/kapinger/ --push

--- a/hack/tools/kapinger/clients/http.go
+++ b/hack/tools/kapinger/clients/http.go
@@ -82,12 +82,12 @@ func (k *KapingerHTTPClient) MakeRequests(ctx context.Context) error {
 	ticker := time.NewTicker(k.interval)
 	sem := make(chan struct{}, 5) // semaphore to limit the number of active goroutines
 
-	serviceController, err := NewServiceLoggingController(k.clientset, k.labelselector)
+	serviceController, err := newServiceController(k.clientset, k.labelselector)
 	if err != nil {
 		return fmt.Errorf("error creating service controller: %w", err)
 	}
 
-	go serviceController.Run(ctx)
+	go serviceController.run(ctx)
 
 	for {
 		select {

--- a/hack/tools/kapinger/clients/http_service_controller.go
+++ b/hack/tools/kapinger/clients/http_service_controller.go
@@ -1,0 +1,97 @@
+package clients
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"golang.org/x/exp/rand"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+type ServiceLoggingController struct {
+	sync.RWMutex
+	serviceInformer cache.SharedIndexInformer
+
+	ips map[string]string
+}
+
+func (c *ServiceLoggingController) Run(ctx context.Context) error {
+	stopCh := make(chan struct{})
+	go func() {
+		<-ctx.Done()
+		close(stopCh)
+	}()
+	c.serviceInformer.Run(stopCh)
+	if !cache.WaitForCacheSync(ctx.Done(), c.serviceInformer.HasSynced) {
+		return fmt.Errorf("failed to sync")
+	}
+	return nil
+}
+
+func (c *ServiceLoggingController) serviceAdd(obj interface{}) {
+	service := obj.(*v1.Service)
+	klog.Infof("SERVICE CREATED: %s/%s", service.Namespace, service.Name)
+	c.Lock()
+	defer c.Unlock()
+	c.ips[service.Name] = service.Spec.ClusterIP
+}
+
+func (c *ServiceLoggingController) serviceUpdate(old, new interface{}) {
+	newsvc := new.(*v1.Service)
+	oldsvc := new.(*v1.Service)
+	klog.Infof("SERVICE UPDATED. %s/%s", newsvc.Namespace, newsvc.Name)
+	c.Lock()
+	defer c.Unlock()
+	delete(c.ips, oldsvc.Name)
+	c.ips[newsvc.Name] = newsvc.Spec.ClusterIP
+}
+
+func (c *ServiceLoggingController) serviceDelete(obj interface{}) {
+	service := obj.(*v1.Service)
+	klog.Infof("SERVICE DELETED: %s/%s", service.Namespace, service.Name)
+	c.Lock()
+	defer c.Unlock()
+	delete(c.ips, service.Name)
+}
+
+func (c *ServiceLoggingController) getIP() string {
+	c.RLock()
+	defer c.RUnlock()
+	// select random ip from map
+	randIndex := rand.Intn(len(c.ips))
+	for key := range c.ips {
+		randIndex--
+		if randIndex == 0 {
+			return c.ips[key]
+		}
+	}
+	return ""
+}
+
+func NewServiceLoggingController(clientset kubernetes.Interface, labelselector string) (*ServiceLoggingController, error) {
+	serviceInformer := informers.NewSharedInformerFactoryWithOptions(clientset, time.Hour*24,
+		informers.WithTweakListOptions(func(options *metav1.ListOptions) {
+			options.LabelSelector = labelselector // Filter by label selector
+		}),
+	).Core().V1().Services().Informer()
+	c := &ServiceLoggingController{
+		serviceInformer: serviceInformer,
+	}
+	serviceInformer.AddEventHandler(
+		cache.ResourceEventHandlerFuncs{
+			AddFunc:    c.serviceAdd,
+			UpdateFunc: c.serviceUpdate,
+			DeleteFunc: c.serviceDelete,
+		},
+	)
+
+	c.ips = make(map[string]string)
+	return c, nil
+}

--- a/hack/tools/kapinger/go.mod
+++ b/hack/tools/kapinger/go.mod
@@ -3,10 +3,12 @@ module github.com/microsoft/retina/hack/tools/kapinger
 go 1.22.5
 
 require (
+	golang.org/x/exp v0.0.0-20250128182459-e0ece0dbea4c
 	golang.org/x/sync v0.10.0
 	k8s.io/api v0.30.2
 	k8s.io/apimachinery v0.30.2
 	k8s.io/client-go v0.30.2
+	k8s.io/klog/v2 v2.120.1
 )
 
 require (
@@ -19,6 +21,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/gnostic-models v0.6.8 // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
@@ -38,7 +41,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/klog/v2 v2.120.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240228011516-70dd3763d340 // indirect
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/hack/tools/kapinger/go.sum
+++ b/hack/tools/kapinger/go.sum
@@ -77,6 +77,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/exp v0.0.0-20250128182459-e0ece0dbea4c h1:KL/ZBHXgKGVmuZBZ01Lt57yE5ws8ZPSkkihmEyq7FXc=
+golang.org/x/exp v0.0.0-20250128182459-e0ece0dbea4c/go.mod h1:tujkw807nyEEAamNbDrEGzRav+ilXA7PCRAd6xsmwiU=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
@@ -111,8 +113,8 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d h1:vU5i/LfpvrRCpgM/VPfJLg5KjxD3E+hfT1SH+d9zLwg=
-golang.org/x/tools v0.21.1-0.20240508182429-e35e4ccd0d2d/go.mod h1:aiJjzUbINMkxbQROHiO6hDPo2LHcIPhhQsa9DLh0yGk=
+golang.org/x/tools v0.29.0 h1:Xx0h3TtM9rzQpQuR4dKLrdglAmCEN5Oi+P74JdhdzXE=
+golang.org/x/tools v0.29.0/go.mod h1:KMQVMRsVxU6nHCFXrBPhDB8XncLNLM0lIy/F14RP588=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/hack/tools/kapinger/main.go
+++ b/hack/tools/kapinger/main.go
@@ -54,7 +54,7 @@ func main() {
 		g.Go(func() error {
 			err = client.MakeRequests(gCtx)
 			if err != nil {
-				return fmt.Errorf("error making request: %w", err)
+				return fmt.Errorf("error making client request: %w", err)
 			}
 			return nil
 		})

--- a/hack/tools/kapinger/servers/http.go
+++ b/hack/tools/kapinger/servers/http.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	_ "net/http/pprof"
 	"strconv"
 )
 

--- a/hack/tools/kapinger/servers/util.go
+++ b/hack/tools/kapinger/servers/util.go
@@ -7,5 +7,5 @@ import (
 
 func getResponse(addressString, protocol string) []byte {
 	podname := os.Getenv("POD_NAME")
-	return []byte(fmt.Sprintf("connected to: %s via %s, connected from: %v", podname, protocol, addressString))
+	return []byte(fmt.Sprintf("connected to: %s via %s, connected from: %v\n", podname, protocol, addressString))
 }

--- a/hack/tools/kapinger/servers/util.go
+++ b/hack/tools/kapinger/servers/util.go
@@ -7,5 +7,5 @@ import (
 
 func getResponse(addressString, protocol string) []byte {
 	podname := os.Getenv("POD_NAME")
-	return []byte(fmt.Sprintf("connected to: %s via %s, connected from: %v\n", podname, protocol, addressString))
+	return []byte(fmt.Sprintf("connected to: %s via %s, connected from: %v", podname, protocol, addressString))
 }

--- a/test/e2e/framework/types/job.go
+++ b/test/e2e/framework/types/job.go
@@ -10,7 +10,7 @@ import (
 var (
 	ErrEmptyDescription    = fmt.Errorf("job description is empty")
 	ErrNonNilError         = fmt.Errorf("expected error to be non-nil")
-	ErrNilError            = fmt.Errorf("expected error to be nil")
+	ErrNilError            = fmt.Errorf("test ")
 	ErrMissingParameter    = fmt.Errorf("missing parameter")
 	ErrParameterAlreadySet = fmt.Errorf("parameter already set")
 	ErrOrphanSteps         = fmt.Errorf("background steps with no corresponding stop")

--- a/test/trafficgen/kapinger.yaml
+++ b/test/trafficgen/kapinger.yaml
@@ -47,7 +47,7 @@ spec:
       serviceAccountName: kapinger-sa
       containers:
         - name: kapinger
-          image: acnpublic.azurecr.io/kapinger:20241009.5
+          image: acnpublic.azurecr.io/kapinger:v0.0.23-9-g23ef222
           resources:
             limits:
               memory: 40Mi
@@ -101,7 +101,7 @@ spec:
       serviceAccountName: kapinger-sa
       containers:
         - name: kapinger
-          image: acnpublic.azurecr.io/kapinger:20241009.5
+          image: acnpublic.azurecr.io/kapinger:v0.0.23-9-g23ef222
           resources:
             limits:
               memory: 20Mi

--- a/test/trafficgen/kapinger.yaml
+++ b/test/trafficgen/kapinger.yaml
@@ -50,12 +50,10 @@ spec:
           image: acnpublic.azurecr.io/kapinger:20241009.5
           resources:
             limits:
-              memory: 20Mi
+              memory: 40Mi
             requests:
               memory: 20Mi
           env:
-            - name: GODEBUG
-              value: netdns=go
             - name: TARGET_TYPE
               value: "service"
             - name: POD_IP
@@ -66,6 +64,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "0"
+                  resource: limits.memory
             - name: HTTP_PORT
               value: "8080"
             - name: TCP_PORT
@@ -115,12 +118,21 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: GOMEMLIMIT
+              valueFrom:
+                resourceFieldRef:
+                  divisor: "0"
+                  resource: limits.memory
             - name: HTTP_PORT
               value: "8080"
             - name: TCP_PORT
               value: "8085"
             - name: UDP_PORT
               value: "8086"
+            - name: BURST_INTERVAL_MS
+              value: "500"
+            - name: BURST_VOLUME
+              value: "1"
           ports:
             - containerPort: 8080
 ---


### PR DESCRIPTION
# Description

CoreDNS wasn't playing nice with massive bursts of service name fqdn lookups, this moves to using the ip of the service(s) directly

Please provide a brief description of the changes made in this pull request.

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
