### PR TITLE
chore: Refactor Captures to use Contexts

### DIFF
--- a/cli/cmd/capture/list.go
+++ b/cli/cmd/capture/list.go
@@ -4,6 +4,10 @@
 package capture
 
 import (
+	"context"
+	"os/signal"
+	"syscall"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/kubernetes"
@@ -36,11 +40,15 @@ var listCaptures = &cobra.Command{
 			return errors.Wrap(err, "failed to initialize kubernetes client")
 		}
 
+		// Create a context that is canceled when a termination signal is received
+		ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM)
+		defer cancel()
+
 		captureNamespace := *opts.Namespace
 		if allNamespaces {
 			captureNamespace = ""
 		}
-		return listCapturesInNamespaceAndPrintCaptureResults(kubeClient, captureNamespace)
+		return listCapturesInNamespaceAndPrintCaptureResults(ctx, kubeClient, captureNamespace)
 	},
 }
 

--- a/cli/cmd/capture/table_util.go
+++ b/cli/cmd/capture/table_util.go
@@ -21,16 +21,16 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func getCaptureAndPrintCaptureResult(kubeClient *kubernetes.Clientset, name, namespace string) error {
-	return listCapturesAndPrintCaptureResults(kubeClient, name, namespace)
+func getCaptureAndPrintCaptureResult(ctx context.Context, kubeClient *kubernetes.Clientset, name, namespace string) error {
+	return listCapturesAndPrintCaptureResults(ctx, kubeClient, name, namespace)
 }
 
-func listCapturesInNamespaceAndPrintCaptureResults(kubeClient *kubernetes.Clientset, namespace string) error {
-	return listCapturesAndPrintCaptureResults(kubeClient, "", namespace)
+func listCapturesInNamespaceAndPrintCaptureResults(ctx context.Context, kubeClient *kubernetes.Clientset, namespace string) error {
+	return listCapturesAndPrintCaptureResults(ctx, kubeClient, "", namespace)
 }
 
 // listCapturesAndPrintCaptureResults list captures and print the running jobs into properly aligned text.
-func listCapturesAndPrintCaptureResults(kubeClient *kubernetes.Clientset, name, namespace string) error {
+func listCapturesAndPrintCaptureResults(ctx context.Context, kubeClient *kubernetes.Clientset, name, namespace string) error {
 	jobListOpt := metav1.ListOptions{}
 	if len(name) != 0 {
 		captureJobSelector := &metav1.LabelSelector{
@@ -45,7 +45,7 @@ func listCapturesAndPrintCaptureResults(kubeClient *kubernetes.Clientset, name, 
 		}
 	}
 
-	jobList, err := kubeClient.BatchV1().Jobs(namespace).List(context.TODO(), jobListOpt)
+	jobList, err := kubeClient.BatchV1().Jobs(namespace).List(ctx, jobListOpt)
 	if err != nil {
 		return err
 	}

--- a/pkg/capture/capture_manager_test.go
+++ b/pkg/capture/capture_manager_test.go
@@ -1,144 +1,144 @@
-// Copyright (c) Microsoft Corporation.
-// Licensed under the MIT license.
+// // Copyright (c) Microsoft Corporation.
+// // Licensed under the MIT license.
 
 package capture
 
-import (
-	"fmt"
-	"os"
-	"strconv"
-	"testing"
+// import (
+// 	"fmt"
+// 	"os"
+// 	"strconv"
+// 	"testing"
 
-	"github.com/google/go-cmp/cmp"
-	captureConstants "github.com/microsoft/retina/pkg/capture/constants"
-	"github.com/microsoft/retina/pkg/capture/file"
-	"github.com/microsoft/retina/pkg/capture/provider"
-	"github.com/microsoft/retina/pkg/log"
-	"github.com/microsoft/retina/pkg/telemetry"
-	"go.uber.org/mock/gomock"
-)
+// 	"github.com/google/go-cmp/cmp"
+// 	captureConstants "github.com/microsoft/retina/pkg/capture/constants"
+// 	"github.com/microsoft/retina/pkg/capture/file"
+// 	"github.com/microsoft/retina/pkg/capture/provider"
+// 	"github.com/microsoft/retina/pkg/log"
+// 	"github.com/microsoft/retina/pkg/telemetry"
+// 	"go.uber.org/mock/gomock"
+// )
 
-func TestCaptureNetwork(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+// func TestCaptureNetwork(t *testing.T) {
+// 	ctrl := gomock.NewController(t)
+// 	defer ctrl.Finish()
 
-	networkCaptureProvider := provider.NewMockNetworkCaptureProviderInterface(ctrl)
-	cm := &CaptureManager{
-		networkCaptureProvider: networkCaptureProvider,
-		tel:                    telemetry.NewNoopTelemetry(),
-	}
+// 	networkCaptureProvider := provider.NewMockNetworkCaptureProviderInterface(ctrl)
+// 	cm := &CaptureManager{
+// 		networkCaptureProvider: networkCaptureProvider,
+// 		tel:                    telemetry.NewNoopTelemetry(),
+// 	}
 
-	timestamp := file.Now()
-	captureName := "capture-name"
-	nodeHostName := "node-host-name"
-	filter := "-i any"
-	duration := 10
-	maxSize := 100
-	os.Setenv(captureConstants.CaptureNameEnvKey, captureName)
-	os.Setenv(captureConstants.NodeHostNameEnvKey, nodeHostName)
-	os.Setenv(captureConstants.CaptureStartTimestampEnvKey, timestamp.String())
-	os.Setenv(captureConstants.TcpdumpFilterEnvKey, filter)
-	os.Setenv(captureConstants.CaptureDurationEnvKey, "10s")
-	os.Setenv(captureConstants.CaptureMaxSizeEnvKey, strconv.Itoa(maxSize))
+// 	timestamp := file.Now()
+// 	captureName := "capture-name"
+// 	nodeHostName := "node-host-name"
+// 	filter := "-i any"
+// 	duration := 10
+// 	maxSize := 100
+// 	os.Setenv(captureConstants.CaptureNameEnvKey, captureName)
+// 	os.Setenv(captureConstants.NodeHostNameEnvKey, nodeHostName)
+// 	os.Setenv(captureConstants.CaptureStartTimestampEnvKey, timestamp.String())
+// 	os.Setenv(captureConstants.TcpdumpFilterEnvKey, filter)
+// 	os.Setenv(captureConstants.CaptureDurationEnvKey, "10s")
+// 	os.Setenv(captureConstants.CaptureMaxSizeEnvKey, strconv.Itoa(maxSize))
 
-	defer func() {
-		os.Unsetenv(captureConstants.CaptureNameEnvKey)
-		os.Unsetenv(captureConstants.NodeHostNameEnvKey)
-		os.Unsetenv(captureConstants.CaptureStartTimestampEnvKey)
-		os.Unsetenv(captureConstants.TcpdumpFilterEnvKey)
-		os.Unsetenv(captureConstants.CaptureDurationEnvKey)
-		os.Unsetenv(captureConstants.CaptureMaxSizeEnvKey)
-	}()
+// 	defer func() {
+// 		os.Unsetenv(captureConstants.CaptureNameEnvKey)
+// 		os.Unsetenv(captureConstants.NodeHostNameEnvKey)
+// 		os.Unsetenv(captureConstants.CaptureStartTimestampEnvKey)
+// 		os.Unsetenv(captureConstants.TcpdumpFilterEnvKey)
+// 		os.Unsetenv(captureConstants.CaptureDurationEnvKey)
+// 		os.Unsetenv(captureConstants.CaptureMaxSizeEnvKey)
+// 	}()
 
-	sigChanel := make(chan os.Signal, 1)
+// 	sigChanel := make(chan os.Signal, 1)
 
-	tmpFilename := file.CaptureFilename{CaptureName: captureName, NodeHostname: nodeHostName, StartTimestamp: &timestamp}
-	networkCaptureProvider.EXPECT().Setup(tmpFilename).Return(fmt.Sprintf("%s-%s-%s", captureName, nodeHostName, &timestamp), nil).Times(1)
-	networkCaptureProvider.EXPECT().CaptureNetworkPacket(filter, duration, maxSize, sigChanel).Return(nil).Times(1)
+// 	tmpFilename := file.CaptureFilename{CaptureName: captureName, NodeHostname: nodeHostName, StartTimestamp: &timestamp}
+// 	networkCaptureProvider.EXPECT().Setup(tmpFilename).Return(fmt.Sprintf("%s-%s-%s", captureName, nodeHostName, &timestamp), nil).Times(1)
+// 	networkCaptureProvider.EXPECT().CaptureNetworkPacket(filter, duration, maxSize, sigChanel).Return(nil).Times(1)
 
-	_, err := cm.CaptureNetwork(sigChanel)
-	if err != nil {
-		t.Errorf("CaptureNetwork should have not fail with error %s", err)
-	}
-}
+// 	_, err := cm.CaptureNetwork(sigChanel)
+// 	if err != nil {
+// 		t.Errorf("CaptureNetwork should have not fail with error %s", err)
+// 	}
+// }
 
-func TestEnabledOutputLocation(t *testing.T) {
-	cases := []struct {
-		name                      string
-		env                       map[string]string
-		wantEnabledOutputLocation []string
-	}{
-		{
-			name: "HostPath output location is enabled",
-			env: map[string]string{
-				string(captureConstants.CaptureOutputLocationEnvKeyHostPath): "/tmp/capture",
-			},
-			wantEnabledOutputLocation: []string{"HostPath"},
-		},
-		{
-			name: "PVC output location is enabled",
-			env: map[string]string{
-				string(captureConstants.CaptureOutputLocationEnvKeyPersistentVolumeClaim): "mypvc",
-			},
-			wantEnabledOutputLocation: []string{"PersistentVolumeClaim"},
-		},
-		{
-			name: "PVC and HostPath output location is enabled",
-			env: map[string]string{
-				string(captureConstants.CaptureOutputLocationEnvKeyHostPath):              "/tmp/capture",
-				string(captureConstants.CaptureOutputLocationEnvKeyPersistentVolumeClaim): "mypvc",
-			},
-			wantEnabledOutputLocation: []string{"HostPath", "PersistentVolumeClaim"},
-		},
-	}
+// func TestEnabledOutputLocation(t *testing.T) {
+// 	cases := []struct {
+// 		name                      string
+// 		env                       map[string]string
+// 		wantEnabledOutputLocation []string
+// 	}{
+// 		{
+// 			name: "HostPath output location is enabled",
+// 			env: map[string]string{
+// 				string(captureConstants.CaptureOutputLocationEnvKeyHostPath): "/tmp/capture",
+// 			},
+// 			wantEnabledOutputLocation: []string{"HostPath"},
+// 		},
+// 		{
+// 			name: "PVC output location is enabled",
+// 			env: map[string]string{
+// 				string(captureConstants.CaptureOutputLocationEnvKeyPersistentVolumeClaim): "mypvc",
+// 			},
+// 			wantEnabledOutputLocation: []string{"PersistentVolumeClaim"},
+// 		},
+// 		{
+// 			name: "PVC and HostPath output location is enabled",
+// 			env: map[string]string{
+// 				string(captureConstants.CaptureOutputLocationEnvKeyHostPath):              "/tmp/capture",
+// 				string(captureConstants.CaptureOutputLocationEnvKeyPersistentVolumeClaim): "mypvc",
+// 			},
+// 			wantEnabledOutputLocation: []string{"HostPath", "PersistentVolumeClaim"},
+// 		},
+// 	}
 
-	for _, tt := range cases {
-		t.Run(tt.name, func(t *testing.T) {
-			for k, v := range tt.env {
-				os.Setenv(k, v)
-			}
+// 	for _, tt := range cases {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			for k, v := range tt.env {
+// 				os.Setenv(k, v)
+// 			}
 
-			defer func() {
-				for k := range tt.env {
-					os.Unsetenv(k)
-				}
-			}()
+// 			defer func() {
+// 				for k := range tt.env {
+// 					os.Unsetenv(k)
+// 				}
+// 			}()
 
-			ctrl := gomock.NewController(t)
-			defer ctrl.Finish()
+// 			ctrl := gomock.NewController(t)
+// 			defer ctrl.Finish()
 
-			networkCaptureProvider := provider.NewMockNetworkCaptureProviderInterface(ctrl)
+// 			networkCaptureProvider := provider.NewMockNetworkCaptureProviderInterface(ctrl)
 
-			log.SetupZapLogger(log.GetDefaultLogOpts())
-			cm := &CaptureManager{
-				networkCaptureProvider: networkCaptureProvider,
-				l:                      log.Logger().Named("test"),
-			}
-			enabledOutputLocations := cm.enabledOutputLocations()
-			enabledOutputLocationNames := []string{}
-			for _, enabledOutputLocation := range enabledOutputLocations {
-				enabledOutputLocationNames = append(enabledOutputLocationNames, enabledOutputLocation.Name())
-			}
+// 			log.SetupZapLogger(log.GetDefaultLogOpts())
+// 			cm := &CaptureManager{
+// 				networkCaptureProvider: networkCaptureProvider,
+// 				l:                      log.Logger().Named("test"),
+// 			}
+// 			enabledOutputLocations := cm.enabledOutputLocations()
+// 			enabledOutputLocationNames := []string{}
+// 			for _, enabledOutputLocation := range enabledOutputLocations {
+// 				enabledOutputLocationNames = append(enabledOutputLocationNames, enabledOutputLocation.Name())
+// 			}
 
-			if diff := cmp.Diff(tt.wantEnabledOutputLocation, enabledOutputLocationNames); diff != "" {
-				t.Errorf("CalculateCaptureTargetsOnNode() mismatch (-want, +got):\n%s", diff)
-			}
-		})
-	}
-}
+// 			if diff := cmp.Diff(tt.wantEnabledOutputLocation, enabledOutputLocationNames); diff != "" {
+// 				t.Errorf("CalculateCaptureTargetsOnNode() mismatch (-want, +got):\n%s", diff)
+// 			}
+// 		})
+// 	}
+// }
 
-func TestCleanup(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
+// func TestCleanup(t *testing.T) {
+// 	ctrl := gomock.NewController(t)
+// 	defer ctrl.Finish()
 
-	networkCaptureProvider := provider.NewMockNetworkCaptureProviderInterface(ctrl)
-	cm := &CaptureManager{
-		networkCaptureProvider: networkCaptureProvider,
-	}
+// 	networkCaptureProvider := provider.NewMockNetworkCaptureProviderInterface(ctrl)
+// 	cm := &CaptureManager{
+// 		networkCaptureProvider: networkCaptureProvider,
+// 	}
 
-	networkCaptureProvider.EXPECT().Cleanup().Return(nil).Times(1)
+// 	networkCaptureProvider.EXPECT().Cleanup().Return(nil).Times(1)
 
-	if err := cm.Cleanup(); err != nil {
-		t.Errorf("Cleanup should have not fail with error %s", err)
-	}
-}
+//		if err := cm.Cleanup(); err != nil {
+//			t.Errorf("Cleanup should have not fail with error %s", err)
+//		}
+//	}

--- a/pkg/capture/capture_manager_test.go
+++ b/pkg/capture/capture_manager_test.go
@@ -4,12 +4,9 @@
 package capture
 
 import (
-	"context"
 	"fmt"
 	"os"
-	"os/signal"
 	"strconv"
-	"syscall"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -53,7 +50,7 @@ func TestCaptureNetwork(t *testing.T) {
 		os.Unsetenv(captureConstants.CaptureMaxSizeEnvKey)
 	}()
 
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM)
+	ctx, cancel := createTestContext(t)
 	defer cancel()
 
 	tmpFilename := file.CaptureFilename{CaptureName: captureName, NodeHostname: nodeHostName, StartTimestamp: &timestamp}

--- a/pkg/capture/capture_manager_test.go
+++ b/pkg/capture/capture_manager_test.go
@@ -1,144 +1,148 @@
-// // Copyright (c) Microsoft Corporation.
-// // Licensed under the MIT license.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 
 package capture
 
-// import (
-// 	"fmt"
-// 	"os"
-// 	"strconv"
-// 	"testing"
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+	"testing"
 
-// 	"github.com/google/go-cmp/cmp"
-// 	captureConstants "github.com/microsoft/retina/pkg/capture/constants"
-// 	"github.com/microsoft/retina/pkg/capture/file"
-// 	"github.com/microsoft/retina/pkg/capture/provider"
-// 	"github.com/microsoft/retina/pkg/log"
-// 	"github.com/microsoft/retina/pkg/telemetry"
-// 	"go.uber.org/mock/gomock"
-// )
+	"github.com/google/go-cmp/cmp"
+	captureConstants "github.com/microsoft/retina/pkg/capture/constants"
+	"github.com/microsoft/retina/pkg/capture/file"
+	"github.com/microsoft/retina/pkg/capture/provider"
+	"github.com/microsoft/retina/pkg/log"
+	"github.com/microsoft/retina/pkg/telemetry"
+	"go.uber.org/mock/gomock"
+)
 
-// func TestCaptureNetwork(t *testing.T) {
-// 	ctrl := gomock.NewController(t)
-// 	defer ctrl.Finish()
+func TestCaptureNetwork(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 
-// 	networkCaptureProvider := provider.NewMockNetworkCaptureProviderInterface(ctrl)
-// 	cm := &CaptureManager{
-// 		networkCaptureProvider: networkCaptureProvider,
-// 		tel:                    telemetry.NewNoopTelemetry(),
-// 	}
+	networkCaptureProvider := provider.NewMockNetworkCaptureProviderInterface(ctrl)
+	cm := &CaptureManager{
+		networkCaptureProvider: networkCaptureProvider,
+		tel:                    telemetry.NewNoopTelemetry(),
+	}
 
-// 	timestamp := file.Now()
-// 	captureName := "capture-name"
-// 	nodeHostName := "node-host-name"
-// 	filter := "-i any"
-// 	duration := 10
-// 	maxSize := 100
-// 	os.Setenv(captureConstants.CaptureNameEnvKey, captureName)
-// 	os.Setenv(captureConstants.NodeHostNameEnvKey, nodeHostName)
-// 	os.Setenv(captureConstants.CaptureStartTimestampEnvKey, timestamp.String())
-// 	os.Setenv(captureConstants.TcpdumpFilterEnvKey, filter)
-// 	os.Setenv(captureConstants.CaptureDurationEnvKey, "10s")
-// 	os.Setenv(captureConstants.CaptureMaxSizeEnvKey, strconv.Itoa(maxSize))
+	timestamp := file.Now()
+	captureName := "capture-name"
+	nodeHostName := "node-host-name"
+	filter := "-i any"
+	duration := 10
+	maxSize := 100
+	os.Setenv(captureConstants.CaptureNameEnvKey, captureName)
+	os.Setenv(captureConstants.NodeHostNameEnvKey, nodeHostName)
+	os.Setenv(captureConstants.CaptureStartTimestampEnvKey, timestamp.String())
+	os.Setenv(captureConstants.TcpdumpFilterEnvKey, filter)
+	os.Setenv(captureConstants.CaptureDurationEnvKey, "10s")
+	os.Setenv(captureConstants.CaptureMaxSizeEnvKey, strconv.Itoa(maxSize))
 
-// 	defer func() {
-// 		os.Unsetenv(captureConstants.CaptureNameEnvKey)
-// 		os.Unsetenv(captureConstants.NodeHostNameEnvKey)
-// 		os.Unsetenv(captureConstants.CaptureStartTimestampEnvKey)
-// 		os.Unsetenv(captureConstants.TcpdumpFilterEnvKey)
-// 		os.Unsetenv(captureConstants.CaptureDurationEnvKey)
-// 		os.Unsetenv(captureConstants.CaptureMaxSizeEnvKey)
-// 	}()
+	defer func() {
+		os.Unsetenv(captureConstants.CaptureNameEnvKey)
+		os.Unsetenv(captureConstants.NodeHostNameEnvKey)
+		os.Unsetenv(captureConstants.CaptureStartTimestampEnvKey)
+		os.Unsetenv(captureConstants.TcpdumpFilterEnvKey)
+		os.Unsetenv(captureConstants.CaptureDurationEnvKey)
+		os.Unsetenv(captureConstants.CaptureMaxSizeEnvKey)
+	}()
 
-// 	sigChanel := make(chan os.Signal, 1)
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM)
+	defer cancel()
 
-// 	tmpFilename := file.CaptureFilename{CaptureName: captureName, NodeHostname: nodeHostName, StartTimestamp: &timestamp}
-// 	networkCaptureProvider.EXPECT().Setup(tmpFilename).Return(fmt.Sprintf("%s-%s-%s", captureName, nodeHostName, &timestamp), nil).Times(1)
-// 	networkCaptureProvider.EXPECT().CaptureNetworkPacket(filter, duration, maxSize, sigChanel).Return(nil).Times(1)
+	tmpFilename := file.CaptureFilename{CaptureName: captureName, NodeHostname: nodeHostName, StartTimestamp: &timestamp}
+	networkCaptureProvider.EXPECT().Setup(tmpFilename).Return(fmt.Sprintf("%s-%s-%s", captureName, nodeHostName, &timestamp), nil).Times(1)
+	networkCaptureProvider.EXPECT().CaptureNetworkPacket(ctx, filter, duration, maxSize).Return(nil).Times(1)
 
-// 	_, err := cm.CaptureNetwork(sigChanel)
-// 	if err != nil {
-// 		t.Errorf("CaptureNetwork should have not fail with error %s", err)
-// 	}
-// }
+	_, err := cm.CaptureNetwork(ctx)
+	if err != nil {
+		t.Errorf("CaptureNetwork should have not fail with error %s", err)
+	}
+}
 
-// func TestEnabledOutputLocation(t *testing.T) {
-// 	cases := []struct {
-// 		name                      string
-// 		env                       map[string]string
-// 		wantEnabledOutputLocation []string
-// 	}{
-// 		{
-// 			name: "HostPath output location is enabled",
-// 			env: map[string]string{
-// 				string(captureConstants.CaptureOutputLocationEnvKeyHostPath): "/tmp/capture",
-// 			},
-// 			wantEnabledOutputLocation: []string{"HostPath"},
-// 		},
-// 		{
-// 			name: "PVC output location is enabled",
-// 			env: map[string]string{
-// 				string(captureConstants.CaptureOutputLocationEnvKeyPersistentVolumeClaim): "mypvc",
-// 			},
-// 			wantEnabledOutputLocation: []string{"PersistentVolumeClaim"},
-// 		},
-// 		{
-// 			name: "PVC and HostPath output location is enabled",
-// 			env: map[string]string{
-// 				string(captureConstants.CaptureOutputLocationEnvKeyHostPath):              "/tmp/capture",
-// 				string(captureConstants.CaptureOutputLocationEnvKeyPersistentVolumeClaim): "mypvc",
-// 			},
-// 			wantEnabledOutputLocation: []string{"HostPath", "PersistentVolumeClaim"},
-// 		},
-// 	}
+func TestEnabledOutputLocation(t *testing.T) {
+	cases := []struct {
+		name                      string
+		env                       map[string]string
+		wantEnabledOutputLocation []string
+	}{
+		{
+			name: "HostPath output location is enabled",
+			env: map[string]string{
+				string(captureConstants.CaptureOutputLocationEnvKeyHostPath): "/tmp/capture",
+			},
+			wantEnabledOutputLocation: []string{"HostPath"},
+		},
+		{
+			name: "PVC output location is enabled",
+			env: map[string]string{
+				string(captureConstants.CaptureOutputLocationEnvKeyPersistentVolumeClaim): "mypvc",
+			},
+			wantEnabledOutputLocation: []string{"PersistentVolumeClaim"},
+		},
+		{
+			name: "PVC and HostPath output location is enabled",
+			env: map[string]string{
+				string(captureConstants.CaptureOutputLocationEnvKeyHostPath):              "/tmp/capture",
+				string(captureConstants.CaptureOutputLocationEnvKeyPersistentVolumeClaim): "mypvc",
+			},
+			wantEnabledOutputLocation: []string{"HostPath", "PersistentVolumeClaim"},
+		},
+	}
 
-// 	for _, tt := range cases {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			for k, v := range tt.env {
-// 				os.Setenv(k, v)
-// 			}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.env {
+				os.Setenv(k, v)
+			}
 
-// 			defer func() {
-// 				for k := range tt.env {
-// 					os.Unsetenv(k)
-// 				}
-// 			}()
+			defer func() {
+				for k := range tt.env {
+					os.Unsetenv(k)
+				}
+			}()
 
-// 			ctrl := gomock.NewController(t)
-// 			defer ctrl.Finish()
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
 
-// 			networkCaptureProvider := provider.NewMockNetworkCaptureProviderInterface(ctrl)
+			networkCaptureProvider := provider.NewMockNetworkCaptureProviderInterface(ctrl)
 
-// 			log.SetupZapLogger(log.GetDefaultLogOpts())
-// 			cm := &CaptureManager{
-// 				networkCaptureProvider: networkCaptureProvider,
-// 				l:                      log.Logger().Named("test"),
-// 			}
-// 			enabledOutputLocations := cm.enabledOutputLocations()
-// 			enabledOutputLocationNames := []string{}
-// 			for _, enabledOutputLocation := range enabledOutputLocations {
-// 				enabledOutputLocationNames = append(enabledOutputLocationNames, enabledOutputLocation.Name())
-// 			}
+			log.SetupZapLogger(log.GetDefaultLogOpts())
+			cm := &CaptureManager{
+				networkCaptureProvider: networkCaptureProvider,
+				l:                      log.Logger().Named("test"),
+			}
+			enabledOutputLocations := cm.enabledOutputLocations()
+			enabledOutputLocationNames := []string{}
+			for _, enabledOutputLocation := range enabledOutputLocations {
+				enabledOutputLocationNames = append(enabledOutputLocationNames, enabledOutputLocation.Name())
+			}
 
-// 			if diff := cmp.Diff(tt.wantEnabledOutputLocation, enabledOutputLocationNames); diff != "" {
-// 				t.Errorf("CalculateCaptureTargetsOnNode() mismatch (-want, +got):\n%s", diff)
-// 			}
-// 		})
-// 	}
-// }
+			if diff := cmp.Diff(tt.wantEnabledOutputLocation, enabledOutputLocationNames); diff != "" {
+				t.Errorf("CalculateCaptureTargetsOnNode() mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
 
-// func TestCleanup(t *testing.T) {
-// 	ctrl := gomock.NewController(t)
-// 	defer ctrl.Finish()
+func TestCleanup(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 
-// 	networkCaptureProvider := provider.NewMockNetworkCaptureProviderInterface(ctrl)
-// 	cm := &CaptureManager{
-// 		networkCaptureProvider: networkCaptureProvider,
-// 	}
+	networkCaptureProvider := provider.NewMockNetworkCaptureProviderInterface(ctrl)
+	cm := &CaptureManager{
+		networkCaptureProvider: networkCaptureProvider,
+	}
 
-// 	networkCaptureProvider.EXPECT().Cleanup().Return(nil).Times(1)
+	networkCaptureProvider.EXPECT().Cleanup().Return(nil).Times(1)
 
-//		if err := cm.Cleanup(); err != nil {
-//			t.Errorf("Cleanup should have not fail with error %s", err)
-//		}
-//	}
+	if err := cm.Cleanup(); err != nil {
+		t.Errorf("Cleanup should have not fail with error %s", err)
+	}
+}

--- a/pkg/capture/capture_manager_test.go
+++ b/pkg/capture/capture_manager_test.go
@@ -50,7 +50,7 @@ func TestCaptureNetwork(t *testing.T) {
 		os.Unsetenv(captureConstants.CaptureMaxSizeEnvKey)
 	}()
 
-	ctx, cancel := createTestContext(t)
+	ctx, cancel := TestContext(t)
 	defer cancel()
 
 	tmpFilename := file.CaptureFilename{CaptureName: captureName, NodeHostname: nodeHostName, StartTimestamp: &timestamp}

--- a/pkg/capture/crd_to_job_test.go
+++ b/pkg/capture/crd_to_job_test.go
@@ -135,7 +135,7 @@ func Test_CaptureTargetsOnNode_AddNodeInterface(t *testing.T) {
 }
 
 func Test_CaptureToPodTranslator_GetCaptureTargetsOnNode(t *testing.T) {
-	ctx, cancel := createTestContext(t)
+	ctx, cancel := TestContext(t)
 	defer cancel()
 
 	cases := []struct {
@@ -411,7 +411,7 @@ func Test_CaptureToPodTranslator_GetCaptureTargetsOnNode(t *testing.T) {
 }
 
 func Test_CaptureToPodTranslator_updateCaptureTargetsOSOnNode(t *testing.T) {
-	ctx, cancel := createTestContext(t)
+	ctx, cancel := TestContext(t)
 	defer cancel()
 
 	cases := []struct {
@@ -590,7 +590,7 @@ func Test_CaptureToPodTranslator_ObtainCaptureJobPodEnv(t *testing.T) {
 }
 
 func Test_CaptureToPodTranslator_RenderJob_NodeSelected(t *testing.T) {
-	ctx, cancel := createTestContext(t)
+	ctx, cancel := TestContext(t)
 	defer cancel()
 
 	cases := []struct {
@@ -834,7 +834,7 @@ func isIgnorableEnvVar(envVar corev1.EnvVar) bool {
 }
 
 func Test_CaptureToPodTranslator_TranslateCaptureToJobs(t *testing.T) {
-	ctx, cancel := createTestContext(t)
+	ctx, cancel := TestContext(t)
 	defer cancel()
 
 	captureName := "capture-test"
@@ -1779,7 +1779,7 @@ func Test_CaptureToPodTranslator_TranslateCaptureToJobs(t *testing.T) {
 }
 
 func Test_CaptureToPodTranslator_TranslateCaptureToJobs_JobNumLimit(t *testing.T) {
-	ctx, cancel := createTestContext(t)
+	ctx, cancel := TestContext(t)
 	defer cancel()
 
 	captureName := "capture-test"

--- a/pkg/capture/crd_to_job_test.go
+++ b/pkg/capture/crd_to_job_test.go
@@ -4,8 +4,11 @@
 package capture
 
 import (
+	"context"
 	"fmt"
+	"os/signal"
 	"strconv"
+	"syscall"
 	"testing"
 	"time"
 
@@ -135,6 +138,9 @@ func Test_CaptureTargetsOnNode_AddNodeInterface(t *testing.T) {
 }
 
 func Test_CaptureToPodTranslator_GetCaptureTargetsOnNode(t *testing.T) {
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM)
+	defer cancel()
+
 	cases := []struct {
 		name                     string
 		captureTarget            retinav1alpha1.CaptureTarget
@@ -393,7 +399,7 @@ func Test_CaptureToPodTranslator_GetCaptureTargetsOnNode(t *testing.T) {
 
 			k8sClient := fakeclientset.NewSimpleClientset(objects...)
 			captureToPodTranslator := NewCaptureToPodTranslatorForTest(k8sClient)
-			gotCaptureTargetsOnNode, err := captureToPodTranslator.getCaptureTargetsOnNode(tt.captureTarget)
+			gotCaptureTargetsOnNode, err := captureToPodTranslator.getCaptureTargetsOnNode(ctx, tt.captureTarget)
 			if tt.wantErr != (err != nil) {
 				t.Errorf("getCaptureTargetsOnNode() want(%t) error, got error %s", tt.wantErr, err)
 			}
@@ -408,6 +414,9 @@ func Test_CaptureToPodTranslator_GetCaptureTargetsOnNode(t *testing.T) {
 }
 
 func Test_CaptureToPodTranslator_updateCaptureTargetsOSOnNode(t *testing.T) {
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM)
+	defer cancel()
+
 	cases := []struct {
 		name                     string
 		captureTargetsOnNode     *CaptureTargetsOnNode
@@ -457,7 +466,7 @@ func Test_CaptureToPodTranslator_updateCaptureTargetsOSOnNode(t *testing.T) {
 
 			k8sClient := fakeclientset.NewSimpleClientset(objects...)
 			captureToPodTranslator := NewCaptureToPodTranslatorForTest(k8sClient)
-			err := captureToPodTranslator.updateCaptureTargetsOSOnNode(tt.captureTargetsOnNode)
+			err := captureToPodTranslator.updateCaptureTargetsOSOnNode(ctx, tt.captureTargetsOnNode)
 			if tt.wantErr != (err != nil) {
 				t.Errorf("updateCaptureTargetsOSOnNode() want(%t) error, got error %s", tt.wantErr, err)
 			}
@@ -584,6 +593,9 @@ func Test_CaptureToPodTranslator_ObtainCaptureJobPodEnv(t *testing.T) {
 }
 
 func Test_CaptureToPodTranslator_RenderJob_NodeSelected(t *testing.T) {
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM)
+	defer cancel()
+
 	cases := []struct {
 		name                string
 		captureTargetOnNode *CaptureTargetsOnNode
@@ -670,7 +682,7 @@ func Test_CaptureToPodTranslator_RenderJob_NodeSelected(t *testing.T) {
 			k8sClient := fakeclientset.NewSimpleClientset()
 			log.SetupZapLogger(log.GetDefaultLogOpts())
 			captureToPodTranslator := NewCaptureToPodTranslatorForTest(k8sClient)
-			err := captureToPodTranslator.initJobTemplate(&retinav1alpha1.Capture{
+			err := captureToPodTranslator.initJobTemplate(ctx, &retinav1alpha1.Capture{
 				Spec: retinav1alpha1.CaptureSpec{
 					CaptureConfiguration: retinav1alpha1.CaptureConfiguration{},
 					OutputConfiguration:  retinav1alpha1.OutputConfiguration{},
@@ -825,6 +837,9 @@ func isIgnorableEnvVar(envVar corev1.EnvVar) bool {
 }
 
 func Test_CaptureToPodTranslator_TranslateCaptureToJobs(t *testing.T) {
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM)
+	defer cancel()
+
 	captureName := "capture-test"
 	hostPath := "/tmp/capture"
 	timestamp := file.Now()
@@ -1711,7 +1726,7 @@ func Test_CaptureToPodTranslator_TranslateCaptureToJobs(t *testing.T) {
 			}
 			k8sClient := fakeclientset.NewSimpleClientset(objects...)
 			captureToPodTranslator := NewCaptureToPodTranslatorForTest(k8sClient)
-			jobs, err := captureToPodTranslator.TranslateCaptureToJobs(&tt.capture)
+			jobs, err := captureToPodTranslator.TranslateCaptureToJobs(ctx, &tt.capture)
 			if tt.wantErr != (err != nil) {
 				t.Errorf("TranslateCaptureToJobs() want(%t) error, got error %s", tt.wantErr, err)
 			}
@@ -1767,6 +1782,9 @@ func Test_CaptureToPodTranslator_TranslateCaptureToJobs(t *testing.T) {
 }
 
 func Test_CaptureToPodTranslator_TranslateCaptureToJobs_JobNumLimit(t *testing.T) {
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM)
+	defer cancel()
+
 	captureName := "capture-test"
 	hostPath := "/tmp/capture"
 	cases := []struct {
@@ -1858,7 +1876,7 @@ func Test_CaptureToPodTranslator_TranslateCaptureToJobs_JobNumLimit(t *testing.T
 			k8sClient := fakeclientset.NewSimpleClientset(objects...)
 			captureToPodTranslator := NewCaptureToPodTranslatorForTest(k8sClient)
 			captureToPodTranslator.config.CaptureJobNumLimit = tt.jobNumLimit
-			_, err := captureToPodTranslator.TranslateCaptureToJobs(&tt.capture)
+			_, err := captureToPodTranslator.TranslateCaptureToJobs(ctx, &tt.capture)
 			if tt.wantErr != (err != nil) {
 				t.Errorf("TranslateCaptureToJobs() want(%t) error, got error %s", tt.wantErr, err)
 			}

--- a/pkg/capture/crd_to_job_test.go
+++ b/pkg/capture/crd_to_job_test.go
@@ -4,11 +4,8 @@
 package capture
 
 import (
-	"context"
 	"fmt"
-	"os/signal"
 	"strconv"
-	"syscall"
 	"testing"
 	"time"
 
@@ -138,7 +135,7 @@ func Test_CaptureTargetsOnNode_AddNodeInterface(t *testing.T) {
 }
 
 func Test_CaptureToPodTranslator_GetCaptureTargetsOnNode(t *testing.T) {
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM)
+	ctx, cancel := createTestContext(t)
 	defer cancel()
 
 	cases := []struct {
@@ -414,7 +411,7 @@ func Test_CaptureToPodTranslator_GetCaptureTargetsOnNode(t *testing.T) {
 }
 
 func Test_CaptureToPodTranslator_updateCaptureTargetsOSOnNode(t *testing.T) {
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM)
+	ctx, cancel := createTestContext(t)
 	defer cancel()
 
 	cases := []struct {
@@ -593,7 +590,7 @@ func Test_CaptureToPodTranslator_ObtainCaptureJobPodEnv(t *testing.T) {
 }
 
 func Test_CaptureToPodTranslator_RenderJob_NodeSelected(t *testing.T) {
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM)
+	ctx, cancel := createTestContext(t)
 	defer cancel()
 
 	cases := []struct {
@@ -837,7 +834,7 @@ func isIgnorableEnvVar(envVar corev1.EnvVar) bool {
 }
 
 func Test_CaptureToPodTranslator_TranslateCaptureToJobs(t *testing.T) {
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM)
+	ctx, cancel := createTestContext(t)
 	defer cancel()
 
 	captureName := "capture-test"
@@ -1782,7 +1779,7 @@ func Test_CaptureToPodTranslator_TranslateCaptureToJobs(t *testing.T) {
 }
 
 func Test_CaptureToPodTranslator_TranslateCaptureToJobs_JobNumLimit(t *testing.T) {
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM)
+	ctx, cancel := createTestContext(t)
 	defer cancel()
 
 	captureName := "capture-test"

--- a/pkg/capture/outputlocation/blob.go
+++ b/pkg/capture/outputlocation/blob.go
@@ -42,7 +42,7 @@ func (bu *BlobUpload) Enabled() bool {
 	return true
 }
 
-func (bu *BlobUpload) Output(srcFilePath string) error {
+func (bu *BlobUpload) Output(ctx context.Context, srcFilePath string) error {
 	bu.l.Info("Upload capture file to blob.", zap.String("location", bu.Name()))
 	blobURL, err := readBlobSASURL()
 	if err != nil {
@@ -71,7 +71,7 @@ func (bu *BlobUpload) Output(srcFilePath string) error {
 
 	blobName := filepath.Base(srcFilePath)
 	_, err = azClient.UploadFile(
-		context.TODO(),
+		ctx,
 		"",
 		blobName,
 		blobFile,

--- a/pkg/capture/outputlocation/hostpath.go
+++ b/pkg/capture/outputlocation/hostpath.go
@@ -4,6 +4,7 @@
 package outputlocation
 
 import (
+	"context"
 	"io"
 	"os"
 	"path/filepath"
@@ -37,7 +38,7 @@ func (hp *HostPath) Enabled() bool {
 	return true
 }
 
-func (hp *HostPath) Output(srcFilePath string) error {
+func (hp *HostPath) Output(_ context.Context, srcFilePath string) error {
 	hostPath := os.Getenv(string(captureConstants.CaptureOutputLocationEnvKeyHostPath))
 	hp.l.Info("Copy file",
 		zap.String("location", hp.Name()),

--- a/pkg/capture/outputlocation/output.go
+++ b/pkg/capture/outputlocation/output.go
@@ -3,11 +3,13 @@
 
 package outputlocation
 
+import "context"
+
 type Location interface {
 	// Name returns the name of the output location.
 	Name() string
 	// Enabled checks whether a output location is enabled.
 	Enabled() bool
 	// Output outputs source file to the location specified by the users.
-	Output(srcFilePath string) error
+	Output(ctx context.Context, srcFilePath string) error
 }

--- a/pkg/capture/outputlocation/output_test.go
+++ b/pkg/capture/outputlocation/output_test.go
@@ -4,6 +4,7 @@
 package outputlocation
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -110,6 +111,9 @@ func TestOutput(t *testing.T) {
 		},
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			for k, v := range tt.env {
@@ -122,7 +126,7 @@ func TestOutput(t *testing.T) {
 				}
 			}()
 
-			err := tt.outputLocation.Output(tt.srcPath)
+			err := tt.outputLocation.Output(ctx, tt.srcPath)
 			assert.Equal(t, tt.hasError, err != nil, "Output check failed on source file open")
 		})
 	}

--- a/pkg/capture/outputlocation/pvc.go
+++ b/pkg/capture/outputlocation/pvc.go
@@ -4,6 +4,7 @@
 package outputlocation
 
 import (
+	"context"
 	"io"
 	"os"
 	"path/filepath"
@@ -37,7 +38,7 @@ func (pvc *PersistentVolumeClaim) Enabled() bool {
 	return true
 }
 
-func (pvc *PersistentVolumeClaim) Output(srcFilePath string) error {
+func (pvc *PersistentVolumeClaim) Output(_ context.Context, srcFilePath string) error {
 	dstDir := captureConstants.PersistentVolumeClaimVolumeMountPathLinux
 	pvc.l.Info("Copy file",
 		zap.String("location", pvc.Name()),

--- a/pkg/capture/outputlocation/s3.go
+++ b/pkg/capture/outputlocation/s3.go
@@ -77,7 +77,7 @@ func (su *S3Upload) Enabled() bool {
 	return true
 }
 
-func (su *S3Upload) Output(srcFilePath string) error {
+func (su *S3Upload) Output(ctx context.Context, srcFilePath string) error {
 	objectKey := path.Join(su.path, srcFilePath)
 
 	su.l.Info("Upload capture file to s3",
@@ -87,7 +87,7 @@ func (su *S3Upload) Output(srcFilePath string) error {
 		zap.String("objectKey", objectKey),
 	)
 
-	s3Client, err := su.getClient()
+	s3Client, err := su.getClient(ctx)
 	if err != nil {
 		su.l.Error("Failed to get AWS client", zap.Error(err))
 		return err
@@ -101,7 +101,7 @@ func (su *S3Upload) Output(srcFilePath string) error {
 	}
 	defer s3File.Close()
 
-	_, err = s3Client.PutObject(context.TODO(), &s3.PutObjectInput{
+	_, err = s3Client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket: aws.String(su.bucket),
 		Key:    aws.String(objectKey),
 		Body:   s3File,
@@ -117,7 +117,7 @@ func (su *S3Upload) Output(srcFilePath string) error {
 	return nil
 }
 
-func (su *S3Upload) getClient() (*s3.Client, error) {
+func (su *S3Upload) getClient(ctx context.Context) (*s3.Client, error) {
 	var opts []func(options *config.LoadOptions) error
 
 	if su.endpoint != "" {
@@ -147,7 +147,7 @@ func (su *S3Upload) getClient() (*s3.Client, error) {
 		)))
 	}
 
-	cfg, err := config.LoadDefaultConfig(context.TODO(),
+	cfg, err := config.LoadDefaultConfig(ctx,
 		opts...,
 	)
 	if err != nil {

--- a/pkg/capture/provider/interface.go
+++ b/pkg/capture/provider/interface.go
@@ -4,7 +4,7 @@
 package provider
 
 import (
-	"os"
+	"context"
 
 	"github.com/microsoft/retina/pkg/capture/file"
 )
@@ -14,7 +14,7 @@ type NetworkCaptureProviderInterface interface {
 	// Setup prepares the provider with folder to store network capture for temporary.
 	Setup(filename file.CaptureFilename) (string, error)
 	// CaptureNetworkPacket capture network traffic per user input and store the captured network packets in local directory.
-	CaptureNetworkPacket(filter string, duration, maxSize int, sigChan <-chan os.Signal) error
+	CaptureNetworkPacket(ctx context.Context, filter string, duration, maxSize int) error
 	// CollectMetadata collects network metadata and store network metadata info in local directory.
 	CollectMetadata() error
 	// Cleanup removes created resources.

--- a/pkg/capture/provider/mock_network_capture.go
+++ b/pkg/capture/provider/mock_network_capture.go
@@ -10,7 +10,7 @@
 package provider
 
 import (
-	os "os"
+	context "context"
 	reflect "reflect"
 
 	file "github.com/microsoft/retina/pkg/capture/file"
@@ -41,17 +41,17 @@ func (m *MockNetworkCaptureProviderInterface) EXPECT() *MockNetworkCaptureProvid
 }
 
 // CaptureNetworkPacket mocks base method.
-func (m *MockNetworkCaptureProviderInterface) CaptureNetworkPacket(filter string, duration, maxSize int, sigChan <-chan os.Signal) error {
+func (m *MockNetworkCaptureProviderInterface) CaptureNetworkPacket(ctx context.Context, filter string, duration, maxSize int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CaptureNetworkPacket", filter, duration, maxSize, sigChan)
+	ret := m.ctrl.Call(m, "CaptureNetworkPacket", ctx, filter, duration, maxSize)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CaptureNetworkPacket indicates an expected call of CaptureNetworkPacket.
-func (mr *MockNetworkCaptureProviderInterfaceMockRecorder) CaptureNetworkPacket(filter, duration, maxSize, sigChan any) *gomock.Call {
+func (mr *MockNetworkCaptureProviderInterfaceMockRecorder) CaptureNetworkPacket(ctx, filter, duration, maxSize any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CaptureNetworkPacket", reflect.TypeOf((*MockNetworkCaptureProviderInterface)(nil).CaptureNetworkPacket), filter, duration, maxSize, sigChan)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CaptureNetworkPacket", reflect.TypeOf((*MockNetworkCaptureProviderInterface)(nil).CaptureNetworkPacket), ctx, filter, duration, maxSize)
 }
 
 // Cleanup mocks base method.

--- a/pkg/capture/provider/network_capture_unix.go
+++ b/pkg/capture/provider/network_capture_unix.go
@@ -6,6 +6,7 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -54,7 +55,10 @@ func (ncp *NetworkCaptureProvider) Setup(filename file.CaptureFilename) (string,
 	return ncp.TmpCaptureDir, nil
 }
 
-func (ncp *NetworkCaptureProvider) CaptureNetworkPacket(filter string, duration, maxSizeMB int, sigChan <-chan os.Signal) error {
+func (ncp *NetworkCaptureProvider) CaptureNetworkPacket(ctx context.Context, filter string, duration, maxSizeMB int) error {
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(duration)*time.Second)
+	defer cancel()
+
 	filename := file.CaptureFilename{CaptureName: ncp.CaptureName, NodeHostname: ncp.NodeHostName, StartTimestamp: ncp.StartTimestamp}
 	captureFileName := fmt.Sprintf("%s.pcap", filename)
 	captureFilePath := filepath.Join(ncp.TmpCaptureDir, captureFileName)
@@ -167,8 +171,9 @@ func (ncp *NetworkCaptureProvider) CaptureNetworkPacket(filter string, duration,
 
 	select {
 	case <-doneChan:
-	case sig := <-sigChan:
-		ncp.l.Info("Got OS signal, tcpdump will be stopped", zap.String("signal", sig.String()))
+	case <-ctx.Done():
+		err := ctx.Err()
+		ncp.l.Info("Tcpdump will be stopped - got OS signal, or timeout reached", zap.Error(err))
 	case err := <-errChan:
 		return err
 	}
@@ -177,7 +182,7 @@ func (ncp *NetworkCaptureProvider) CaptureNetworkPacket(filter string, duration,
 	// flushed to the capture file. Instead, we signal terminate and wait until the process to exit.
 	if err := captureStartCmd.Process.Signal(syscall.SIGTERM); err != nil {
 		ncp.l.Error("Failed to signal terminate to process, will kill the process", zap.Error(err))
-		if killErr := captureStartCmd.Process.Kill(); err != nil {
+		if killErr := captureStartCmd.Process.Kill(); killErr != nil {
 			return fmt.Errorf("tcpdump stop failed, error: %s", killErr)
 		}
 		return err

--- a/pkg/capture/provider/network_capture_unix.go
+++ b/pkg/capture/provider/network_capture_unix.go
@@ -172,8 +172,7 @@ func (ncp *NetworkCaptureProvider) CaptureNetworkPacket(ctx context.Context, fil
 	select {
 	case <-doneChan:
 	case <-ctx.Done():
-		err := ctx.Err()
-		ncp.l.Info("Tcpdump will be stopped - got OS signal, or timeout reached", zap.Error(err))
+		ncp.l.Info("Tcpdump will be stopped - got OS signal, or timeout reached", zap.Error(ctx.Err()))
 	case err := <-errChan:
 		return err
 	}

--- a/pkg/capture/provider/network_capture_win.go
+++ b/pkg/capture/provider/network_capture_win.go
@@ -130,8 +130,7 @@ func (ncp *NetworkCaptureProvider) CaptureNetworkPacket(ctx context.Context, fil
 	select {
 	case <-doneChan:
 	case <-ctx.Done():
-		err := ctx.Err()
-		ncp.l.Info("Netsh will be stopped - got OS signal, or timeout reached", zap.Error(err))
+		ncp.l.Info("Netsh will be stopped - got OS signal, or timeout reached", zap.Error(ctx.Err()))
 	}
 
 	ncp.l.Info("Stop netsh")

--- a/pkg/capture/test_helper.go
+++ b/pkg/capture/test_helper.go
@@ -7,11 +7,13 @@ import (
 	"testing"
 )
 
-func createTestContext(t *testing.T) (context.Context, func()) {
+func TestContext(t *testing.T) (context.Context, context.CancelFunc) {
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM)
+
 	deadline, ok := t.Deadline()
-	if !ok {
-		return signal.NotifyContext(context.Background(), syscall.SIGTERM)
-	} else {
-		return context.WithDeadline(context.Background(), deadline)
+	if ok {
+		return context.WithDeadline(ctx, deadline)
 	}
+
+	return ctx, cancel
 }

--- a/pkg/capture/test_helper.go
+++ b/pkg/capture/test_helper.go
@@ -1,0 +1,17 @@
+package capture
+
+import (
+	"context"
+	"os/signal"
+	"syscall"
+	"testing"
+)
+
+func createTestContext(t *testing.T) (context.Context, func()) {
+	deadline, ok := t.Deadline()
+	if !ok {
+		return signal.NotifyContext(context.Background(), syscall.SIGTERM)
+	} else {
+		return context.WithDeadline(context.Background(), deadline)
+	}
+}

--- a/pkg/controllers/operator/capture/controller.go
+++ b/pkg/controllers/operator/capture/controller.go
@@ -224,7 +224,7 @@ func (cr *CaptureReconciler) createJobsFromCapture(ctx context.Context, capture 
 		Name:      capture.Name,
 	}
 
-	jobs, err := cr.captureToPodTranslator.TranslateCaptureToJobs(capture)
+	jobs, err := cr.captureToPodTranslator.TranslateCaptureToJobs(ctx, capture)
 	if err != nil {
 		cr.logger.Error("Failed to translate Capture to jobs", zap.Error(err), zap.String("Capture", captureRef.String()))
 		var errorReason string

--- a/pkg/controllers/operator/capture/suite_test.go
+++ b/pkg/controllers/operator/capture/suite_test.go
@@ -44,7 +44,7 @@ var _ = BeforeSuite(func() {
 
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
-	ctx, cancel = context.WithCancel(context.TODO())
+	ctx, cancel = context.WithCancel(context.Background())
 
 	By("Bootstrapping test environment")
 	testEnv = &envtest.Environment{


### PR DESCRIPTION
# Description

Refactoring the capture manager and capture commands to create a context hierarchy by passing it around, rather than creating a new one in each method with `context.TODO`.

## Related Issue

https://github.com/microsoft/retina/issues/317

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Additional Notes

https://go.dev/blog/context

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
