### PR TITLE
fix(lint-ci): Removing golang-lint govet deprecated parameter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -47,8 +47,5 @@ linters-settings:
   govet:
     enable:
     - shadow
-    settings:
-      shadow:
-        strict: true
   lll:
     line-length: 200

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -44,7 +44,5 @@ linters-settings:
     - "performance"
     disabled-checks:
     - "hugeParam"
-  govet:
-    check-shadowing: true
   lll:
     line-length: 200

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -47,5 +47,8 @@ linters-settings:
   govet:
     enable:
     - shadow
+    settings:
+      shadow:
+        strict: true
   lll:
     line-length: 200

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -44,5 +44,8 @@ linters-settings:
     - "performance"
     disabled-checks:
     - "hugeParam"
+  govet:
+    enable:
+    - shadow
   lll:
     line-length: 200


### PR DESCRIPTION
# Description

After [deps: bump github.com/golangci/golangci-lint from 1.64.2 to 1.64.5 in /hack/tools](https://github.com/microsoft/retina/commit/f4d8f1610a54dc282282cdd3ac14c7f1291388c0), all PR started failing the golangci-lint workflow.
This PR removes a parameter that has been deprecated by golanci-lint.

## Related Issue

No issue created.

## Checklist

- [X] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [X] I have correctly attributed the author(s) of the code.
- [X] I have tested the changes locally.
- [X] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

See workflow below.
![image](https://github.com/user-attachments/assets/c1b0021d-5c02-4b21-bddd-e09171c91736)

## Additional Notes

Syntax updated as per golang-lint documentation
https://golangci-lint.run/usage/linters/#govet
![image](https://github.com/user-attachments/assets/f4e96ce2-7694-4dd6-b7bf-59be1767e271)

![image](https://github.com/user-attachments/assets/a0da406b-36d9-48f1-9dbf-a8a0824b0efb)

https://github.com/golangci/golangci-lint/blob/a8b68a590a88bbde93b27f8bf02031cb1db78b2b/pkg/config/loader.go#L402-L407
![image](https://github.com/user-attachments/assets/75eea0c1-1b19-468d-a511-35db13c0bd9e)

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
