### PR TITLE
test(mc): Add function to override logger for sensitive outputs

### DIFF
--- a/test/multicloud/Makefile
+++ b/test/multicloud/Makefile
@@ -5,7 +5,7 @@ STACK_NAME ?= $(PREFIX)-aks
 
 plan:
 	cd live/$(STACK_NAME) && \
-		tofu fmt && tofu init && tofu plan
+		tofu init && tofu plan
 
 apply:
 	cd live/$(STACK_NAME) && \
@@ -38,5 +38,13 @@ clean: destroy
 kind-kubeconfig:
 	@kubectl config set-context live/$(PREFIX)-kind/mc-kind-config
 
+# For now we only want to run the retina-kind integration
+# since we do not have credentials for the other cloud providers
+# Once we do this targets will be updated to
+# @cd test && go test -v -count=1 -timeout 30m ./...
 test:
-	@cd test && go test -v -count=1 -timeout 30m ./...
+	@cd test && go test -run TestRetinaKindIntegration -count=1 -timeout 10m
+
+fmt:
+	@tofu fmt -recursive
+	@cd test && go fmt ./...

--- a/test/multicloud/examples/aks/outputs.tf
+++ b/test/multicloud/examples/aks/outputs.tf
@@ -1,0 +1,19 @@
+output "host" {
+  value     = module.aks.host
+  sensitive = true
+}
+
+output "client_certificate" {
+  value     = module.aks.client_certificate
+  sensitive = true
+}
+
+output "client_key" {
+  value     = module.aks.client_key
+  sensitive = true
+}
+
+output "cluster_ca_certificate" {
+  value     = module.aks.cluster_ca_certificate
+  sensitive = true
+}

--- a/test/multicloud/live/retina-aks/outputs.tf
+++ b/test/multicloud/live/retina-aks/outputs.tf
@@ -1,0 +1,19 @@
+output "host" {
+  value     = module.aks.host
+  sensitive = true
+}
+
+output "client_certificate" {
+  value     = module.aks.client_certificate
+  sensitive = true
+}
+
+output "client_key" {
+  value     = module.aks.client_key
+  sensitive = true
+}
+
+output "cluster_ca_certificate" {
+  value     = module.aks.cluster_ca_certificate
+  sensitive = true
+}

--- a/test/multicloud/modules/aks/outputs.tf
+++ b/test/multicloud/modules/aks/outputs.tf
@@ -4,21 +4,21 @@ output "azure_get_kubeconfig" {
 }
 
 output "host" {
-  value = azurerm_kubernetes_cluster.aks.kube_config.0.host
+  value     = azurerm_kubernetes_cluster.aks.kube_config.0.host
   sensitive = true
 }
 
 output "client_certificate" {
-  value = azurerm_kubernetes_cluster.aks.kube_config.0.client_certificate
+  value     = azurerm_kubernetes_cluster.aks.kube_config.0.client_certificate
   sensitive = true
 }
 
 output "client_key" {
-  value = azurerm_kubernetes_cluster.aks.kube_config.0.client_key
+  value     = azurerm_kubernetes_cluster.aks.kube_config.0.client_key
   sensitive = true
 }
 
 output "cluster_ca_certificate" {
-  value = azurerm_kubernetes_cluster.aks.kube_config.0.cluster_ca_certificate
+  value     = azurerm_kubernetes_cluster.aks.kube_config.0.cluster_ca_certificate
   sensitive = true
 }

--- a/test/multicloud/modules/gke/output.tf
+++ b/test/multicloud/modules/gke/output.tf
@@ -4,11 +4,11 @@ output "gcloud_get_kubeconfig" {
 }
 
 output "host" {
-  value = "https://${google_container_cluster.gke.endpoint}"
+  value     = "https://${google_container_cluster.gke.endpoint}"
   sensitive = true
 }
 
 output "cluster_ca_certificate" {
-  value = google_container_cluster.gke.master_auth.0.cluster_ca_certificate
+  value     = google_container_cluster.gke.master_auth.0.cluster_ca_certificate
   sensitive = true
 }

