### PR TITLE
chore(dashboards): Updating grafana dashboards and adding them to Grafana Portal

### DIFF
--- a/deploy/hubble/grafana/dashboards/clusters.json
+++ b/deploy/hubble/grafana/dashboards/clusters.json
@@ -3728,7 +3728,7 @@
     ]
   },
   "timezone": "",
-  "title": "Kubernetes / Networking / Clusters",
-  "uid": "NetObs6738",
+  "title": "Kubernetes / Networking / Retina (Hubble) / Clusters",
+  "uid": "RetinaHubbleClusters",
   "version": 39
 }

--- a/deploy/hubble/grafana/dashboards/dns.json
+++ b/deploy/hubble/grafana/dashboards/dns.json
@@ -1016,7 +1016,7 @@
     ]
   },
   "timezone": "",
-  "title": "Kubernetes / Networking / DNS",
-  "uid": "NetObsDNS6741",
+  "title": "Kubernetes / Networking / Retina (Hubble) / DNS",
+  "uid": "RetinaHubbleDNS",
   "version": 1
 }

--- a/deploy/hubble/grafana/dashboards/pod-flows-namespace.json
+++ b/deploy/hubble/grafana/dashboards/pod-flows-namespace.json
@@ -4263,7 +4263,7 @@
     ]
   },
   "timezone": "",
-  "title": "Kubernetes / Networking / Pod Flows (Namespace)",
-  "uid": "NetObsFlowsNamespace6739",
+  "title": "Kubernetes / Networking / Retina (Hubble) / Pod Flows (Namespace)",
+  "uid": "RetinaHubblePodFlowsNamespace",
   "version": 1
 }

--- a/deploy/hubble/grafana/dashboards/pod-flows-workload.json
+++ b/deploy/hubble/grafana/dashboards/pod-flows-workload.json
@@ -4013,7 +4013,7 @@
     ]
   },
   "timezone": "",
-  "title": "Kubernetes / Networking / Pod Flows (Workload)",
-  "uid": "NetObsFlowsWorkload6740",
+  "title": "Kubernetes / Networking / Retina (Hubble) / Pod Flows (Workload)",
+  "uid": "RetinaHubblePodFlowsWorkload",
   "version": 1
 }

--- a/deploy/standard/grafana/dashboards/clusters.json
+++ b/deploy/standard/grafana/dashboards/clusters.json
@@ -3753,7 +3753,7 @@
     ]
   },
   "timezone": "",
-  "title": "Kubernetes / Networking / Clusters",
+  "title": "Kubernetes / Networking / Retina / Clusters",
   "uid": "Retina11",
   "version": 1
 }

--- a/deploy/standard/grafana/dashboards/dns.json
+++ b/deploy/standard/grafana/dashboards/dns.json
@@ -920,7 +920,7 @@
     ]
   },
   "timezone": "",
-  "title": "Kubernetes / Networking / DNS",
+  "title": "Kubernetes / Networking / Retina / DNS",
   "uid": "Retina55",
   "version": 1
 }

--- a/deploy/standard/grafana/dashboards/pod-level.json
+++ b/deploy/standard/grafana/dashboards/pod-level.json
@@ -1108,7 +1108,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Kubernetes / Networking / Pod Traffic",
+  "title": "Kubernetes / Networking / Retina / Pod Traffic",
   "uid": "Retina22",
   "version": 1
 }

--- a/docs/02-Installation/05-grafana.md
+++ b/docs/02-Installation/05-grafana.md
@@ -34,9 +34,13 @@ If you followed the steps to install and configure [Prometheus](./04-prometheus.
 
    ![Grafana datasources](./img/grafana-datasources.png)
 
-5. Import the [kubernetes-networking-observability](https://grafana.com/grafana/dashboards/18814/) dashboard by id `18814` at [localhost:8080/dashboard/import](http://localhost:8080/dashboard/import)
+5. Import the [kubernetes-networking-retina-cluster](https://grafana.com/grafana/dashboards/22771/) dashboard by id `22771` at [localhost:8080/dashboard/import](http://localhost:8080/dashboard/import)
 
    ![Grafana import](./img/grafana-import.png)
+
+   Some other dashboards available are:
+   - [kubernetes-networking-retina-DNS](https://grafana.com/grafana/dashboards/22772/) dashboard (id `22772`)
+   - [kubernetes-networking-retina-PodTraffic](https://grafana.com/grafana/dashboards/22773/) dashboard (id `22773`)
 
 6. Kubernetes cluster metrics shouold be visible
 
@@ -49,3 +53,5 @@ There is a set of Retina dashboards that you can import directly into Grafana as
 Here is an example of the Retina `dns.json` dashboard.
 
 ![Grafana retina DNS dashboard](./img/grafana-retina-dns-dash.png)
+
+These dashboards are also available at the [Grafana Portal Retina Page](https://grafana.com/orgs/retina1/dashboards)


### PR DESCRIPTION
# Description

This PR updates the Grafana dashboards for the Retina project and adds them to the Grafana Portal.

## Related Issue

[pods and dns dashboards are not part of the published Grafana dashboards #178](https://github.com/microsoft/retina/issues/178)

## Checklist

- [X] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [X] I have correctly attributed the author(s) of the code.
- [X] I have tested the changes locally.
- [X] I have followed the project's style guidelines.
- [X] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Additional Notes

New Retina Grafana account has been created as part of this PR. 
Also, the scope has been extended to cover dashboards for Hubble control plane which was not mentioned in the original issue.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
