### PR TITLE
feat(shell): install less in retina-shell image

### DIFF
--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -14,6 +14,7 @@ RUN tdnf install -y \
 	iputils \
 	jq \
 	ldns-utils \
+	less \
 	net-tools \
 	nftables \
 	nmap \


### PR DESCRIPTION
# Description

Install `less` command in retina-shell image.

## Related Issue

N/A

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

<img width="587" alt="image" src="https://github.com/user-attachments/assets/969a6847-4cd4-4a8e-acc1-f465f59cb165" />

## Additional Notes

N/A

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
