### PR TITLE
fix: captures document link not working.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ See [retina.sh](http://retina.sh) for documentation and examples.
 Retina has two major features:
 
 - [Metrics](https://retina.sh/docs/metrics/modes)
-- [Captures](https://retina.sh/docs/captures)
+- [Captures](https://retina.sh/docs/captures/overview)
 
 ### Metrics Quick Install Guide
 


### PR DESCRIPTION
# Description

Hiya, while doing #1326, I've noticed that the document link is not working. this PR is made with an intent to fix that.

You can see working `Captures` here - * https://github.com/Tatsinnit/retina/tree/fix/doclink?tab=readme-ov-file whereas the main repo has broken link for `captueres` which goes to page not found.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshot:

<img width="1456" alt="Screenshot 2025-02-10 at 8 38 19 AM" src="https://github.com/user-attachments/assets/4a5c1974-1882-46f7-856a-ff6de87fe77b" />


---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
