### PR TITLE
feat(shell): run bash as a login shell to get hostname in prompt

### DIFF
--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -24,4 +24,4 @@ RUN tdnf install -y \
 	wget \
 	&& tdnf clean all
 
-CMD ["/bin/bash"]
+CMD ["/bin/bash", "-l"]


### PR DESCRIPTION
# Description

Running `bash -l` causes bash to source /etc/profile, which includes the hostname in the shell prompt.
This is useful for keeping track of where retina-shell is running if you have multiple terminals open.

## Related Issue

N/A 

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

<img width="530" alt="image" src="https://github.com/user-attachments/assets/c16dc14d-a8b9-4e84-b19e-fb7e265b3a30" />

## Additional Notes

N/A

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
