### PR TITLE
ebpfwindows e2e tests

### DIFF
--- a/.github/workflows/e2e-test-event-writer.yml
+++ b/.github/workflows/e2e-test-event-writer.yml
@@ -1,0 +1,87 @@
+name: Build E2E Test Event Writer
+on:
+  pull_request:
+    branches: [main]
+  merge_group:
+    types: [checks_requested]
+  workflow_dispatch:
+
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  EVENT_WRITER_PATH: "${{ github.workspace }}/test/e2e/tools/event-writer/"
+
+jobs:
+  retina-win-e2e-bpf-images:
+    name: Build E2E Test Event Writer
+    runs-on: windows-2022
+
+    strategy:
+      matrix:
+        platform: ["windows"]
+        arch: ["amd64"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.2.2
+
+      - name: Az CLI login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION }}
+
+      - name: Set MSBuild path
+        run: |
+          echo "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Set standalone LLVM path
+        run: |
+          echo "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Nuget Restore
+        shell: cmd
+        run: |
+          nuget restore .\event_writer.sln
+        working-directory: ${{ env.EVENT_WRITER_PATH }}
+
+      - name: Configure eBPF store
+        shell: cmd
+        run: |
+          .\export_program_info.exe --clear
+          .\export_program_info.exe
+        working-directory: ${{ env.EVENT_WRITER_PATH }}\packages\eBPF-for-Windows.x64.0.20.0\build\native\bin
+
+      - name: Build Event-Writer
+        shell: cmd
+        run: |
+          msbuild /m /t:Clean /p:Configuration=Release /p:Platform=x64 /restore event_writer.sln
+          msbuild /m /p:Configuration=Release /p:Platform=x64 /restore event_writer.sln
+        working-directory: ${{ env.EVENT_WRITER_PATH }}
+
+      - name: Determine Docker tag
+        shell: pwsh
+        run: |
+          if ($env:IS_MERGE_GROUP -eq "true") {
+            $TAG = $(git tag --points-at HEAD)
+            if (-not $TAG) {
+              $TAG = $(git rev-parse --short HEAD)
+            }
+            echo "TAG=$TAG" >> $env:GITHUB_ENV
+          }
+        env:
+          IS_MERGE_GROUP: ${{ github.event_name == 'merge_group' }}
+
+      - name: Build Images
+        shell: cmd
+        run: |
+          if "%IS_MERGE_GROUP%"=="true" (
+            az acr login -n ${{ vars.ACR_NAME }} && docker build --file .\Dockerfile --tag ${{ vars.ACR_NAME }}/${{ github.repository }}/e2e-test-event-writer:${{ env.TAG }} . && docker build --file .\Dockerfile --tag ${{ vars.ACR_NAME }}/${{ github.repository }}/e2e-test-event-writer:latest . && docker push ${{ vars.ACR_NAME }}/${{ github.repository }}/e2e-test-event-writer:${{ env.TAG }} && docker push ${{ vars.ACR_NAME }}/${{ github.repository }}/e2e-test-event-writer:latest
+          )
+        working-directory: ${{ env.EVENT_WRITER_PATH }}
+        env:
+          IS_MERGE_GROUP: ${{ github.event_name == 'merge_group' }}

--- a/test/e2e/framework/kubernetes/apply-yaml-config.go
+++ b/test/e2e/framework/kubernetes/apply-yaml-config.go
@@ -1,0 +1,107 @@
+package kubernetes
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/restmapper"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+const (
+	applyTimeout = 10 * time.Minute
+)
+
+type ApplyYamlConfig struct {
+	KubeConfigFilePath string
+	YamlFilePath       string
+}
+
+func (a *ApplyYamlConfig) Run() error {
+	ctx, cancel := context.WithTimeout(context.Background(), applyTimeout)
+	defer cancel()
+
+	config, err := clientcmd.BuildConfigFromFlags("", a.KubeConfigFilePath)
+	if err != nil {
+		return fmt.Errorf("error building kubeconfig: %w", err)
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return fmt.Errorf("error creating dynamic client: %w", err)
+	}
+
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return fmt.Errorf("error creating discovery client: %w", err)
+	}
+
+	resources, err := restmapper.GetAPIGroupResources(discoveryClient)
+	if err != nil {
+		return fmt.Errorf("error getting API group resources: %w", err)
+	}
+
+	mapper := restmapper.NewDiscoveryRESTMapper(resources)
+
+	yamlFile, err := os.ReadFile(a.YamlFilePath)
+	if err != nil {
+		return fmt.Errorf("error reading YAML file: %w", err)
+	}
+
+	reader := bytes.NewReader(yamlFile)
+	decoder := yaml.NewYAMLOrJSONDecoder(reader, 100)
+	var rawObj unstructured.Unstructured
+	if err := decoder.Decode(&rawObj); err != nil {
+		return fmt.Errorf("error decoding YAML file: %w", err)
+	}
+
+	// Get GroupVersionResource to invoke the dynamic client
+	gvk := rawObj.GroupVersionKind()
+	restMapping, err := mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return fmt.Errorf("error getting REST mapping: %w", err)
+	}
+	gvr := restMapping.Resource
+
+	// Apply the YAML document
+	namespace := rawObj.GetNamespace()
+	if len(namespace) == 0 {
+		namespace = "default"
+	}
+	applyOpts := metav1.ApplyOptions{FieldManager: "kube-apply"}
+	_, err = dynamicClient.Resource(gvr).Namespace(namespace).Apply(ctx, rawObj.GetName(), &rawObj, applyOpts)
+	if err != nil {
+		return fmt.Errorf("apply error: %w", err)
+	}
+
+	log.Printf("applied YAML file: %s\n", a.YamlFilePath)
+	return nil
+}
+
+func (a *ApplyYamlConfig) Prevalidate() error {
+	_, err := os.Stat(a.YamlFilePath)
+	if os.IsNotExist(err) {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get current working directory %s: %w", cwd, err)
+		}
+		log.Printf("the current working directory %s", cwd)
+		return fmt.Errorf("YAML file not found at %s: working directory: %s: %w", a.YamlFilePath, cwd, err)
+	}
+	log.Printf("found YAML file at %s", a.YamlFilePath)
+
+	return nil
+}
+
+func (a *ApplyYamlConfig) Stop() error {
+	return nil
+}

