### PR TITLE
fix(docs): Fix lack of space in title

### DIFF
--- a/docs/07-Consuming Tools/vscode.md
+++ b/docs/07-Consuming Tools/vscode.md
@@ -1,4 +1,4 @@
-# Retina Integration in AKS VS Code Extension
+# AKS VS Code Extension
 
 ## Overview
 


### PR DESCRIPTION
# Description

The recent addition to our docs by #1326 introduced a title without a space, this PR fixes that.

## Related Issue

N/A

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Before/Current
![image](https://github.com/user-attachments/assets/83d22b68-7941-4007-9e40-56f69f1a5056)

New
![image](https://github.com/user-attachments/assets/0b50ef40-28a6-4f2e-b969-318e3da7fd32)


---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
