### PR TITLE
test(release): Add release validation workflow

### DIFF
--- a/.github/workflows/release-validation.yaml
+++ b/.github/workflows/release-validation.yaml
@@ -1,0 +1,72 @@
+name: Release Validation
+
+on:
+  workflow_run:
+    workflows:
+      - Release Retina Charts
+      - Release Retina Container Images
+    types:
+      - completed
+
+jobs:
+  release_validation:
+    name: Release Validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4.2.2
+
+      - name: Get latest tag
+        id: get_latest_tag
+        run: |
+          TAG=$(curl -s https://api.github.com/repos/microsoft/retina/releases | jq -r '.[0].name')
+          echo "TAG=$TAG" >> $GITHUB_ENV
+
+      - name: Test Docker images pull
+        run: |
+          TAG=${{ env.TAG }}
+          images=(
+             "retina-agent"
+             "retina-init"
+             "retina-operator"
+             "kubectl-retina"
+             "retina-shell"
+          )
+          for image in "${images[@]}"; do
+            echo "Checking image: ghcr.io/microsoft/$image:$TAG"
+            if curl --head --silent --fail "https://ghcr.io/v2/microsoft/$image/manifests/$TAG"; then
+              docker pull "ghcr.io/microsoft/$image:$TAG"
+            else
+              echo "Image ghcr.io/microsoft/$image:$TAG does not exist or you do not have access."
+            fi
+          done
+
+      - name: Test Helm chart pull
+        run: |
+          helm pull oci://ghcr.io/microsoft/retina/charts/retina-hubble --version  ${{ env.TAG }}
+          helm pull oci://ghcr.io/microsoft/retina/charts/retina --version ${{ env.TAG }}
+
+      - name: Setup kind cluster
+        uses: helm/kind-action@v1.12.0
+
+      # krew does not support installing a specific verison
+      # so if this step fails it means there was something wrong
+      # with the krew index update as part of the release
+      - name: Test krew install retina
+        run: |
+          (
+            set -x; cd "$(mktemp -d)" &&
+            OS="$(uname | tr '[:upper:]' '[:lower:]')" &&
+            ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" &&
+            KREW="krew-${OS}_${ARCH}" &&
+            curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/${KREW}.tar.gz" &&
+            tar zxvf "${KREW}.tar.gz" &&
+            ./"${KREW}" install krew
+            echo 'export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"' >> ~/.bashrc
+            source ~/.bashrc
+            kubectl krew install retina
+          )
+
+      - name: Check Go package version
+        run: |
+          go list -m github.com/microsoft/retina@{{ env.TAG }}


### PR DESCRIPTION
# Description

Add workflow to validate retina release. This workflow is dependent on successful run of images and helm release workflows. The job includes steps which validate the following:

1. All retina images can be pulled
2. Helm chart can be pulled
3. `kubectl krew install retina` works
4.  go package version exist

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

* I have tested the workflow dependency in my own fork
* I have tested every job step in my own fork using latest tag v0.0.26

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