--- a/test/e2e/framework/kubernetes/load-winbpf.go
+++ b/test/e2e/framework/kubernetes/load-winbpf.go
@@ -1,0 +1,110 @@
+package kubernetes
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	retry "github.com/microsoft/retina/test/retry"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type LoadAndPinWinBPF struct {
+	KubeConfigFilePath                 string
+	LoadAndPinWinBPFDeamonSetNamespace string
+	LoadAndPinWinBPFDeamonSetName      string
+}
+
+func ExecCommandInWinPod(KubeConfigFilePath string, cmd string, Namespace string, LabelSelector string) (string, error) {
+	defaultRetrier = retry.Retrier{Attempts: 15, Delay: 5 * time.Second}
+	// Create a context with a timeout (e.g., 30 seconds)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	config, err := clientcmd.BuildConfigFromFlags("", KubeConfigFilePath)
+	if err != nil {
+		return "", fmt.Errorf("error building kubeconfig: %w", err)
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return "", fmt.Errorf("error creating Kubernetes client: %w", err)
+	}
+
+	pods, err := clientset.CoreV1().Pods(Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: LabelSelector,
+	})
+	if err != nil {
+		panic(err.Error())
+	}
+
+	var windowsPod *v1.Pod
+	for pod := range pods.Items {
+		if pods.Items[pod].Spec.NodeSelector["kubernetes.io/os"] == "windows" {
+			windowsPod = &pods.Items[pod]
+		}
+	}
+
+	if windowsPod == nil {
+		return "", fmt.Errorf("no Windows Pod found in label %s", LabelSelector)
+	}
+
+	var outputBytes []byte
+	err = defaultRetrier.Do(ctx, func() error {
+		outputBytes, err = ExecPod(ctx, clientset, config, windowsPod.Namespace, windowsPod.Name, cmd)
+		if err != nil {
+			return fmt.Errorf("error executing command in windows pod: %w", err)
+		}
+
+		if len(outputBytes) == 0 {
+			return fmt.Errorf("no output from command")
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	return string(outputBytes), nil
+}
+
+func (a *LoadAndPinWinBPF) Run() error {
+	// Copy Event Writer into Node
+	LoadAndPinWinBPFDLabelSelector := fmt.Sprintf("name=%s", a.LoadAndPinWinBPFDeamonSetName)
+	_, err := ExecCommandInWinPod(a.KubeConfigFilePath, "move /Y .\\event-writer-helper.bat C:\\event-writer-helper.bat", a.LoadAndPinWinBPFDeamonSetNamespace, LoadAndPinWinBPFDLabelSelector)
+	if err != nil {
+		return err
+	}
+
+	_, err = ExecCommandInWinPod(a.KubeConfigFilePath, "C:\\event-writer-helper.bat EventWriter-Setup", a.LoadAndPinWinBPFDeamonSetNamespace, LoadAndPinWinBPFDLabelSelector)
+	if err != nil {
+		return err
+	}
+
+	// pin maps
+	output, err := ExecCommandInWinPod(a.KubeConfigFilePath, "C:\\event-writer-helper.bat EventWriter-LoadAndPinPrgAndMaps", a.LoadAndPinWinBPFDeamonSetNamespace, LoadAndPinWinBPFDLabelSelector)
+	if err != nil {
+		return err
+	}
+
+	time.Sleep(5 * time.Second)
+	fmt.Println(output)
+	if strings.Contains(output, "error") || strings.Contains(output, "failed") || strings.Contains(output, "existing") {
+		return fmt.Errorf("error in loading and pinning BPF maps and program: %s", output)
+	}
+	return nil
+}
+
+func (a *LoadAndPinWinBPF) Prevalidate() error {
+	return nil
+}
+
+func (a *LoadAndPinWinBPF) Stop() error {
+	return nil
+}

--- a/test/e2e/framework/kubernetes/unload-winbpf.go
+++ b/test/e2e/framework/kubernetes/unload-winbpf.go
@@ -1,0 +1,34 @@
+package kubernetes
+
+import (
+	"fmt"
+	"strings"
+)
+
+type UnLoadAndPinWinBPF struct {
+	KubeConfigFilePath                   string
+	UnLoadAndPinWinBPFDeamonSetNamespace string
+	UnLoadAndPinWinBPFDeamonSetName      string
+}
+
+func (a *UnLoadAndPinWinBPF) Run() error {
+	UnLoadAndPinWinBPFDLabelSelector := fmt.Sprintf("name=%s", a.UnLoadAndPinWinBPFDeamonSetName)
+	output, err := ExecCommandInWinPod(a.KubeConfigFilePath, "C:\\event-writer-helper.bat EventWriter-UnPinPrgAndMaps", a.UnLoadAndPinWinBPFDeamonSetNamespace, UnLoadAndPinWinBPFDLabelSelector)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(output)
+	if strings.Contains(output, "error") || strings.Contains(output, "failed") {
+		return fmt.Errorf("error in UnLoading and pinning BPF maps and program: %s", output)
+	}
+	return nil
+}
+
+func (a *UnLoadAndPinWinBPF) Prevalidate() error {
+	return nil
+}
+
+func (a *UnLoadAndPinWinBPF) Stop() error {
+	return nil
+}

--- a/test/e2e/framework/prometheus/prometheus.go
+++ b/test/e2e/framework/prometheus/prometheus.go
@@ -58,6 +58,31 @@ func CheckMetric(promAddress, metricName string, validMetric map[string]string) 
 	return nil
 }
 
+func GetMetricGuageValueFromBuffer(prometheusMetricData []byte, metricName string, expectedLabels map[string]string) (float64, error) {
+	metrics, err := getAllPrometheusMetricsFromBuffer(prometheusMetricData)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse prometheus metrics: %w", err)
+	}
+
+	for _, metric := range metrics {
+		if metric.GetName() == metricName {
+			for _, metric := range metric.GetMetric() {
+				// get all labels and values on the metric
+				metricLabels := map[string]string{}
+				for _, label := range metric.GetLabel() {
+					metricLabels[label.GetName()] = label.GetValue()
+				}
+				if reflect.DeepEqual(metricLabels, expectedLabels) {
+					return *metric.GetGauge().Value, nil
+				}
+
+			}
+		}
+	}
+
+	return 0, fmt.Errorf("metric not found %s", metricName)
+}
+
 func CheckMetricFromBuffer(prometheusMetricData []byte, metricName string, validMetric map[string]string) error {
 	metrics, err := getAllPrometheusMetricsFromBuffer(prometheusMetricData)
 	if err != nil {
@@ -132,12 +157,10 @@ func ParseReaderPrometheusMetrics(input io.Reader) (map[string]*promclient.Metri
 
 // When capturing promethus output via curl and exect, there's a lot
 // of garbage at the front
-func stripExecGarbage(s string) string {
+func StripExecGarbage(s string) string {
 	index := strings.Index(s, "#")
 	if index == -1 {
-		// If there's no `#`, return the original string
 		return s
 	}
-	// Slice the string up to the character before the first `#`
-	return s[:index]
+	return s[index:]
 }

--- a/test/e2e/jobs/jobs.go
+++ b/test/e2e/jobs/jobs.go
@@ -20,7 +20,6 @@ import (
 
 func CreateTestInfra(subID, rg, clusterName, location, kubeConfigFilePath string, createInfra bool) *types.Job {
 	job := types.NewJob("Create e2e test infrastructure")
-
 	if createInfra {
 		job.AddStep(&azure.CreateResourceGroup{
 			SubscriptionID:    subID,
@@ -106,6 +105,18 @@ func UninstallRetina(kubeConfigFilePath, chartPath string) *types.Job {
 	return job
 }
 
+func InstallEbpfXdp(kubeConfigFilePath string) *types.Job {
+	job := types.NewJob("Install EBPF and XDP")
+	job.AddStep(&kubernetes.CreateNamespace{
+		KubeConfigFilePath: kubeConfigFilePath,
+		Namespace:          "install-ebpf-xdp"}, nil)
+
+	job.AddStep(&kubernetes.ApplyYamlConfig{
+		YamlFilePath: "yaml/windows/install-ebpf-xdp.yaml",
+	}, nil)
+	return job
+}
+
 func InstallAndTestRetinaBasicMetrics(kubeConfigFilePath, chartPath string, testPodNamespace string) *types.Job {
 	job := types.NewJob("Install and test Retina with basic metrics")
 
@@ -166,8 +177,6 @@ func InstallAndTestRetinaBasicMetrics(kubeConfigFilePath, chartPath string, test
 			name := scenario.name + " - Arch: " + arch
 			job.AddScenario(dns.ValidateBasicDNSMetrics(name, scenario.req, scenario.resp, testPodNamespace, arch))
 		}
-
-		job.AddScenario(windows.ValidateWindowsBasicMetric())
 	}
 
 	job.AddStep(&kubernetes.EnsureStableComponent{
@@ -181,6 +190,7 @@ func InstallAndTestRetinaBasicMetrics(kubeConfigFilePath, chartPath string, test
 
 func UpgradeAndTestRetinaAdvancedMetrics(kubeConfigFilePath, chartPath, valuesFilePath string, testPodNamespace string) *types.Job {
 	job := types.NewJob("Upgrade and test Retina with advanced metrics")
+
 	// enable advanced metrics
 	job.AddStep(&kubernetes.UpgradeRetinaHelmChart{
 		Namespace:          common.KubeSystemNamespace,
@@ -232,12 +242,22 @@ func UpgradeAndTestRetinaAdvancedMetrics(kubeConfigFilePath, chartPath, valuesFi
 		},
 	}
 
+	// Validate Windows BPF Metrics
+	job.AddStep(&kubernetes.ApplyYamlConfig{
+		YamlFilePath: "yaml/windows/non-hpc-pod.yaml",
+	}, nil)
+	time.Sleep(2 * time.Minute)
+
 	for _, arch := range common.Architectures {
 		for _, scenario := range dnsScenarios {
 			name := scenario.name + " - Arch: " + arch
 			job.AddScenario(dns.ValidateAdvancedDNSMetrics(name, scenario.req, scenario.resp, kubeConfigFilePath, testPodNamespace, arch))
 		}
 	}
+
+	job.AddScenario(windows.ValidateWindowsBasicMetric())
+
+	job.AddScenario(windows.ValidateWinBpfMetricScenario())
 
 	job.AddScenario(latency.ValidateLatencyMetric(testPodNamespace))
 
@@ -318,6 +338,28 @@ func RunPerfTest(kubeConfigFilePath string, chartPath string) *types.Job {
 	}, &types.StepOptions{
 		SkipSavingParametersToJob: true,
 	})
+
+	return job
+}
+
+func LoadAndPinWinBPFJob(kubeConfigFilePath string) *types.Job {
+	job := types.NewJob("Load Windows BPF Maps")
+	job.AddStep(&kubernetes.LoadAndPinWinBPF{
+		KubeConfigFilePath:                 kubeConfigFilePath,
+		LoadAndPinWinBPFDeamonSetNamespace: "install-ebpf-xdp",
+		LoadAndPinWinBPFDeamonSetName:      "install-ebpf-xdp",
+	}, nil)
+
+	return job
+}
+
+func UnLoadAndPinWinBPFJob(kubeConfigFilePath string) *types.Job {
+	job := types.NewJob("Unload Windows BPF Maps")
+	job.AddStep(&kubernetes.UnLoadAndPinWinBPF{
+		KubeConfigFilePath:                   kubeConfigFilePath,
+		UnLoadAndPinWinBPFDeamonSetNamespace: "install-ebpf-xdp",
+		UnLoadAndPinWinBPFDeamonSetName:      "install-ebpf-xdp",
+	}, nil)
 
 	return job
 }

--- a/test/e2e/retina_e2e_test.go
+++ b/test/e2e/retina_e2e_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/microsoft/retina/test/e2e/common"
 	"github.com/microsoft/retina/test/e2e/framework/helpers"

--- a/test/e2e/scenarios/windows/scenario.go
+++ b/test/e2e/scenarios/windows/scenario.go
@@ -5,6 +5,25 @@ import (
 	"github.com/microsoft/retina/test/e2e/framework/types"
 )
 
+func ValidateWinBpfMetricScenario() *types.Scenario {
+	name := "Validate Windows BPF Basic and Advanced Metrics"
+	steps := []*types.StepWrapper{
+		{
+			Step: &ValidateWinBpfMetric{
+				KubeConfigFilePath:        "./test.pem",
+				RetinaDaemonSetNamespace:  common.KubeSystemNamespace,
+				RetinaDaemonSetName:       "retina-agent-win",
+				EbpfXdpDeamonSetNamespace: "install-ebpf-xdp",
+				EbpfXdpDeamonSetName:      "install-ebpf-xdp",
+				NonHpcAppNamespace:        "default",
+				NonHpcAppName:             "non-hpc",
+				NonHpcPodName:             "non-hpc-pod",
+			},
+		},
+	}
+	return types.NewScenario(name, steps...)
+}
+
 func ValidateWindowsBasicMetric() *types.Scenario {
 	name := "Windows Metrics"
 	steps := []*types.StepWrapper{

--- a/test/e2e/scenarios/windows/validate-winbpf-metrics.go
+++ b/test/e2e/scenarios/windows/validate-winbpf-metrics.go
@@ -1,0 +1,379 @@
+package windows
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	kubernetes "github.com/microsoft/retina/test/e2e/framework/kubernetes"
+	prom "github.com/microsoft/retina/test/e2e/framework/prometheus"
+)
+
+type ValidateWinBpfMetric struct {
+	KubeConfigFilePath        string
+	EbpfXdpDeamonSetNamespace string
+	EbpfXdpDeamonSetName      string
+	RetinaDaemonSetNamespace  string
+	RetinaDaemonSetName       string
+	NonHpcAppNamespace        string
+	NonHpcAppName             string
+	NonHpcPodName             string
+}
+
+func (v *ValidateWinBpfMetric) GetPromMetrics() (string, error) {
+	retinaLabelSelector := "k8s-app=retina"
+	var promOutput string
+	var err error
+	attempts := 10
+
+	for i := 0; i < attempts; i++ {
+		promOutput, err = kubernetes.ExecCommandInWinPod(
+			v.KubeConfigFilePath,
+			"C:\\event-writer-helper.bat EventWriter-GetRetinaPromMetrics",
+			v.RetinaDaemonSetNamespace,
+			retinaLabelSelector,
+		)
+
+		promOutput = prom.StripExecGarbage(promOutput)
+		if err == nil && promOutput != "" {
+			break
+		}
+		time.Sleep(3 * time.Second)
+	}
+
+	if err != nil {
+		return "", err
+	}
+	return promOutput, nil
+}
+
+func (v *ValidateWinBpfMetric) Run() error {
+	ebpfLabelSelector := fmt.Sprintf("name=%s", v.EbpfXdpDeamonSetName)
+	promOutput, err := v.GetPromMetrics()
+	if err != nil {
+		return err
+	}
+
+	fwd_labels := map[string]string{
+		"direction": "ingress",
+	}
+	drp_labels := map[string]string{
+		"direction": "ingress",
+		"reason":    "130, 0",
+	}
+
+	var preTestFwdBytes float64 = 0
+	var preTestDrpBytes float64 = 0
+	var preTestFwdCount float64 = 0
+	var preTestDrpCount float64 = 0
+	if promOutput == "" {
+		fmt.Println("Pre test - no prometheus metrics found")
+	} else {
+		err = prom.CheckMetricFromBuffer([]byte(promOutput), "networkobservability_forward_bytes", fwd_labels)
+		if err != nil {
+			return fmt.Errorf("failed to verify prometheus metrics: %w", err)
+		}
+
+		preTestFwdBytes, err = prom.GetMetricGuageValueFromBuffer([]byte(promOutput), "networkobservability_forward_bytes", fwd_labels)
+		if err != nil && strings.Contains(err.Error(), "failed to parse prometheus metrics") {
+			return err
+		}
+		fmt.Printf("Pre test - networkobservability_forward_bytes value %f, labels: %v\n", preTestFwdBytes, fwd_labels)
+
+		preTestFwdCount, err = prom.GetMetricGuageValueFromBuffer([]byte(promOutput), "networkobservability_forward_count", fwd_labels)
+		if err != nil && strings.Contains(err.Error(), "failed to parse prometheus metrics") {
+			return err
+		}
+		fmt.Printf("Pre test - networkobservability_forward_count value %f, labels: %v\n", preTestFwdCount, fwd_labels)
+
+		preTestDrpBytes, err = prom.GetMetricGuageValueFromBuffer([]byte(promOutput), "networkobservability_drop_bytes", drp_labels)
+		if err != nil && strings.Contains(err.Error(), "failed to parse prometheus metrics") {
+			return err
+		}
+		fmt.Printf("Pre test - networkobservability_drop_bytes value %f, labels: %v\n", preTestDrpBytes, drp_labels)
+
+		preTestDrpCount, err = prom.GetMetricGuageValueFromBuffer([]byte(promOutput), "networkobservability_drop_count", drp_labels)
+		if err != nil && strings.Contains(err.Error(), "failed to parse prometheus metrics") {
+			return err
+		}
+		fmt.Printf("Pre test - networkobservability_drop_count value %f, labels: %v\n", preTestDrpCount, drp_labels)
+	}
+
+	nonHpcLabelSelector := fmt.Sprintf("app=%s", v.NonHpcAppName)
+	nonHpcIpAddr, err := kubernetes.ExecCommandInWinPod(
+		v.KubeConfigFilePath,
+		"C:\\event-writer-helper.bat EventWriter-GetPodIpAddress",
+		v.NonHpcAppNamespace,
+		nonHpcLabelSelector)
+	if err != nil {
+		return err
+	}
+	nonHpcIpAddr = strings.TrimSpace(nonHpcIpAddr)
+
+	if strings.Contains(nonHpcIpAddr, "failed") || strings.Contains(nonHpcIpAddr, "error") {
+		return fmt.Errorf("failed to get nonHpcIpAddr")
+	}
+	fmt.Println("Non HPC IP Addr: ", nonHpcIpAddr)
+
+	nonHpcIfIndex, err := kubernetes.ExecCommandInWinPod(
+		v.KubeConfigFilePath,
+		"C:\\event-writer-helper.bat EventWriter-GetPodIfIndex",
+		v.NonHpcAppNamespace,
+		nonHpcLabelSelector)
+	if err != nil {
+		return err
+	}
+	if strings.Contains(nonHpcIfIndex, "failed") || strings.Contains(nonHpcIfIndex, "error") {
+		return fmt.Errorf("failed to get nonHpcIfIndex")
+	}
+	fmt.Println("Non HPC Interface Index: ", nonHpcIfIndex)
+
+	//Attach to the non HPC pod
+	output, err := kubernetes.ExecCommandInWinPod(
+		v.KubeConfigFilePath,
+		fmt.Sprintf("C:\\event-writer-helper.bat EventWriter-Attach %s", nonHpcIfIndex),
+		v.EbpfXdpDeamonSetNamespace,
+		ebpfLabelSelector)
+	if err != nil {
+		return err
+	}
+	fmt.Println(output)
+	if strings.Contains(output, "failed") || strings.Contains(output, "error") || strings.Contains(output, "exiting") {
+		return fmt.Errorf("failed to attach to non HPC pod interface %s", output)
+	}
+
+	//TRACE
+	fmt.Printf("Produce Trace Events\n")
+	//Example.com - 23.192.228.84
+	output, err = kubernetes.ExecCommandInWinPod(
+		v.KubeConfigFilePath,
+		"C:\\event-writer-helper.bat EventWriter-SetFilter -event 4 -srcIP 23.192.228.84",
+		v.EbpfXdpDeamonSetNamespace,
+		ebpfLabelSelector)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(output)
+	if strings.Contains(output, "failed") || strings.Contains(output, "error") || strings.Contains(output, "exiting") {
+		return fmt.Errorf("failed to set filter for event writer")
+	}
+
+	numcurls := 10
+	for numcurls > 0 {
+		_, err = kubernetes.ExecCommandInWinPod(
+			v.KubeConfigFilePath,
+			"C:\\event-writer-helper.bat EventWriter-Curl 23.192.228.84",
+			v.NonHpcAppNamespace,
+			nonHpcLabelSelector)
+		if err != nil {
+			return err
+		}
+		numcurls--
+	}
+
+	//DROP
+	time.Sleep(20 * time.Second)
+	fmt.Printf("Produce Drop Events\n")
+	output, err = kubernetes.ExecCommandInWinPod(
+		v.KubeConfigFilePath,
+		"C:\\event-writer-helper.bat EventWriter-SetFilter -event 1 -srcIP 23.192.228.84",
+		v.EbpfXdpDeamonSetNamespace,
+		ebpfLabelSelector)
+	if err != nil {
+		return err
+	}
+
+	if strings.Contains(output, "failed") || strings.Contains(output, "error") || strings.Contains(output, "exiting") {
+		return fmt.Errorf("failed to start event writer")
+	}
+
+	numcurls = 10
+	for numcurls > 0 {
+		_, err = kubernetes.ExecCommandInWinPod(
+			v.KubeConfigFilePath,
+			"C:\\event-writer-helper.bat EventWriter-Curl 23.192.228.84",
+			v.NonHpcAppNamespace,
+			nonHpcLabelSelector)
+		if err != nil {
+			return err
+		}
+		numcurls--
+	}
+
+	fmt.Println("Waiting for basic metrics to be updated as part of next polling cycle")
+	time.Sleep(60 * time.Second)
+	promOutput, err = v.GetPromMetrics()
+	if err != nil {
+		return err
+	}
+
+	//TBR
+	fmt.Println(promOutput)
+
+	postTestFwdCount, err := prom.GetMetricGuageValueFromBuffer([]byte(promOutput), "networkobservability_forward_count", fwd_labels)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Post test - networkobservability_forward_count value %f, labels: %v\n", preTestFwdBytes, fwd_labels)
+
+	postTestFwdBytes, err := prom.GetMetricGuageValueFromBuffer([]byte(promOutput), "networkobservability_forward_bytes", fwd_labels)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Post test - networkobservability_forward_bytes value %f, labels: %v\n", postTestFwdBytes, fwd_labels)
+
+	postTestDrpBytes, err := prom.GetMetricGuageValueFromBuffer([]byte(promOutput), "networkobservability_drop_bytes", drp_labels)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Post test - networkobservability_drop_bytes value %f, labels: %v\n", postTestDrpBytes, drp_labels)
+
+	postTestDrpCount, err := prom.GetMetricGuageValueFromBuffer([]byte(promOutput), "networkobservability_drop_count", drp_labels)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Post test - networkobservability_drop_count value %f, labels: %v\n", preTestDrpBytes, drp_labels)
+
+	if postTestFwdBytes <= preTestFwdBytes {
+		return fmt.Errorf("networkobservability_forward_bytes not incremented")
+	}
+
+	if postTestDrpBytes <= preTestDrpBytes {
+		return fmt.Errorf("networkobservability_drop_bytes not incremented")
+	}
+
+	if postTestFwdCount <= preTestFwdCount {
+		return fmt.Errorf("networkobservability_forward_count not incremented")
+	}
+	if postTestDrpCount <= preTestDrpCount {
+		return fmt.Errorf("networkobservability_drop_count not incremnted")
+	}
+
+	// Advanced Metrics
+	adv_fwd_count_labels := map[string]string{
+		"direction":     "egress",
+		"ip":            "23.192.228.84",
+		"namespace":     "",
+		"podname":       "",
+		"workload_kind": "unknown",
+		"workload_name": "unknown",
+	}
+	err = prom.CheckMetricFromBuffer([]byte(promOutput), "networkobservability_adv_forward_count", adv_fwd_count_labels)
+	if err != nil {
+		return fmt.Errorf("failed to find networkobservability_adv_forward_count")
+	}
+
+	tcpFlags := []string{"ACK", "FIN", "PSH"}
+	for _, flag := range tcpFlags {
+		tcpFlagLabels := map[string]string{
+			"flag":          flag,
+			"ip":            "23.192.228.84",
+			"namespace":     "",
+			"podname":       "",
+			"workload_kind": "unknown",
+			"workload_name": "unknown",
+		}
+
+		err = prom.CheckMetricFromBuffer([]byte(promOutput), "networkobservability_adv_tcpflags_count", tcpFlagLabels)
+		if err != nil {
+			return fmt.Errorf("failed to find networkobservability_adv_tcpflags_count for flag %s: %w", flag, err)
+		}
+		fmt.Printf("Found TCP flag metric for %s\n", flag)
+	}
+
+	adv_drop_byte_labels := map[string]string{
+		"direction":     "egress",
+		"ip":            "23.192.228.84",
+		"namespace":     "",
+		"podname":       "",
+		"reason":        "Drop_NotAccepted",
+		"workload_kind": "unknown",
+		"workload_name": "unknown",
+	}
+	err = prom.CheckMetricFromBuffer([]byte(promOutput), "networkobservability_adv_drop_bytes", adv_drop_byte_labels)
+	if err != nil {
+		return fmt.Errorf("failed to find networkobservability_adv_drop_bytes")
+	}
+
+	adv_drop_count_labels := map[string]string{
+		"direction":     "egress",
+		"ip":            "23.192.228.84",
+		"namespace":     "",
+		"podname":       "",
+		"reason":        "Drop_NotAccepted",
+		"workload_kind": "unknown",
+		"workload_name": "unknown",
+	}
+	err = prom.CheckMetricFromBuffer([]byte(promOutput), "networkobservability_adv_drop_count", adv_drop_count_labels)
+	if err != nil {
+		return fmt.Errorf("failed to find networkobservability_adv_drop_count")
+	}
+
+	adv_fwd_count_labels = map[string]string{
+		"direction":     "ingress",
+		"ip":            "10.224.0.202",
+		"namespace":     v.NonHpcAppNamespace,
+		"podname":       v.NonHpcPodName,
+		"workload_kind": "unknown",
+		"workload_name": "unknown",
+	}
+	err = prom.CheckMetricFromBuffer([]byte(promOutput), "networkobservability_adv_forward_count", adv_fwd_count_labels)
+	if err != nil {
+		return fmt.Errorf("failed to find networkobservability_adv_forward_count")
+	}
+
+	for _, flag := range tcpFlags {
+		tcpFlagLabels := map[string]string{
+			"flag":          flag,
+			"ip":            nonHpcIpAddr,
+			"namespace":     v.NonHpcAppNamespace,
+			"podname":       v.NonHpcPodName,
+			"workload_kind": "unknown",
+			"workload_name": "unknown",
+		}
+
+		err = prom.CheckMetricFromBuffer([]byte(promOutput), "networkobservability_adv_tcpflags_count", tcpFlagLabels)
+		if err != nil {
+			return fmt.Errorf("failed to find networkobservability_adv_tcpflags_count for flag %s: %w", flag, err)
+		}
+		fmt.Printf("Found TCP flag metric for %s\n", flag)
+	}
+
+	adv_drop_byte_labels = map[string]string{
+		"direction":     "ingress",
+		"ip":            nonHpcIpAddr,
+		"namespace":     v.NonHpcAppNamespace,
+		"podname":       v.NonHpcPodName,
+		"reason":        "Drop_NotAccepted",
+		"workload_kind": "unknown",
+		"workload_name": "unknown",
+	}
+	err = prom.CheckMetricFromBuffer([]byte(promOutput), "networkobservability_adv_drop_bytes", adv_drop_byte_labels)
+	if err != nil {
+		return fmt.Errorf("failed to find networkobservability_adv_drop_bytes with ingress label")
+	}
+
+	adv_drop_count_labels = map[string]string{
+		"direction":     "ingress",
+		"ip":            nonHpcIpAddr,
+		"namespace":     v.NonHpcAppNamespace,
+		"podname":       v.NonHpcPodName,
+		"reason":        "Drop_NotAccepted",
+		"workload_kind": "unknown",
+		"workload_name": "unknown",
+	}
+	err = prom.CheckMetricFromBuffer([]byte(promOutput), "networkobservability_adv_drop_count", adv_drop_count_labels)
+	if err != nil {
+		return fmt.Errorf("failed to find networkobservability_adv_drop_count with ingress label")
+	}
+	return nil
+}
+
+func (v *ValidateWinBpfMetric) Prevalidate() error {
+	return nil
+}
+
+func (v *ValidateWinBpfMetric) Stop() error {
+	return nil
+}

--- a/test/e2e/tools/event-writer/Dockerfile
+++ b/test/e2e/tools/event-writer/Dockerfile
@@ -1,0 +1,6 @@
+FROM mcr.microsoft.com/windows/servercore:ltsc2022 As base
+
+COPY ./install-ebpf-xdp.ps1 ./install-ebpf-xdp.ps1
+COPY ./x64/Release/bpf_event_writer.sys ./bpf_event_writer.sys
+COPY ./x64/Release/event_writer.exe ./event_writer.exe
+COPY ./event-writer-helper.bat ./event-writer-helper.bat

--- a/test/e2e/tools/event-writer/bpf_event_writer.c
+++ b/test/e2e/tools/event-writer/bpf_event_writer.c
@@ -1,0 +1,252 @@
+#include "bpf_helpers.h"
+#include "bpf_helper_defs.h"
+#include "bpf_endian.h"
+#include "xdp/ebpfhook.h"
+#include "event_writer.h"
+
+SEC (".maps")
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, struct five_tuple);
+    __type(value, uint8_t);
+    __uint(pinning, LIBBPF_PIN_BY_NAME);
+    __uint(max_entries, 512 * 4096);
+} five_tuple_map;
+
+SEC(".maps")
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __type(key, uint8_t);
+    __type(value, struct filter);
+    __uint(pinning, LIBBPF_PIN_BY_NAME);
+    __uint(max_entries, 1);
+} filter_map;
+
+SEC(".maps")
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, uint32_t);
+    __type(value, struct trace_notify);
+    __uint(max_entries, 1);
+} trc_buffer;
+
+SEC(".maps")
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __type(key, uint32_t);
+    __type(value, struct drop_notify);
+    __uint(max_entries, 1);
+} drp_buffer;
+
+SEC(".maps")
+struct {
+    __uint(type, BPF_MAP_TYPE_RINGBUF);
+    __uint(pinning, LIBBPF_PIN_BY_NAME);
+    __uint(max_entries, 512 * 4096);
+} cilium_events;
+
+SEC(".maps")
+struct {
+	__uint(type, BPF_MAP_TYPE_PERCPU_HASH);
+	__type(key, struct metrics_key);
+	__type(value, struct metrics_value);
+	__uint(pinning, LIBBPF_PIN_BY_NAME);
+	__uint(max_entries, 512 * 4096);
+} cilium_metrics;
+
+void update_metrics(uint64_t bytes, uint8_t direction,
+					uint8_t reason, uint16_t line, uint8_t file)
+{
+	struct metrics_value *entry, new_entry = {};
+	struct metrics_key key = {};
+
+	key.reason = reason;
+	key.dir    = direction;
+	key.line   = line;
+	key.file   = file;
+
+	entry = bpf_map_lookup_elem(&cilium_metrics, &key);
+	if (entry) {
+		entry->count += 1;
+		entry->bytes += bytes;
+	} else {
+		new_entry.count = 1;
+		new_entry.bytes = bytes;
+		bpf_map_update_elem(&cilium_metrics, &key, &new_entry, 0);
+	}
+}
+
+void create_trace_ntfy_event(struct trace_notify* trc_elm)
+{
+    memset(trc_elm, 0, sizeof(struct trace_notify));
+    trc_elm->type       = CILIUM_NOTIFY_TRACE;
+    trc_elm->subtype    = 0;
+	trc_elm->source     = 10; // random source
+	trc_elm->hash       = 0;
+    trc_elm->len_orig   = 128;
+	trc_elm->len_cap    = 128;
+    trc_elm->version    = 1;
+	trc_elm->src_label	= 0;
+	trc_elm->dst_label	= 0;
+	trc_elm->dst_id		= 0;
+	trc_elm->reason		= 0;
+	trc_elm->ifindex	= 0;
+}
+
+void create_drop_event(struct drop_notify* drp_elm)
+{
+    memset(drp_elm, 0, sizeof(struct drop_notify));
+    drp_elm->type       = CILIUM_NOTIFY_DROP;
+	drp_elm->subtype    = 6;
+	drp_elm->source     = 10; // random source
+	drp_elm->hash       = 0;
+	drp_elm->len_orig   = 128;
+	drp_elm->len_cap    = 128;
+	drp_elm->version    = 1;
+	drp_elm->src_label	= 0;
+	drp_elm->dst_label	= 0;
+	drp_elm->dst_id		= 0;
+	drp_elm->line		= 0;
+    drp_elm->file		= 0;
+    drp_elm->ext_error	= 0;
+	drp_elm->ifindex	= 0;
+}
+
+int
+check_filter(struct filter* flt, struct five_tuple* tup) {
+
+    if (flt->srcIP != 0 && flt->srcIP != tup->srcIP) {
+        return 1;
+    }
+
+    if (flt->dstIP != 0 && flt->dstIP != tup->dstIP) {
+        return 1;
+    }
+
+    if (flt->srcprt != 0 && flt->srcprt != tup->srcprt) {
+        return 1;
+    }
+
+    if (flt->dstprt != 0 && flt->dstprt != tup->dstprt) {
+        return 1;
+    }
+
+    return 0;
+}
+
+int extract_five_tuple_info(void* data, int bytes_to_copy, struct five_tuple* tup) {
+    struct ethhdr *eth;
+    uint8_t present = 1;
+
+    if (bytes_to_copy < sizeof(struct ethhdr)) {
+        return 1;
+    }
+
+    eth = data;
+    if (eth->ethertype != htons(0x0800)) {
+        return 1;
+    }
+
+    if (bytes_to_copy < sizeof(struct ethhdr) + sizeof(struct iphdr)) {
+        return 1;
+    }
+
+    struct iphdr *iph = data + sizeof(struct ethhdr);
+
+    // Only process TCP or UDP packets
+    if (iph->protocol != 6 && iph->protocol != 17) {
+        return 1;
+    }
+
+    tup->srcIP = htonl(iph->saddr);
+    tup->dstIP = htonl(iph->daddr);
+    tup->proto = iph->protocol;
+
+    if (tup->proto == 6) {
+        if (bytes_to_copy < sizeof(struct ethhdr) + sizeof(struct iphdr) + sizeof(struct tcphdr)) {
+            return 1;
+        }
+
+        struct tcphdr *tcph = data + sizeof(struct ethhdr) + sizeof(struct iphdr);
+        tup->srcprt = htons(tcph->source);
+        tup->dstprt = htons(tcph->dest);
+    }
+    else if (tup->proto == 17) {
+        if (bytes_to_copy < sizeof(struct ethhdr) + sizeof(struct iphdr) + sizeof(struct udphdr)) {
+            return 1;
+        }
+
+        struct udphdr *udph = data + sizeof(struct ethhdr) + sizeof(struct iphdr);
+        tup->srcprt = htons(udph->source);
+        tup->dstprt = htons(udph->dest);
+    }
+    return 0;
+}
+
+SEC("xdp")
+int
+event_writer(xdp_md_t* ctx) {
+    uint8_t flt_key = 0;
+    uint32_t buf_key = 0;
+    struct filter* flt;
+    struct five_tuple tup;
+    uint32_t size_to_copy = 128;
+    uint8_t flt_evttype, present = 1;
+    uint8_t reason  = 0;
+
+    if ((uintptr_t)ctx->data + size_to_copy > (uintptr_t)ctx->data_end) {
+		size_to_copy = (uintptr_t)ctx->data_end - (uintptr_t)ctx->data;
+	}
+
+    memset(&tup, 0, sizeof(tup));
+    if (extract_five_tuple_info(ctx->data, size_to_copy, &tup) != 0) {
+        return XDP_PASS;
+    }
+
+    flt = (struct filter*) bpf_map_lookup_elem(&filter_map, &flt_key);
+	if (flt == NULL) {
+		return XDP_PASS;
+	}
+
+    if (check_filter(flt, &tup) != 0) {
+        return XDP_PASS;
+    }
+
+    if (bpf_map_update_elem(&five_tuple_map, &tup, &present, BPF_ANY) != 0) {
+        return XDP_PASS;
+    }
+
+    flt_evttype = flt->event;
+	if (flt_evttype == CILIUM_NOTIFY_TRACE) {
+        struct trace_notify* trc_elm;
+
+        //Create a Mock Trace Event
+        trc_elm = (struct trace_notify *) bpf_map_lookup_elem(&trc_buffer, &buf_key);
+        if (trc_elm == NULL) {
+            return XDP_PASS;
+        }
+        create_trace_ntfy_event(trc_elm);
+        memset(trc_elm->data, 0, sizeof(trc_elm->data));
+        memcpy(trc_elm->data, ctx->data, size_to_copy);
+        bpf_ringbuf_output(&cilium_events, trc_elm, sizeof(struct trace_notify), 0);
+    }
+
+    if (flt_evttype == CILIUM_NOTIFY_DROP) {
+        struct drop_notify* drp_elm;
+
+        //Create a Mock Drop Event
+        drp_elm = (struct drop_notify *) bpf_map_lookup_elem(&drp_buffer, &buf_key);
+        if (drp_elm == NULL) {
+            return XDP_PASS;
+        }
+        reason = 130;
+        create_drop_event(drp_elm);
+        memset(drp_elm->data, 0, sizeof(drp_elm->data));
+        memcpy(drp_elm->data, ctx->data, size_to_copy);
+        bpf_ringbuf_output(&cilium_events, drp_elm, sizeof(struct drop_notify), 0);
+    }
+
+    update_metrics(size_to_copy, METRIC_INGRESS, reason, 0, 0);
+
+    return XDP_PASS;
+}

--- a/test/e2e/tools/event-writer/event-writer-helper.bat
+++ b/test/e2e/tools/event-writer/event-writer-helper.bat
@@ -1,0 +1,62 @@
+@echo off
+REM Add logic to call a specific function based on the argument
+if "%1"=="EventWriter-Setup" goto EventWriter-Setup
+if "%1"=="EventWriter-SetFilter" goto EventWriter-SetFilter
+if "%1"=="EventWriter-GetRetinaPromMetrics" goto EventWriter-GetRetinaPromMetrics
+if "%1"=="EventWriter-Curl" goto EventWriter-Curl
+if "%1"=="EventWriter-LoadAndPinPrgAndMaps" goto EventWriter-LoadAndPinPrgAndMaps
+if "%1"=="EventWriter-UnPinPrgAndMaps" goto EventWriter-UnPinPrgAndMaps
+if "%1"=="EventWriter-Attach" goto EventWriter-Attach
+if "%1"=="EventWriter-GetRetinaPromMetrics" goto EventWriter-GetPodIpAddress
+if "%1"=="EventWriter-GetPodIpAddress" goto EventWriter-GetPodIpAddress
+if "%1"=="EventWriter-GetPodIfIndex" goto EventWriter-GetPodIfIndex
+goto :EOF
+
+:EventWriter-Setup
+   copy .\event_writer.exe C:\event_writer.exe
+   copy .\bpf_event_writer.sys C:\bpf_event_writer.sys
+   goto :EOF
+
+:EventWriter-SetFilter
+   set PREV_DIR=%CD%
+   cd C:\
+   .\event_writer.exe -set-filter -event %3 -srcIP %5 -ifindx %7
+   cd /d %PREV_DIR%
+   goto :EOF
+
+:EventWriter-Attach
+   set PREV_DIR=%CD%
+   cd C:\
+   .\event_writer.exe -attach -ifindx %2
+   cd /d %PREV_DIR%
+   goto :EOF
+
+:EventWriter-LoadAndPinPrgAndMaps
+   set PREV_DIR=%CD%
+   cd C:\
+   .\event_writer.exe -load-pin
+   cd /d %PREV_DIR%
+   goto :EOF
+
+:EventWriter-UnPinPrgAndMaps
+   set PREV_DIR=%CD%
+   cd C:\
+   .\event_writer.exe -unpin
+   cd /d %PREV_DIR%
+   goto :EOF
+
+:EventWriter-GetRetinaPromMetrics
+   curl -s http://localhost:10093/metrics
+   goto :EOF
+
+:EventWriter-Curl
+   curl http://%2
+   goto :EOF
+
+:EventWriter-GetPodIpAddress
+   powershell -command "Get-NetIPAddress | Where-Object {$_.AddressFamily -eq 'IPv4' -and $_.IPAddress -ne '127.0.0.1'} | Select-Object -ExpandProperty IPAddress"
+   goto :EOF
+
+:EventWriter-GetPodIfIndex
+   powershell -command "Get-NetAdapter | Where-Object { $_.InterfaceDescription -like '*Hyper-V Virtual Ethernet Container*' } | ForEach-Object { Write-Output $_.ifIndex }"
+   goto :EOF

--- a/test/e2e/tools/event-writer/event_writer.cpp
+++ b/test/e2e/tools/event-writer/event_writer.cpp
@@ -1,0 +1,329 @@
+#include <winsock2.h>
+#include <iphlpapi.h>
+#include <bpf/libbpf.h>
+#include <bpf/bpf.h>
+
+#include <vector>
+#include "event_writer.h"
+#include <ebpf_api.h>
+
+bpf_object *obj = NULL;
+bpf_link* link = NULL;
+
+int
+set_filter(struct filter* flt) {
+    uint8_t key = 0;
+    int map_flt_fd = 0;
+
+    // Attempt to open the pinned map
+    map_flt_fd = bpf_obj_get(FILTER_MAP_PIN_PATH);
+    if (map_flt_fd < 0) {
+        fprintf(stderr, "%s - failed to lookup filter_map\n", __FUNCTION__);
+        return 1;
+    }
+    if (bpf_map_update_elem(map_flt_fd, &key, flt, 0) != 0) {
+        fprintf(stderr, "%s - failed to update filter\n", __FUNCTION__);
+        return 1;
+    }
+    return 0;
+}
+
+int _pin(const char* pin_path, int fd, bool is_map) {
+    if (bpf_obj_get(pin_path) < 0) {
+        if (bpf_obj_pin(fd, pin_path) < 0) {
+            fprintf(stderr, "%s - failed to pin %s to %s\n", __FUNCTION__,
+                    is_map ? "map" : "prog", pin_path);
+            return 1;
+        }
+
+        printf("%s - %s successfully pinned at %s\n", __FUNCTION__,
+                    is_map ? "map" : "prog",
+                    pin_path);
+    } else {
+        printf("%s - pinned %s found %s\n", __FUNCTION__,
+                                            is_map ? "map" : "prog",
+                                            pin_path);
+    }
+    return 0;
+}
+
+int
+attach_program_to_interface(int ifindx) {
+    int evt_wrt_fd = 0;
+    evt_wrt_fd = bpf_obj_get(EVENT_WRITER_PIN_PATH);
+    if (evt_wrt_fd < 0) {
+        fprintf(stderr, "%s - failed to lookup event_writer at %s\n", __FUNCTION__, EVENT_WRITER_PIN_PATH);
+        return 1;
+    }
+
+    // Verify there's no program attached to the specified ifindex.
+    uint32_t program_id;
+    if (bpf_xdp_query_id(ifindx, 0, &program_id) < 0) {
+        if (bpf_xdp_attach(ifindx, evt_wrt_fd, 0, nullptr) != 0) {
+            fprintf(stderr, "%s - failed to attach to interface with ifindex %d\n", __FUNCTION__, ifindx);
+            return 1;
+        }
+        printf("%s - Attached program %s to interface with ifindex %d\n", __FUNCTION__, EVENT_WRITER_PIN_PATH, ifindx);
+    } else {
+        if (program_id == evt_wrt_fd) {
+            printf("%s - program alteady attached %s to interface with ifindex %d\n", __FUNCTION__, EVENT_WRITER_PIN_PATH, ifindx);
+        } else {
+            if (bpf_xdp_attach(ifindx, evt_wrt_fd, XDP_FLAGS_REPLACE, nullptr) != 0) {
+                fprintf(stderr, "%s - failed to attach to interface with ifindex %d\n", __FUNCTION__, ifindx);
+                return 1;
+            }
+        }
+    }
+
+    printf("%s - Attached program %s to interface with ifindex %d\n", __FUNCTION__, EVENT_WRITER_PIN_PATH, ifindx);
+    return 0;
+}
+
+int
+load_pin(void) {
+    struct bpf_program* prg = NULL;
+    struct bpf_map *map_ev = NULL, *map_met = NULL, *map_fvt = NULL, *map_flt = NULL;
+    int prg_fd = 0;
+
+    // Load the BPF object file
+    obj = bpf_object__open("bpf_event_writer.sys");
+    if (obj == NULL) {
+        fprintf(stderr, "%s - failed to open BPF object\n", __FUNCTION__);
+        goto fail;
+    }
+
+    // Load cilium_events map and event_writer bpf program
+    if (bpf_object__load(obj) < 0) {
+        fprintf(stderr, "%s - failed to load BPF sys\n", __FUNCTION__);
+        goto fail;
+    }
+
+    // Find the program by its name
+    prg = bpf_object__find_program_by_name(obj, "event_writer");
+    if (prg == NULL) {
+        fprintf(stderr, "%s - failed to find event_writer program", __FUNCTION__);
+        goto fail;
+    }
+
+    if (_pin(EVENT_WRITER_PIN_PATH, bpf_program__fd(prg), false) != 0) {
+        goto fail;
+    }
+
+    // Find the map by its name
+    map_ev = bpf_object__find_map_by_name(obj, "cilium_events");
+    if (map_ev == NULL) {
+        fprintf(stderr, "%s - failed to find cilium_events by name\n", __FUNCTION__);
+        goto fail;
+    }
+    if (_pin(EVENTS_MAP_PIN_PATH, bpf_map__fd(map_ev), true) != 0) {
+        goto fail;
+    }
+
+    // Find the map by its name
+    map_met = bpf_object__find_map_by_name(obj, "cilium_metrics");
+    if (map_met == NULL) {
+        fprintf(stderr, "%s - failed to find cilium_metrics by name\n", __FUNCTION__);
+        goto fail;
+    }
+    if (_pin(METRICS_MAP_PIN_PATH, bpf_map__fd(map_ev), true) != 0) {
+        goto fail;
+    }
+
+    // Find the map by its name
+    map_fvt = bpf_object__find_map_by_name(obj, "five_tuple_map");
+    if (map_fvt == NULL) {
+        fprintf(stderr, "%s - failed to find five_tuple_map by name\n", __FUNCTION__);
+        goto fail;
+    }
+    if (_pin(FIVE_TUPLE_MAP_PIN_PATH, bpf_map__fd(map_fvt), true) != 0) {
+        goto fail;
+    }
+
+    // Find the map by its name
+    map_flt = bpf_object__find_map_by_name(obj, "filter_map");
+    if (map_flt == NULL) {
+        fprintf(stderr, "%s - failed to lookup filter_map\n", __FUNCTION__);
+        goto fail;
+    }
+    if (_pin(FILTER_MAP_PIN_PATH, bpf_map__fd(map_flt), true) != 0) {
+        goto fail;
+    }
+
+    printf("%s - event-writer loaded successfully\n", __FUNCTION__);
+    bpf_object__close(obj);
+    return 0; // Return success
+
+fail:
+    if (prg != NULL) {
+        bpf_program__unpin(prg, EVENT_WRITER_PIN_PATH);
+    }
+
+    if (map_ev != NULL) {
+        bpf_map__unpin(map_ev, EVENTS_MAP_PIN_PATH);
+    }
+
+    if (map_flt != NULL) {
+        bpf_map__unpin(map_flt, FILTER_MAP_PIN_PATH);
+    }
+
+    if (map_fvt != NULL) {
+        bpf_map__unpin(map_fvt, FIVE_TUPLE_MAP_PIN_PATH);
+    }
+
+    if (map_met != NULL) {
+        bpf_map__unpin(map_met, METRICS_MAP_PIN_PATH);
+    }
+
+    if (obj != NULL) {
+        bpf_object__close(obj);
+    }
+    return 1;
+}
+
+int
+unpin(void) {
+    if (bpf_obj_get(EVENT_WRITER_PIN_PATH) < 0) {
+        fprintf(stderr, "%s - failed to lookup event_writer at %s\n", __FUNCTION__, EVENT_WRITER_PIN_PATH);
+    } else {
+        ebpf_object_unpin(EVENT_WRITER_PIN_PATH);
+    }
+
+    if (bpf_obj_get(FILTER_MAP_PIN_PATH) < 0) {
+        fprintf(stderr, "%s - failed to lookup filter_map at %s\n", __FUNCTION__, FILTER_MAP_PIN_PATH);
+   } else {
+       ebpf_object_unpin(FILTER_MAP_PIN_PATH);
+   }
+
+    if (bpf_obj_get(EVENTS_MAP_PIN_PATH) < 0) {
+         fprintf(stderr, "%s - failed to lookup cilium_events at %s\n", __FUNCTION__, EVENTS_MAP_PIN_PATH);
+    } else {
+        ebpf_object_unpin(EVENTS_MAP_PIN_PATH);
+    }
+
+    if (bpf_obj_get(METRICS_MAP_PIN_PATH) < 0) {
+        fprintf(stderr, "%s - failed to lookup cilium_metrics at %s\n", __FUNCTION__, METRICS_MAP_PIN_PATH);
+    } else {
+        ebpf_object_unpin(METRICS_MAP_PIN_PATH);
+    }
+
+    if (bpf_obj_get(FIVE_TUPLE_MAP_PIN_PATH) < 0) {
+        fprintf(stderr, "%s - failed to lookup five_tuple_map at %s\n", __FUNCTION__, FIVE_TUPLE_MAP_PIN_PATH);
+    } else {
+        ebpf_object_unpin(FIVE_TUPLE_MAP_PIN_PATH);
+    }
+
+    return 0;
+ }
+
+uint32_t _ipStrToUint(const char* ipStr) {
+    uint32_t ip = 0;
+    int part = 0;
+    int parts = 0;
+    const char *p = ipStr;
+    char c;
+
+    while ((c = *p++) != '\0') {
+        if (c >= '0' && c <= '9') {
+            part = part * 10 + (c - '0');
+        } else if (c == '.') {
+            ip = (ip << 8) | (part & 0xFF);
+            part = 0;
+            parts++;
+        } else {
+            // Invalid character in IP string.
+            return 0;
+        }
+    }
+
+    // Process the last octet.
+    ip = (ip << 8) | (part & 0xFF);
+    parts++;
+
+    // Ensure we have exactly four parts
+    if (parts != 4) {
+        return 0;
+    }
+
+    return ip;
+}
+
+int main(int argc, char* argv[]) {
+    setvbuf(stdout, NULL, _IONBF, 0);
+    // Parse the command-line arguments (flags)
+    if (argc < 2) {
+        fprintf(stderr, "valid arguments are required. Exiting..\n");
+        return 1;
+    }
+
+    if (strcmp(argv[1], "-load-pin") == 0) {
+        if (load_pin() != 0) {
+            return 1;
+        }
+    } else if (strcmp(argv[1], "-set-filter") == 0) {
+        struct filter flt;
+        memset(&flt, 0, sizeof(flt));
+
+        for (int i = 2; i < argc; i++) {
+            if (strcmp(argv[i], "-event") == 0) {
+                if (i + 1 < argc)
+                    flt.event = static_cast<uint8_t>(atoi(argv[++i]));
+            } else if (strcmp(argv[i], "-srcIP") == 0) {
+                if (i + 1 < argc)
+                    flt.srcIP = _ipStrToUint(argv[++i]);
+            } else if (strcmp(argv[i], "-dstIP") == 0) {
+                if (i + 1 < argc)
+                    flt.dstIP = _ipStrToUint(argv[++i]);
+            } else if (strcmp(argv[i], "-srcprt") == 0) {
+                if (i + 1 < argc)
+                    flt.srcprt = static_cast<uint16_t>(atoi(argv[++i]));
+            } else if (strcmp(argv[i], "-dstprt") == 0) {
+                if (i + 1 < argc)
+                    flt.dstprt = static_cast<uint16_t>(atoi(argv[++i]));
+            }
+        }
+        printf("Parsed Values:\n");
+        printf("Event: %d\n", flt.event);
+        printf("Source IP: %u.%u.%u.%u\n",
+               (flt.srcIP >> 24) & 0xFF, (flt.srcIP >> 16) & 0xFF,
+               (flt.srcIP >> 8) & 0xFF, flt.srcIP & 0xFF);
+        printf("Destination IP: %u.%u.%u.%u\n",
+               (flt.dstIP >> 24) & 0xFF, (flt.dstIP >> 16) & 0xFF,
+               (flt.dstIP >> 8) & 0xFF, flt.dstIP & 0xFF);
+        printf("Source Port: %u\n", flt.srcprt);
+        printf("Destination Port: %u\n", flt.dstprt);
+
+        if (set_filter(&flt) != 0) {
+            return 1;
+        } else {
+            printf("filter updated successfully\n");
+        }
+
+    } else if (strcmp(argv[1], "-attach") == 0) {
+        int ifindx = 0;
+        for (int i = 2; i < argc; i++) {
+            if (strcmp(argv[i], "-ifindx") == 0) {
+                if (i + 1 < argc)
+                    ifindx = static_cast<uint16_t>(atoi(argv[++i]));
+            }
+        }
+
+        printf("Interface Index: %d\n", ifindx);
+        if (ifindx <= 0) {
+            fprintf(stderr, "valid ifindx is required. Exiting..\n");
+            return 1;
+        }
+
+        if (attach_program_to_interface(ifindx) != 0) {
+            return 1;
+        }
+    } else if (strcmp(argv[1], "-unpin") == 0) {
+        if (unpin() != 0) {
+            return 1;
+        }
+    } else {
+        fprintf(stderr, "invalid arguments. Exiting..\n");
+        return 1;
+    }
+
+    return 0;
+}

--- a/test/e2e/tools/event-writer/event_writer.h
+++ b/test/e2e/tools/event-writer/event_writer.h
@@ -1,0 +1,176 @@
+/* Copyright (c) Microsoft Corporation */
+/* SPDX-License-Identifier: MIT */
+
+#ifndef _EVENT_WRITER__
+#define _EVENT_WRITER__
+
+
+#define EVENTS_MAP_PIN_PATH \
+    "/ebpf/global/cilium_events"
+
+#define METRICS_MAP_PIN_PATH \
+    "/ebpf/global/cilium_metrics"
+
+#define FILTER_MAP_PIN_PATH \
+    "/ebpf/global/filter_map"
+
+#define FIVE_TUPLE_MAP_PIN_PATH \
+    "/ebpf/global/five_tuple_map"
+
+#define EVENT_WRITER_PIN_PATH \
+    "/ebpf/global/event_writer"
+
+enum {
+	CILIUM_NOTIFY_UNSPEC = 0,
+	CILIUM_NOTIFY_DROP,
+	CILIUM_NOTIFY_DBG_MSG,
+	CILIUM_NOTIFY_DBG_CAPTURE,
+	CILIUM_NOTIFY_TRACE,
+	CILIUM_NOTIFY_POLICY_VERDICT,
+	CILIUM_NOTIFY_CAPTURE,
+	CILIUM_NOTIFY_TRACE_SOCK,
+};
+
+enum {
+	METRIC_INGRESS = 1,
+	METRIC_EGRESS,
+};
+
+struct ethhdr {
+    uint8_t dst_mac[6];
+    uint8_t src_mac[6];
+    uint16_t ethertype;
+};
+
+struct iphdr {
+    uint8_t ihl : 4,
+            version : 4;
+    uint8_t tos;
+    uint16_t tot_len;
+    uint16_t id;
+    uint16_t frag_off;
+    uint8_t ttl;
+    uint8_t protocol;
+    uint16_t check;
+    uint32_t saddr;
+    uint32_t daddr;
+};
+
+struct tcphdr {
+    uint16_t source;       // Source port
+    uint16_t dest;         // Destination port
+    uint32_t seq;          // Sequence number
+    uint32_t ack_seq;      // Acknowledgment number
+    uint8_t  doff;       // Data offset
+    uint8_t  res1:4;       // Reserved
+    uint8_t  fin:1,
+            syn:1,
+            rst:1,
+            psh:1,
+            ack:1,
+            urg:1,
+            ece:1,
+            cwr:1,
+            ns:1;
+    uint16_t window;       // Window size
+    uint16_t check;        // Checksum
+    uint16_t urg_ptr;      // Urgent pointer
+};
+
+struct udphdr {
+    uint16_t source;   // Source port
+    uint16_t dest;     // Destination port
+    uint16_t len;      // Length of the UDP packet (header + data)
+    uint16_t check;    // Checksum
+};
+
+union v6addr {
+    struct {
+        uint32_t p1;
+        uint32_t p2;
+        uint32_t p3;
+        uint32_t p4;
+    };
+    struct {
+        __u64 d1;
+        __u64 d2;
+    };
+    uint8_t addr[16];
+}__packed;
+
+struct five_tuple {
+    uint8_t proto;
+    uint32_t srcIP;
+    uint32_t dstIP;
+    uint16_t srcprt;
+    uint16_t dstprt;
+};
+
+struct filter {
+    uint8_t    event;
+    uint32_t   srcIP;
+    uint32_t   dstIP;
+    uint16_t   srcprt;
+    uint16_t   dstprt;
+};
+
+struct trace_notify {
+	uint8_t		type;
+    uint8_t		subtype;
+	uint16_t		source;
+	uint32_t		hash;
+    uint32_t		len_orig;
+	uint16_t		len_cap;
+	uint16_t		version;
+	uint32_t		src_label;
+	uint32_t		dst_label;
+	uint16_t		dst_id;
+	uint8_t		reason;
+	uint8_t		ipv6:1;
+	uint8_t		pad:7;
+	uint32_t		ifindex;
+	union {
+		struct {
+			uint32_t		orig_ip4;
+			uint32_t		orig_pad1;
+			uint32_t		orig_pad2;
+			uint32_t		orig_pad3;
+		};
+		union v6addr	orig_ip6;
+	};
+	uint8_t        data[128];
+};
+
+struct drop_notify {
+	uint8_t		type;
+    uint8_t		subtype;
+	uint16_t		source;
+	uint32_t		hash;
+    uint32_t		len_orig;
+	uint16_t		len_cap;
+	uint16_t		version;
+	uint32_t		src_label;
+	uint32_t		dst_label;
+	uint32_t		dst_id; /* 0 for egress */
+	uint16_t		line;
+	uint8_t		file;
+	int8_t		ext_error;
+	uint32_t		ifindex;
+	uint8_t        data[128];
+};
+
+struct metrics_key {
+	uint8_t     reason;	/* 0: forwarded, >0 dropped */
+	uint8_t     dir:2,	/* 1: ingress 2: egress */
+		        pad:6;
+	uint16_t	line;		/* __MAGIC_LINE__ */
+	uint8_t	    file;		/* __MAGIC_FILE__, needs to fit __source_file_name_to_id */
+	uint8_t	    reserved[3];	/* reserved for future extension */
+};
+
+struct metrics_value {
+	uint64_t	count;
+	uint64_t	bytes;
+};
+
+#endif  /* _EVENT_WRITER__ */

--- a/test/e2e/tools/event-writer/event_writer.sln
+++ b/test/e2e/tools/event-writer/event_writer.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.11.35431.28
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "event_writer", "event_writer.vcxproj", "{A12E2603-25A2-4A9C-9B9D-9156C9520789}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{A12E2603-25A2-4A9C-9B9D-9156C9520789}.Release|x64.ActiveCfg = Release|x64
+		{A12E2603-25A2-4A9C-9B9D-9156C9520789}.Release|x64.Build.0 = Release|x64
+		EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1B17387E-FD19-4848-96B1-6A0F1322EE37}
+	EndGlobalSection
+EndGlobal

--- a/test/e2e/tools/event-writer/event_writer.vcxproj
+++ b/test/e2e/tools/event-writer/event_writer.vcxproj
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="packages\XDP-for-Windows.1.1.0\build\native\xdp-for-windows.props" Condition="Exists('packages\XDP-for-Windows.1.1.0\build\native\xdp-for-windows.props')" />
+  <Import Project="packages\Microsoft.Windows.WDK.x64.10.0.26100.2454\build\native\Microsoft.Windows.WDK.x64.props" Condition="Exists('packages\Microsoft.Windows.WDK.x64.10.0.26100.2454\build\native\Microsoft.Windows.WDK.x64.props')" />
+  <Import Project="packages\Microsoft.Windows.SDK.CPP.x64.10.0.26100.2454\build\native\Microsoft.Windows.SDK.cpp.x64.props" Condition="Exists('packages\Microsoft.Windows.SDK.CPP.x64.10.0.26100.2454\build\native\Microsoft.Windows.SDK.cpp.x64.props')" />
+  <Import Project="packages\Microsoft.Windows.SDK.CPP.10.0.26100.2454\build\native\Microsoft.Windows.SDK.cpp.props" Condition="Exists('packages\Microsoft.Windows.SDK.CPP.10.0.26100.2454\build\native\Microsoft.Windows.SDK.cpp.props')" />
+  <Import Project="packages\eBPF-for-Windows.x64.0.20.0\build\native\ebpf-for-windows.x64.props" Condition="Exists('packages\eBPF-for-Windows.x64.0.20.0\build\native\ebpf-for-windows.x64.props')" />
+  <PropertyGroup>
+    <WDKVersion>10.0.26100.2454</WDKVersion>
+  </PropertyGroup>
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>17.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{A12E2603-25A2-4A9C-9B9D-9156C9520789}</ProjectGuid>
+    <RootNamespace>event_writer</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
+    <EbpfPackagePath>$(SolutionDir)packages\eBPF-for-Windows.x64.0.20.0\build\native\</EbpfPackagePath>
+    <XdpPackagePath>$(SolutionDir)packages\XDP-for-Windows.1.1.0\build\native\</XdpPackagePath>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <TargetName>event_writer</TargetName>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.10.0.26100.2454\c\Include\10.0.26100.0\um;$(SolutionDir)packages\eBPF-for-Windows.x64.0.20.0\build\native\include;$(SolutionDir)packages\XDP-for-Windows.1.1.0\build\native\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableUAC>false</EnableUAC>
+      <AdditionalLibraryDirectories>$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.x64.10.0.26100.2454\c\um\x64;$(SolutionDir)packages\eBPF-for-Windows.x64.0.20.0\build\native\lib;$(SolutionDir)packages\XDP-for-Windows.1.1.0\build\native\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>ebpfapi.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClInclude Include="event_writer.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="event_writer.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="bpf_event_writer.c">
+      <Outputs>$(Platform)\$(Configuration)\bpf_event_writer.sys</Outputs>
+      <Command>
+        $(XdpPackagePath)bin\$(Platform)\xdpbpfexport.exe --clear
+        $(XdpPackagePath)bin\$(Platform)\xdpbpfexport.exe
+        clang -g -target bpf -O2 -Werror -I$(EbpfPackagePath)include -I$(XdpPackagePath)include -c bpf_event_writer.c -o $(Platform)\$(Configuration)\bpf_event_writer.o
+        pushd $(OutDir)
+        powershell -NonInteractive -ExecutionPolicy Unrestricted $(EbpfPackagePath)bin\Convert-BpfToNative.ps1 -FileName bpf_event_writer -IncludeDir $(EbpfPackagePath)include -Platform $(Platform) -Packages $(SolutionDir)packages -Configuration $(Configuration) -KernelMode $true
+        popd
+      </Command>
+    </CustomBuild>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+    <Import Project="packages\Microsoft.Windows.SDK.CPP.10.0.26100.2454\build\native\Microsoft.Windows.SDK.cpp.targets" Condition="Exists('packages\Microsoft.Windows.SDK.CPP.10.0.26100.2454\build\native\Microsoft.Windows.SDK.cpp.targets')" />
+  </ImportGroup>
+  <Target Name="CustomClean" AfterTargets="Clean">
+    <!-- Remove custom generated output directory, adjust the path as needed -->
+    <RemoveDir Directories="$(SolutionDir)$(Platform)" />
+</Target>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('packages\eBPF-for-Windows.x64.0.20.0\build\native\ebpf-for-windows.x64.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\eBPF-for-Windows.x64.0.20.0\build\native\ebpf-for-windows.x64.props'))" />
+    <Error Condition="!Exists('packages\Microsoft.Windows.SDK.CPP.10.0.26100.2454\build\native\Microsoft.Windows.SDK.cpp.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Windows.SDK.CPP.10.0.26100.2454\build\native\Microsoft.Windows.SDK.cpp.props'))" />
+    <Error Condition="!Exists('packages\Microsoft.Windows.SDK.CPP.10.0.26100.2454\build\native\Microsoft.Windows.SDK.cpp.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Windows.SDK.CPP.10.0.26100.2454\build\native\Microsoft.Windows.SDK.cpp.targets'))" />
+    <Error Condition="!Exists('packages\Microsoft.Windows.SDK.CPP.x64.10.0.26100.2454\build\native\Microsoft.Windows.SDK.cpp.x64.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Windows.SDK.CPP.x64.10.0.26100.2454\build\native\Microsoft.Windows.SDK.cpp.x64.props'))" />
+    <Error Condition="!Exists('packages\Microsoft.Windows.WDK.x64.10.0.26100.2454\build\native\Microsoft.Windows.WDK.x64.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Windows.WDK.x64.10.0.26100.2454\build\native\Microsoft.Windows.WDK.x64.props'))" />
+    <Error Condition="!Exists('packages\XDP-for-Windows.1.1.0\build\native\xdp-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\XDP-for-Windows.1.1.0\build\native\xdp-for-windows.props'))" />
+  </Target>
+</Project>

--- a/test/e2e/tools/event-writer/event_writer.vcxproj.filters
+++ b/test/e2e/tools/event-writer/event_writer.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="event_writer_api.cpp" />
+    <ClCompile Include="event_writer_util.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{75e6b9b2-c419-46ce-adb9-38f5a0454ea8}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="bpf_event_writer.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="event_writer.h" />
+    <ClInclude Include="event_writer_util.h" />
+  </ItemGroup>
+</Project>

--- a/test/e2e/tools/event-writer/event_writer.vcxproj.user
+++ b/test/e2e/tools/event-writer/event_writer.vcxproj.user
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+</Project>

--- a/test/e2e/tools/event-writer/install-ebpf-xdp.ps1
+++ b/test/e2e/tools/event-writer/install-ebpf-xdp.ps1
@@ -1,0 +1,739 @@
+#Requires -RunAsAdministrator
+
+Function Assert-SoftwareInstalled
+{
+   [cmdletbinding(DefaultParameterSetName='Software')]
+
+   Param
+   (
+      [Parameter(ParameterSetName='Service',Mandatory=$true)]
+      [ValidateScript({-Not [String]::IsNullOrWhiteSpace($_)})]
+      [String] $ServiceName,
+
+      [Parameter(ParameterSetName='Service',Mandatory=$false)]
+      [ValidateSet($null,'Running','Stopped')]
+      [String] $ServiceState,
+
+      [Parameter(ParameterSetName='Software',Mandatory=$true)]
+      [ValidateScript({-Not [String]::IsNullOrWhiteSpace($_)})]
+      [String] $SoftwareName,
+
+      [Parameter(ParameterSetName='Software',Mandatory=$false)]
+      [String] $SoftwareVersion,
+
+      [Parameter(ParameterSetName='Service',Mandatory=$false)]
+      [Parameter(ParameterSetName='Software',Mandatory=$false)]
+      [Switch] $Silent
+   )
+
+   [String] $name = If($ServiceName) {"$($ServiceName)"}Else{"$($SoftwareName)"}
+
+   If(-Not $Silent.IsPresent)
+   {
+       Write-Host -Object:"Checking if $($name) is installed ..."
+   }
+
+   [Boolean] $isInstalled = $false
+
+   Try
+   {
+      If($SoftwareName)
+      {
+         $software = Get-WmiObject -Class:'Win32_Product' | Where-Object -Property:'Name' -like "*$($SoftwareName)*"
+
+         If($software -And
+            (-Not [String]::IsNullOrWhiteSpace($SoftwareVersion)))
+         {
+            $software = $software | Where-Object -Property:'Version' -like "*$($SoftwareVersion)*"
+         }
+
+         If($software)
+         {
+           $isInstalled = $true
+         }
+      }
+      ElseIF($ServiceName)
+      {
+        [Object] $state = Get-Service -Name:"$($ServiceName)" -ErrorAction:'SilentlyContinue'
+        If($state)
+        {
+           $isInstalled = $true
+
+           If($ServiceState -And
+              -Not ($state.Status -INE $ServiceState))
+           {
+              Write-Warning -Message:"`t$ServiceName is $$(state.Status)"
+           }
+        }
+      }
+   }
+   Catch
+   {
+
+   }
+
+   If(-Not $Silent.IsPresent)
+   {
+      If($isInstalled)
+      {
+         Write-Host -Object:"`t$($name) is installed"
+      }
+      Else
+      {
+         Write-Host -Object:"`t$($name) is not installed"
+      }
+   }
+
+   Return $isInstalled
+}
+
+<#
+ .Name
+   Assert-TestSigningIsEnabled
+
+ .Synopsis
+   Internal cmdlet to check if testsigning is enabled in the boot loader.
+
+ .Description
+   Returns TRUE if test signing is enabled, otherwise FALSE.
+
+ .Parameter Silent
+   Optional switch used to suppress output messages
+
+ .Example
+   # Check if test signing is enabled
+   Assert-TestSigningIsEnabled
+#>
+Function Assert-TestSigningIsEnabled
+{
+   Param
+   (
+      [Parameter(ParameterSetName='Default',Mandatory=$false)]
+      [Switch] $Silent
+   )
+
+   [Boolean] $isEnabled = $false
+   [String]  $state     = 'Disabled'
+
+   Try
+   {
+      [Boolean] $current = $false
+
+      If(-Not ($Silent.IsPresent))
+      {
+         Write-Host -Object:"`tAssert Test Signing is Enabled"
+      }
+
+      [Object[]] $entries = BCDEdit.exe /enum
+      If($entries.Count -ILT 3)
+      {
+         Write-Error -Message:"$entries"
+
+         Throw
+      }
+
+      ForEach($entry in $entries)
+      {
+         If($entry.StartsWith('identifier'))
+         {
+            If($entry -ILike '*{current}*')
+            {
+               $current = $true
+            }
+            Else
+            {
+               $current = $false
+            }
+         }
+         Else
+         {
+            If($current)
+            {
+               If($entry -ILike '*testsigning*Yes*')
+               {
+                  $state = 'Enabled'
+
+                  $isEnabled = $true
+
+                  Break
+               }
+            }
+         }
+      }
+   }
+   Catch
+   {
+      $isEnabled = $false
+
+      $state = 'Unknown'
+   }
+
+   If(-Not ($Silent.IsPresent))
+   {
+      Write-Host -Object:"`t`t$($state)"
+   }
+
+   Return $isEnabled
+}
+
+<#
+ .Name
+   Disable-TestSigning
+
+ .Synopsis
+   Internal cmdlet to turn off Test Signing in the Windows Boot Loader.
+
+ .Description
+   Returns TRUE if test signing is disabled, otherwise FALSE.
+   If set, the setting does not take effect until a reboot
+
+ .Parameter Reboot
+   Optional parameter which will trigger a reboot if needed
+
+ .Example
+   # Disable test signing
+   Disable-TestSigning
+#>
+Function Disable-TestSigning
+{
+   Param
+   (
+      [Parameter(ParameterSetName='Default',Mandatory=$false)]
+      [Switch] $Reboot
+   )
+
+   [Boolean] $isSuccess = $true
+
+   Try
+   {
+      [Boolean] $current = $false
+      [Boolean] $found   = $false
+
+      Write-Host -Object:"`tDisabling Test Signing"
+
+      If(Assert-TestSigningIsEnabled -Silent)
+      {
+         Start-Process -FilePath:"$($env:WinDir)\System32\BCDEdit.exe" -ArgumentList @('/Set TestSigning Off') -PassThru | Wait-Process
+
+         If(Assert-TestSigningIsEnabled -Silent)
+         {
+            Write-Error -Message:"`t`tFailed"
+
+            Throw
+         }
+
+         $script:RequiresReboot = $true
+      }
+
+      Write-Host -Object:"`t`tDisabled"
+   }
+   Catch
+   {
+      $isSuccess = $false
+   }
+
+   If($Reboot.IsPresent -and
+      $script:RequiresReboot)
+   {
+      Write-Host -Object:'Restarting'
+
+      Start-Sleep -Seconds:5
+
+      Restart-Computer
+      Start-Sleep -Seconds:60
+   }
+
+   Return $isSuccess
+}
+
+<#
+ .Name
+   Enable-TestSigning
+
+ .Synopsis
+   Internal cmdlet to turn on Test Signing in the Windows Boot Loader.
+
+ .Description
+   Returns TRUE if test signing is enabled, otherwise FALSE.
+
+ .Parameter Reboot
+   Optional parameter which will trigger a reboot if needed
+
+ .Example
+   # Enable test signing
+   Enable-TestSigning
+#>
+Function Enable-TestSigning
+{
+   Param
+   (
+      [Parameter(ParameterSetName='Default',Mandatory=$false)]
+      [Switch] $Reboot
+   )
+
+   [Boolean] $isSuccess = $true
+
+   Try
+   {
+      [Boolean] $current = $false
+      [Boolean] $found   = $false
+
+      Write-Host -Object:"`tEnabling Test Signing"
+
+      If(-Not (Assert-TestSigningIsEnabled -Silent))
+      {
+         Start-Process -FilePath:"$($env:WinDir)\System32\BCDEdit.exe" -ArgumentList @('/Set TestSigning On') -PassThru | Wait-Process
+
+         If(-Not (Assert-TestSigningIsEnabled -Silent))
+         {
+            Write-Error -Message:"`t`tFailed"
+
+            Throw
+         }
+
+         $script:RequiresReboot = $true
+      }
+
+      Write-Host -Object:"`t`tEnabled"
+
+   }
+   Catch
+   {
+      Write-Host "Enable-TestSigning : $_"
+      $isSuccess = $false
+   }
+
+   If($Reboot.IsPresent -and
+      $script:RequiresReboot)
+   {
+      Write-Host -Object:'Restarting'
+
+      Start-Sleep -Seconds:5
+
+      Restart-Computer
+      Start-Sleep -Seconds:60
+   }
+
+   Return $isSuccess
+}
+
+#endregion PrivateFns
+
+#region Public
+
+<#
+ .Name
+   Assert-WindowsEbpfXdpIsReady
+
+ .Synopsis
+   Check if EBPF and XDP for Windows is ready
+
+ .Description
+   Returns TRUE if EBPF and XDP for Windows is ready, otherwise FALSE.
+
+ .Example
+   # Check if EBPF and XDP for Windows is ready
+   Assert-WindowsCiliumFunctions
+#>
+Function Assert-WindowsEbpfXdpIsReady
+{
+    Write-Host -Object:'Validating EBPF and XDP for Windows is ready'
+
+   [Boolean]  $isReady  = $true
+   [String[]] $services = @(
+                            'eBPFCore',
+                            'NetEbpfExt',
+                            'XDP'
+                           )
+   ForEach($service in $services)
+   {
+      If(-Not (Assert-SoftwareInstalled -ServiceName:"$($service)" -ServiceState:'Running'))
+      {
+         $isReady = $false
+
+         Write-Warning -Message:"`t$($service) is not ready"
+      }
+   }
+
+   Return $isReady
+}
+
+<#
+ .Name
+   Install-eBPF
+
+ .Synopsis
+   Installs extended Berkley Packet Filter for Windows.
+
+ .Description
+   Returns TRUE if extended Berkley Packet Filter for Windows is installed successfully, otherwise FALSE.
+   Function requires that Test Signing is enabled.
+
+ .Parameter LocalPath
+   Local directory to the eBPF for Windows binaries.
+   Default location is $env:LocalAppData\Temp
+
+ .Example
+   # Install eBPF for Windows
+   Install-eBPF -LocalPath:"$env:TEMP"
+#>
+Function Install-eBPF
+{
+   [cmdletbinding(DefaultParameterSetName='Default')]
+
+   Param
+   (
+      [Parameter(ParameterSetName='Default',Mandatory=$false)]
+      [ValidateScript({Test-Path $_ -PathType:'Container'})]
+      [String] $LocalPath = "$env:TEMP"
+   )
+
+   [Boolean] $isSuccess = $true
+
+   Try
+   {
+      Write-Host 'Installing extended Berkley Packet Filter for Windows'
+      If(-Not (Assert-TestSigningIsEnabled))
+      {
+         If(-Not (Enable-TestSigning -Reboot)) { Throw }
+      }
+
+      If(Assert-SoftwareInstalled -ServiceName:"eBPFCore")
+      {
+         Write-Host 'extended Berkley Packet Filter for Windows is already installed'
+         return $isSuccess
+      }
+
+      Write-Host 'Installing extended Berkley Packet Filter for Windows'
+      # Download eBPF-for-Windows.
+      $packageEbpfUrl = "https://github.com/microsoft/ebpf-for-windows/releases/download/Release-v0.20.0/Build-x64-native-only.NativeOnlyRelease.zip"
+      Invoke-WebRequest -Uri $packageEbpfUrl -OutFile "$LocalPath\Build-x64-native-only.NativeOnlyRelease.zip"
+      Expand-Archive -Path "$LocalPath\Build-x64-native-only.NativeOnlyRelease.zip" -DestinationPath "$LocalPath\Build-x64-native-only.NativeOnlyRelease\msi" -Force
+      Copy-Item "$LocalPath\Build-x64-native-only.NativeOnlyRelease\msi\Build-x64-native-only NativeOnlyRelease\*.msi" -Destination $LocalPath
+
+      Start-Process -FilePath "$($env:WinDir)\System32\MSIExec.exe" -ArgumentList @("/i", "$LocalPath\ebpf-for-windows.msi", "/qn", "INSTALLFOLDER=`"$($env:ProgramFiles)\ebpf-for-windows`"", "ADDLOCAL=eBPF_Runtime_Components") -PassThru | Wait-Process
+      If(-Not (Assert-SoftwareInstalled -ServiceName:'eBPFCore' -Silent) -Or
+         -Not (Assert-SoftwareInstalled -ServiceName:'NetEbpfExt' -Silent))
+      {
+         Write-Error -Message:"`teBPF service failed to install"
+         Throw
+      }
+
+      $isSuccess = Assert-SoftwareInstalled -ServiceName:"eBPFCore"
+   }
+   Catch
+   {
+      $isSuccess = $false
+      Write-Host "EBPF install failed : $_"
+      Uninstall-eBPF
+   }
+
+   Return $isSuccess
+}
+
+<#
+ .Name
+   Install-XDP
+
+ .Synopsis
+   Installs the eXpress Data Path for Windows service.
+
+ .Description
+   Returns TRUE if the eXpress Data Path for Windows service is installed successfully, otherwise FALSE.
+
+ .Parameter LocalPath
+   Local directory to the eXpress Data Path for Windows service binaries.
+   Default location is $env:LocalAppData\Temp
+
+ .Example
+   # Install the eXpress Data Path service
+   Install-XDP -LocalPath:"$env:TEMP"
+#>
+Function Install-XDP
+{
+   [cmdletbinding(DefaultParameterSetName='Default')]
+
+   Param
+   (
+      [Parameter(ParameterSetName='Default',Mandatory=$false)]
+      [ValidateScript({Test-Path $_ -PathType:'Container'})]
+      [String] $LocalPath = "$env:TEMP"
+   )
+
+   [Boolean] $isSuccess = $true
+
+   Try
+   {
+      If(Assert-SoftwareInstalled -SoftwareName:'XDP for Windows' -Silent)
+      {
+         Write-Host 'XDP for Windows is already installed'
+         return $isSuccess
+      }
+
+      # Download XDP-for-Windows.
+      Write-Host 'Installing eXpress Data Path for Windows'
+      $packageXdpUrl = "https://github.com/microsoft/xdp-for-windows/releases/download/v1.1.0%2Bbed474a/bin_Release_x64.zip"
+      Invoke-WebRequest -Uri $packageXdpUrl -OutFile "$LocalPath\bin_Release_x64.zip"
+      Expand-Archive -Path "$LocalPath\bin_Release_x64.zip" -DestinationPath "$LocalPath\bin_Release_x64" -Force
+      copy "$LocalPath\bin_Release_x64\amd64fre\xdp.cer" $LocalPath
+      copy "$LocalPath\bin_Release_x64\amd64fre\xdpcfg.exe" $LocalPath
+      CertUtil.exe -addstore Root "$LocalPath\xdp.cer"
+      CertUtil.exe -addstore TrustedPublisher "$LocalPath\xdp.cer"
+      Invoke-WebRequest -Uri "https://github.com/microsoft/xdp-for-windows/releases/download/v1.1.0%2Bbed474a/xdp-for-windows.1.1.0.msi" -OutFile "$LocalPath\xdp-for-windows.1.1.0.msi"
+      Start-Process -FilePath:"$($env:WinDir)\System32\MSIExec.exe" -ArgumentList @("/i $LocalPath\xdp-for-windows.1.1.0.msi", '/qn') -PassThru | Wait-Process
+      sc.exe query xdp
+      reg.exe add "HKLM\SYSTEM\CurrentControlSet\Services\xdp\Parameters" /v XdpEbpfEnabled /d 1 /t REG_DWORD /f
+      net.exe stop xdp
+      net.exe start xdp
+      Write-Output "XDP for Windows installed"
+      Write-Host "Setting SDDL for XDP service"
+      & "$LocalPath\xdpcfg.exe" SetDeviceSddl "D:P(A;;GA;;;SY)(A;;GA;;;BA)"
+      If(-Not (Assert-SoftwareInstalled -SoftwareName:'XDP for Windows' -Silent)) {
+         Throw
+      }
+
+      Restart-Computer -Force
+      #to prevent any further commands in between
+      Start-Sleep -Seconds:60
+   }
+   Catch
+   {
+      $isSuccess = $false
+      Write-Host "XDP install failed : $_"
+      Uninstall-XDP
+   }
+
+   Return $isSuccess
+}
+
+<#
+ .Name
+   Install-EbpfXdp
+
+ .Synopsis
+   Installs EBPF and XDP for Windows
+
+ .Description
+   Returns TRUE if EBPF and XDP for Windows is installed successfully, otherwise FALSE.
+
+ .Example
+   # Install EBPF and XDP for Windows
+   Install-EbpfXdp
+#>
+Function Install-EbpfXdp
+{
+   Try
+   {
+      If(Assert-WindowsEbpfXdpIsReady) {
+          return
+      }
+
+      If(-Not (Assert-TestSigningIsEnabled -Silent))
+      {
+         If(-Not (Enable-TestSigning -Reboot)) {Throw}
+      }
+
+      If(-Not (Install-eBPF)) {Throw}
+
+      If(-Not (Install-XDP)) {Throw}
+
+      If(Assert-WindowsEbpfXdpIsReady) {Throw}
+
+      # Create the probe ready file
+      New-Item -Path "C:\install-ebpf-xdp-probe-ready" -ItemType File -Force
+   }
+   Catch
+   {
+      $isSuccess = $false
+   }
+
+   return $isSuccess
+}
+
+<#
+ .Name
+   Uninstall-eBPF
+
+ .Synopsis
+   Uninstalls the extended Berkley Packet Filter for Windows.
+
+ .Description
+   Returns TRUE if the extended Berkley Packet Filter for Windows is uninstalled successfully, otherwise FALSE.
+
+ .Parameter LocalPath
+   Local directory to the extended Berkley Packet Filter for Windows binaries.
+   Default location is $env:LocalAppData\Temp
+
+ .Example
+   # Uninstall the extended Berkley Packet Filter for Windows
+   Uninstall-eBPF -LocalPath:"$(env:LocalAppData)\Temp"
+#>
+Function Uninstall-eBPF
+{
+   [cmdletbinding(DefaultParameterSetName='Default')]
+
+   Param
+   (
+      [Parameter(ParameterSetName='Default',Mandatory=$false)]
+      [ValidateScript({Test-Path $_ -PathType:'Container'})]
+      [String] $LocalPath = "$env:TEMP"
+   )
+
+   Write-Host 'Uninstalling the extended Berkley Packet Filter for Windows'
+
+   [Boolean] $isSuccess = $true
+
+   Try
+   {
+      [String[]] $services = @('eBPFCore',
+                               'NetEbpfExt'
+                              )
+
+      ForEach($service in $services)
+      {
+         [Object] $state = Get-Service -Name:$($service) -ErrorAction:'SilentlyContinue'
+         If($state)
+         {
+            For([Byte]$i = 0;
+                $i -ILE 5;
+                $i++)
+            {
+               If($state.Status -IEQ 'Stopped')
+               {
+                   Break
+               }
+               Else
+               {
+                  If($state.Status -IEQ 'Running')
+                  {
+                     Stop-Service -Name:"$($service)" -Force
+                  }
+                  ElseIf($state.Status -IEQ 'StopPending')
+                  {
+                     Start-Sleep -Seconds:5
+                  }
+                  Else
+                  {
+                     Write-Error -Message:"$($service) service is $($state.status)"
+
+                     Throw
+                  }
+               }
+
+               $state = Get-Service -Name:"$($service)"
+            }
+         }
+
+         Start-Process -FilePath:"$($env:WinDir)\System32\MSIExec.exe" -ArgumentList @("/x $($LocalPath)\ebpf-for-windows.msi", '/qn') -PassThru | Wait-Process
+      }
+
+      If((Assert-SoftwareInstalled -ServiceName:'eBPFCore' -Silent) -or
+         (Assert-SoftwareInstalled -ServiceName:'NetEbpfExt' -Silent) -or
+         (Assert-SoftwareInstalled -SoftwareName:'eBPF for Windows' -Silent))
+      {
+         Write-Error -Message:"eBPF for Windows is still installed"
+
+         Throw
+      }
+   }
+   Catch
+   {
+      $isSuccess = $false
+   }
+
+   Return $isSuccess
+}
+
+<#
+ .Name
+   Uninstall-XDP
+
+ .Synopsis
+   Uninstalls the express Data Path for Windows service
+
+ .Description
+   Returns TRUE if the eXpress Data Path for Windows service is uninstalled successfully, otherwise FALSE.
+
+ .Parameter LocalPath
+   Local directory to the eXpress Data Path for Windows service binaries.
+   Default location is $env:LocalAppData\Temp
+
+ .Example
+   # Uninstall the eXpress Data Path for Windows service
+   Uninstall-XDP -LocalPath:"$($env:LocalAppData)\Temp"
+#>
+Function Uninstall-XDP
+{
+   [cmdletbinding(DefaultParameterSetName='Default')]
+
+   Param
+   (
+      [Parameter(ParameterSetName='Default',Mandatory=$false)]
+      [ValidateScript({Test-Path $_ -PathType:'Container'})]
+      [String] $LocalPath = "$env:TEMP"
+   )
+
+   Write-Host 'Uninstalling eXpress Data Path for Windows'
+
+   [Boolean] $isSuccess = $true
+
+   Try
+   {
+      [Object] $state = Get-Service -Name:'XDP' -ErrorAction:'SilentlyContinue'
+      If($state)
+      {
+         For([Byte]$i = 0;
+             $i -ILE 5;
+             $i++)
+         {
+            If($state.Status -IEQ 'Stopped')
+            {
+                Break
+            }
+            Else
+            {
+               If($state.Status -IEQ 'Running')
+               {
+                  Stop-Service -Name:'XDP' -Force
+               }
+               ElseIf($state.Status -IEQ 'StopPending')
+               {
+                  Start-Sleep -Seconds:5
+               }
+               Else
+               {
+                  Write-Error -Message:"XDP service is $($state.status)"
+
+                  Throw
+               }
+            }
+
+            $state = Get-Service -Name:'XDP'
+         }
+
+         $regValue = New-ItemProperty -Path:'HKLM:\SYSTEM\CurrentControlSet\Services\xdp\Parameters' -Name:'xdpEbpfEnabled' -PropertyType:'DWORD' -Value:0 -Force
+         If($regValue.xdpEbpfEnabled -IEQ 0)
+         {
+            Start-Process -FilePath:"$($env:WinDir)\System32\MSIExec.exe" -ArgumentList @("/x $($LocalPath)\xdp-for-windows.1.1.0.msi", '/qn') -PassThru | Wait-Process
+         }
+      }
+
+      If((Assert-SoftwareInstalled -ServiceName:'XDP' -Silent) -or
+         (Assert-SoftwareInstalled -SoftwareName:'XDP for Windows' -Silent))
+      {
+         Write-Error -Message:"XDP for Windows is still installed"
+
+         Throw
+      }
+   }
+   Catch
+   {
+      $isSuccess = $false
+   }
+
+   Return $isSuccess
+}
+
+
+#Script Start
+exit $(Install-EbpfXdp)

--- a/test/e2e/tools/event-writer/packages.config
+++ b/test/e2e/tools/event-writer/packages.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="eBPF-for-Windows" version="0.19.2" targetFramework="native" />
+  <package id="eBPF-for-Windows.ARM64" version="0.20.0" targetFramework="native" />
+  <package id="eBPF-for-Windows.x64" version="0.20.0" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP" version="10.0.26100.2454" targetFramework="native" />
+  <package id="Microsoft.Windows.SDK.CPP.x64" version="10.0.26100.2454" targetFramework="native" />
+  <package id="Microsoft.Windows.WDK.x64" version="10.0.26100.2454" targetFramework="native" />
+  <package id="XDP-for-Windows" version="1.1.0" targetFramework="native" />
+</packages>

--- a/test/e2e/yaml/windows/install-ebpf-xdp.yaml
+++ b/test/e2e/yaml/windows/install-ebpf-xdp.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: install-ebpf-xdp
+  namespace: install-ebpf-xdp  # Ensure this namespace exists
+spec:
+  selector:
+    matchLabels:
+      name: install-ebpf-xdp
+  template:
+    metadata:
+      labels:
+        name: install-ebpf-xdp
+    spec:
+      containers:
+      - name: install-ebpf-xdp-container
+        image: ghcr.io/microsoft/retina/e2e-test-event-writer:latest
+        imagePullPolicy: Always
+        command:
+          - powershell.exe
+          - -command
+          - '& .\install-ebpf-xdp.ps1 ; while ($true) { Start-Sleep -Seconds 300; }'
+        readinessProbe:
+          exec:
+            command:
+              - powershell.exe
+              - -command
+              - Test-Path C:\install-ebpf-xdp-probe-ready
+          initialDelaySeconds: 10
+          periodSeconds: 5
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/os: windows
+      securityContext:
+        windowsOptions:
+          hostProcess: true
+          runAsUserName: "NT AUTHORITY\\SYSTEM"

--- a/test/e2e/yaml/windows/non-hpc-pod.yaml
+++ b/test/e2e/yaml/windows/non-hpc-pod.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: non-hpc-pod
+  labels:
+    app: non-hpc
+spec:
+  nodeSelector:
+    "kubernetes.io/os": windows
+  containers:
+  - name: non-hpc-container
+    image: ghcr.io/microsoft/retina/e2e-test-event-writer:latest
+    command: ["powershell", "-Command", "while ($true) { Start-Sleep -Seconds 3600 }"]
+    securityContext:
+        windowsOptions:
+          runAsUserName: "NT AUTHORITY\\SYSTEM"


### PR DESCRIPTION
Changes being introduced.

test\e2e\tools\event-writer : this is an test tool that helps generating mock trace and drop events using a bpf program based on customer inputs. The tools consists a BPF program and C++ Application that is used to load/unload and attach/update filter
Tool is intentionally building only for Release config variant for x64.

Additional changes in E2E with jobs
a. to load program,maps and pin it because retina ebpforwindows plugin expects cilium pre-loaded.
b. to validate windows bpf metrics advanced + basic.
1. collect pre-test basic metrics
2. create a non-hpc-pod
3. capture ifindex, interface of that non-hpc-pod and attach the bpf program to that interface
4. set filter for event-writer to trace and initiate curl from the non-hpc-pod
5. capture post-test BPF program and check if the metrics have increased.
6. check for the presence of advanced metrics
c. to unpin bpf program, maps at the end of tests