### PR TITLE
fix(grafana): Fix Hubble DNS dash for Response Table query

### DIFF
--- a/deploy/grafana-dashboards/hubble-dns.json
+++ b/deploy/grafana-dashboards/hubble-dns.json
@@ -775,7 +775,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "label_replace(\r\n  label_replace(\r\n      sum by (query, qtypes, response, rcode) (\r\n        60*rate(hubble_dns_responses_total{cluster=\"$cluster\", instance=~\"$Nodes\", ips_returned!=\"0\"}[$__rate_interval])\r\n      ), \"rcode\", \"non-existent domain\", \"rcode\", \"nxdomain\"\r\n  ), \"rcode\", \"success\", \"rcode\", \"noerror\"\r\n)",
+          "expr": "label_replace(\r\n  label_replace(\r\n      sum by (query, qtypes, response, rcode) (\r\n        60*rate(hubble_dns_responses_total{cluster=\"$cluster\", instance=~\"$Nodes\"}[$__rate_interval])\r\n      ), \"rcode\", \"non-existent domain\", \"rcode\", \"nxdomain\"\r\n  ), \"rcode\", \"success\", \"rcode\", \"noerror\"\r\n)",
           "instant": true,
           "interval": "",
           "legendFormat": "__auto",


### PR DESCRIPTION
# Description

Fix query to remove `ips_returned!="0"` which only included responses that did return at least 1 IP - this resulted in no DNS errors showing in the table

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

With filter

![image](https://github.com/user-attachments/assets/047b6da3-0289-47bb-bf3e-087b941ececb)

Without filter

![image](https://github.com/user-attachments/assets/ee2ce1c0-e0d5-4ac4-ae25-74f5fa2a3400)

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
