### PR TITLE
fix(test): fix test cleanup

### DIFF
--- a/test/e2e/infra/azure_temp_infra_setup.go
+++ b/test/e2e/infra/azure_temp_infra_setup.go
@@ -37,13 +37,14 @@ func CreateAzureTempK8sInfra(ctx context.Context, t *testing.T, rootDir string) 
 
 	// CreateTestInfra
 	createTestInfra := types.NewRunner(t, jobs.CreateTestInfra(subID, rg, clusterName, location, kubeConfigFilePath, *common.CreateInfra))
-	createTestInfra.Run(ctx)
-
 	t.Cleanup(func() {
 		err := jobs.DeleteTestInfra(subID, rg, location, *common.DeleteInfra).Run()
 		if err != nil {
 			t.Logf("Failed to delete test infrastructure: %v", err)
 		}
 	})
+
+	createTestInfra.Run(ctx)
+
 	return kubeConfigFilePath
 }

--- a/test/e2e/scale_test.go
+++ b/test/e2e/scale_test.go
@@ -91,11 +91,11 @@ func TestE2ERetina_Scale(t *testing.T) {
 
 	// CreateTestInfra
 	createTestInfra := types.NewRunner(t, jobs.CreateTestInfra(subID, rg, clusterName, location, common.KubeConfigFilePath(rootDir), *common.CreateInfra))
-	createTestInfra.Run(ctx)
-
 	t.Cleanup(func() {
 		_ = jobs.DeleteTestInfra(subID, rg, location, *common.DeleteInfra).Run()
 	})
+
+	createTestInfra.Run(ctx)
 
 	fqdn, err := azure.GetFqdnFn(subID, rg, clusterName)
 	require.NoError(t, err)
@@ -104,10 +104,6 @@ func TestE2ERetina_Scale(t *testing.T) {
 	// Install Retina
 	installRetina := types.NewRunner(t, jobs.InstallRetina(common.KubeConfigFilePath(rootDir), common.RetinaChartPath(rootDir)))
 	installRetina.Run(ctx)
-
-	t.Cleanup(func() {
-		_ = jobs.UninstallRetina(common.KubeConfigFilePath(rootDir), common.RetinaChartPath(rootDir)).Run()
-	})
 
 	scale := types.NewRunner(t, jobs.ScaleTest(&opt))
 	scale.Run(ctx)


### PR DESCRIPTION
# Description

When there's a failure in infra creation, `t.Cleanup` function is not called because it is registered after job's `Run` method is called.

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
