### PR TITLE
chore(test): increase telemetry interval of scale test

### DIFF
--- a/test/e2e/framework/scaletest/get-publish-metrics.go
+++ b/test/e2e/framework/scaletest/get-publish-metrics.go
@@ -27,7 +27,7 @@ import (
 const (
 	defaultRetryAttempts = 10
 	defaultRetryDelay    = 3 * time.Second
-	defaultInterval      = 2 * time.Minute
+	defaultInterval      = 10 * time.Minute
 )
 
 type GetAndPublishMetrics struct {


### PR DESCRIPTION
# Description

Scale test is a long running test (~4h), so telemetry interval can be increased to 10m to reduce the volume of telemetry produced while still remaining meaningful.

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
