### PR TITLE
docs: fix broken links to `retina.sh/docs`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ If this pull request is related to any issue, please mention it here. Additional
 
 ## Checklist
 
-- [ ] I have read the [contributing documentation](https://retina.sh/docs/contributing).
+- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
 - [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
 - [ ] I have correctly attributed the author(s) of the code.
 - [ ] I have tested the changes locally.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,4 +31,4 @@ This will add a `Signed-off-by` trailer to your Git commit, affirming your accep
 
 ## More info
 
-Getting started guides, community meetings, and more can be found on the [Retina website](https://retina.sh/docs/contributing).
+Getting started guides, community meetings, and more can be found on the [Retina website](https://retina.sh/docs/Contributing/overview).

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Retina **collects customizable telemetry**, which can be exported to **multiple 
 
 ## Why Retina?
 
-Retina lets you **investigate network issues on-demand** and **continuously monitor your clusters**. For scenarios where Retina shines, see the intro docs [here](https://retina.sh/docs/intro)
+Retina lets you **investigate network issues on-demand** and **continuously monitor your clusters**. For scenarios where Retina shines, see the intro docs [here](https://retina.sh/docs/Introduction/intro)
 
 ## Documentation
 
@@ -37,8 +37,8 @@ See [retina.sh](http://retina.sh) for documentation and examples.
 
 Retina has two major features:
 
-- [Metrics](https://retina.sh/docs/metrics/modes)
-- [Captures](https://retina.sh/docs/captures/overview)
+- [Metrics](https://retina.sh/docs/Metrics/modes)
+- [Captures](https://retina.sh/docs/Captures/overview)
 
 ### Metrics Quick Install Guide
 
@@ -57,7 +57,7 @@ helm upgrade --install retina oci://ghcr.io/microsoft/retina/charts/retina \
 
 Set the `version` and image `tag` arguments to the desired version, if different.
 
-After Helm install, follow steps in [Using Prometheus and Grafana](https://retina.sh/docs/installation/grafana/prometheus-unmanaged) to set up metrics collection and visualization.
+After Helm install, follow the steps for setting up [Prometheus](https://retina.sh/docs/Installation/prometheus) and [Grafana](https://retina.sh/docs/Installation/grafana) to configure metrics collection and visualization.
 
 ### Captures Quick Start Guide
 
@@ -69,7 +69,7 @@ The preferred way to install the Retina CLI using [Krew](https://krew.sigs.k8s.i
 kubectl krew install retina
 ```
 
-Other installation options are documented in [CLI Installation](https://retina.sh/docs/installation/cli).
+Other installation options are documented in [CLI Installation](https://retina.sh/docs/Installation/CLI).
 
 Verify installation:
 
@@ -84,7 +84,7 @@ To quickly start creating a capture:
 kubectl retina capture create --name <my-capture> --namespace <my-namespace> --selector <app=my-app>
 ```
 
-For further CLI documentation, see [Capture with Retina CLI](https://retina.sh/docs/captures/cli).
+For further CLI documentation, see [Capture with Retina CLI](https://retina.sh/docs/Captures/cli).
 
 #### Captures via CRD
 
@@ -105,7 +105,7 @@ helm upgrade --install retina oci://ghcr.io/microsoft/retina/charts/retina \
     --set enabledPlugin_linux="\[dropreason\,packetforward\,linuxutil\,dns\,packetparser\]"
 ```
 
-Then follow steps in [Capture CRD](https://retina.sh/docs/captures/#option-2-capture-crd-custom-resource-definition) for documentation of the CRD and examples for setting up Captures.
+Then follow steps in [Capture CRD](https://retina.sh/docs/Captures/overview/#option-2-capture-crd-custom-resource-definition) for documentation of the CRD and examples for setting up Captures.
 
 ## Contributing
 
@@ -121,7 +121,7 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
-[Read more about how to begin contributing here.](https://retina.sh/docs/contributing)
+[Read more about how to begin contributing here.](https://retina.sh/docs/Contributing/overview)
 
 ### Verify signed images
 
@@ -136,7 +136,7 @@ cosign verify ghcr.io/$REPO/$IMAGE:$TAG --certificate-oidc-issuer https://token.
 
 ### Office Hours and Community Meetings
 
-We host a periodic open community meeting. [Find the details here.](https://retina.sh/docs/contributing/#office-hours-and-community-meetings)
+We host a periodic open community meeting. [Find the details here.](https://retina.sh/docs/Contributing/overview#office-hours-and-community-meetings)
 
 ## Trademarks
 

--- a/docs/03-Metrics/plugins/Linux/dns.md
+++ b/docs/03-Metrics/plugins/Linux/dns.md
@@ -12,7 +12,7 @@ The `dns` plugin requires the `CAP_SYS_ADMIN` capability.
 
 This plugin uses [Inspektor Gadget](https://github.com/inspektor-gadget/inspektor-gadget)'s DNS Tracer to track DNS traffic and generate basic metrics derived from the captured events.
 
-In [Advanced mode](https://retina.sh/docs/metrics/modes), the plugin further processes the capture results into an enriched Flow with additional Pod information. Subsequently, the Flow is transmitted to an external channel. This allows a DNS module to generate additional Pod-Level metrics.
+In [Advanced mode](https://retina.sh/docs/Metrics/modes), the plugin further processes the capture results into an enriched Flow with additional Pod information. Subsequently, the Flow is transmitted to an external channel. This allows a DNS module to generate additional Pod-Level metrics.
 
 ### Code locations
 


### PR DESCRIPTION
# Description

This PR fixes broken links to the contributing guide and other `retina.sh/docs` pages. 

## Related Issue

Resolves #1333

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/contributing).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

N/A

## Additional Notes

I also adjusted some working links to `retina.sh/docs` to avoid a brief "Page Not Found" flash before loading.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
