### PR TITLE
fix(conntrack): remove closing tcp connections from conntrack gracefully

### DIFF
--- a/pkg/plugin/conntrack/_cprog/conntrack.h
+++ b/pkg/plugin/conntrack/_cprog/conntrack.h
@@ -18,7 +18,9 @@
 // Time units in seconds
 
 // Define how long a TCP connection should be kept in the table
-#define CT_CONNECTION_LIFETIME_TCP 360 
+#define CT_CONNECTION_LIFETIME_TCP 360
+// Define how long a TCP connection should be kept in the TIME_WAIT state
+#define CT_TIME_WAIT_TIMEOUT_TCP 30
 // Define how long a non-TCP connection should be kept in the table
 #define CT_CONNECTION_LIFETIME_NONTCP 60
 // Define how long a TCP connection should be kept alive after receiving the first SYN


### PR DESCRIPTION
# Description

Before, conntrack will immediately delete a connection from its map whenever we see the `FIN` flag, which is problematic for connections that got closed from server-side. This PR fixes that by take into account the 4-way teardown process. Also refactored some code to make it more readable.
## Related Issue
Closes #1417


## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Verified with kapinger that the issue no longer appears
```bash
Mar 14 22:08:47.238: kapinger-good-65454cb695-kglv4:49474 (ID:40841) -> kapinger-good-65454cb695-nh72g:8080 (ID:40841) to-endpoint FORWARDED (TCP Flags: SYN:true)
Mar 14 22:08:47.238: kapinger-good-65454cb695-kglv4:49474 (ID:40841) <- kapinger-good-65454cb695-nh72g:8080 (ID:40841) to-stack FORWARDED (TCP Flags: SYN:true  ACK:true)
Mar 14 22:08:47.239: kapinger-good-65454cb695-kglv4:49474 (ID:40841) -> kapinger-ns/kapinger-service:8080 (world) to-stack FORWARDED (TCP Flags: SYN:true)
Mar 14 22:08:47.239: kapinger-good-65454cb695-kglv4:49474 (ID:40841) -> kapinger-good-65454cb695-nh72g:8080 (ID:40841) to-endpoint FORWARDED (TCP Flags: ACK:true)
Mar 14 22:08:47.239: kapinger-good-65454cb695-kglv4:49474 (ID:40841) -> kapinger-good-65454cb695-nh72g:8080 (ID:40841) to-endpoint FORWARDED (TCP Flags: PSH:true  ACK:true)
Mar 14 22:08:47.240: kapinger-good-65454cb695-kglv4:49474 (ID:40841) <- kapinger-good-65454cb695-nh72g:8080 (ID:40841) to-stack FORWARDED (TCP Flags: ACK:true)
Mar 14 22:08:47.240: kapinger-good-65454cb695-kglv4:49474 (ID:40841) <- kapinger-good-65454cb695-nh72g:8080 (ID:40841) to-stack FORWARDED (TCP Flags: PSH:true  ACK:true)
Mar 14 22:08:47.240: kapinger-good-65454cb695-kglv4:49474 (ID:40841) <- kapinger-good-65454cb695-nh72g:8080 (ID:40841) to-stack FORWARDED (TCP Flags: FIN:true  ACK:true)
Mar 14 22:08:47.240: kapinger-good-65454cb695-kglv4:49474 (ID:40841) -> kapinger-good-65454cb695-nh72g:8080 (ID:40841) to-endpoint FORWARDED (TCP Flags: ACK:true)
Mar 14 22:08:47.240: kapinger-good-65454cb695-kglv4:49474 (ID:40841) <- kapinger-ns/kapinger-service:8080 (world) to-endpoint FORWARDED (TCP Flags: SYN:true  ACK:true)
Mar 14 22:08:47.240: kapinger-good-65454cb695-kglv4:49474 (ID:40841) -> kapinger-good-65454cb695-nh72g:8080 (ID:40841) to-endpoint FORWARDED (TCP Flags: FIN:true  ACK:true)
Mar 14 22:08:47.240: kapinger-good-65454cb695-kglv4:49474 (ID:40841) -> kapinger-ns/kapinger-service:8080 (world) to-stack FORWARDED (TCP Flags: ACK:true)
Mar 14 22:08:47.240: kapinger-good-65454cb695-kglv4:49474 (ID:40841) <- kapinger-good-65454cb695-nh72g:8080 (ID:40841) to-stack FORWARDED (TCP Flags: ACK:true)
Mar 14 22:08:47.240: kapinger-good-65454cb695-kglv4:49474 (ID:40841) -> kapinger-ns/kapinger-service:8080 (world) to-stack FORWARDED (TCP Flags: PSH:true  ACK:true)
Mar 14 22:08:47.241: kapinger-good-65454cb695-kglv4:49474 (ID:40841) <- kapinger-ns/kapinger-service:8080 (world) to-endpoint FORWARDED (TCP Flags: ACK:true)
Mar 14 22:08:47.241: kapinger-good-65454cb695-kglv4:49474 (ID:40841) <- kapinger-ns/kapinger-service:8080 (world) to-endpoint FORWARDED (TCP Flags: PSH:true  ACK:true)
Mar 14 22:08:47.241: kapinger-good-65454cb695-kglv4:49474 (ID:40841) -> kapinger-ns/kapinger-service:8080 (world) to-stack FORWARDED (TCP Flags: ACK:true)
Mar 14 22:08:47.241: kapinger-good-65454cb695-kglv4:49474 (ID:40841) <- kapinger-ns/kapinger-service:8080 (world) to-endpoint FORWARDED (TCP Flags: FIN:true  ACK:true)
Mar 14 22:08:47.241: kapinger-good-65454cb695-kglv4:49474 (ID:40841) -> kapinger-ns/kapinger-service:8080 (world) to-stack FORWARDED (TCP Flags: FIN:true  ACK:true)
Mar 14 22:08:47.242: kapinger-good-65454cb695-kglv4:49474 (ID:40841) <- kapinger-ns/kapinger-service:8080 (world) to-endpoint FORWARDED (TCP Flags: ACK:true)
```

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