--- a/test/multicloud/modules/kind/output.tf
+++ b/test/multicloud/modules/kind/output.tf
@@ -1,24 +1,24 @@
 output "kubeconfig" {
-  value = kind_cluster.kind.kubeconfig
+  value     = kind_cluster.kind.kubeconfig
   sensitive = true
 }
 
 output "host" {
-  value = kind_cluster.kind.endpoint
+  value     = kind_cluster.kind.endpoint
   sensitive = true
 }
 
 output "client_certificate" {
-  value = kind_cluster.kind.client_certificate
+  value     = kind_cluster.kind.client_certificate
   sensitive = true
 }
 
 output "client_key" {
-  value = kind_cluster.kind.client_key
+  value     = kind_cluster.kind.client_key
   sensitive = true
 }
 
 output "cluster_ca_certificate" {
-  value = kind_cluster.kind.cluster_ca_certificate
+  value     = kind_cluster.kind.cluster_ca_certificate
   sensitive = true
 }

--- a/test/multicloud/test/example_kind_test.go
+++ b/test/multicloud/test/example_kind_test.go
@@ -19,15 +19,13 @@ func TestKindExample(t *testing.T) {
 
 	// clean up at the end of the test
 	defer terraform.Destroy(t, opts)
-
-	terraform.Init(t, opts)
-	terraform.Apply(t, opts)
+	terraform.InitAndApply(t, opts)
 
 	// get outputs
-	caCert := terraform.Output(t, opts, "cluster_ca_certificate")
-	clientCert := terraform.Output(t, opts, "client_certificate")
-	clientKey := terraform.Output(t, opts, "client_key")
-	host := terraform.Output(t, opts, "host")
+	caCert := fetchSensitiveOutput(t, opts, "cluster_ca_certificate")
+	clientCert := fetchSensitiveOutput(t, opts, "client_certificate")
+	clientKey := fetchSensitiveOutput(t, opts, "client_key")
+	host := fetchSensitiveOutput(t, opts, "host")
 
 	// build the REST config
 	restConfig := createRESTConfigWithClientCert(caCert, clientCert, clientKey, host)

--- a/test/multicloud/test/integration_retina_kind_test.go
+++ b/test/multicloud/test/integration_retina_kind_test.go
@@ -20,15 +20,13 @@ func TestRetinaKindIntegration(t *testing.T) {
 
 	// clean up at the end of the test
 	defer terraform.Destroy(t, opts)
-
-	terraform.Init(t, opts)
-	terraform.Apply(t, opts)
+	terraform.InitAndApply(t, opts)
 
 	// get outputs
-	caCert := terraform.Output(t, opts, "cluster_ca_certificate")
-	clientCert := terraform.Output(t, opts, "client_certificate")
-	clientKey := terraform.Output(t, opts, "client_key")
-	host := terraform.Output(t, opts, "host")
+	caCert := fetchSensitiveOutput(t, opts, "cluster_ca_certificate")
+	clientCert := fetchSensitiveOutput(t, opts, "client_certificate")
+	clientKey := fetchSensitiveOutput(t, opts, "client_key")
+	host := fetchSensitiveOutput(t, opts, "host")
 
 	// build the REST config
 	restConfig := createRESTConfigWithClientCert(caCert, clientCert, clientKey, host)
@@ -38,6 +36,9 @@ func TestRetinaKindIntegration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create Kubernetes clientset: %v", err)
 	}
+
+	// check the retina pods are running
+	checkRetinaPodsRunning(t, clientSet)
 
 	// test the cluster is accessible
 	testClusterAccess(t, clientSet)


### PR DESCRIPTION
# Description

* add fetchSensitiveOutputs function to override default logger to prevent sensitive outputs from being logged
* add checkRetinaPodsRunning function to check if Retina pods are running
* add make target for formatting both OpenTofu and go code
* modify make test target to run test ONLY for TestRetinaKindIntegration till we get cloud creds
* refactor tests to use new func

## Related Issue

#1267 

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

![image](https://github.com/user-attachments/assets/fd711fa8-4064-4c57-87cc-2a7acc088f6f)

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
