### PR TITLE
fix: enable annotations

### DIFF
--- a/pkg/controllers/daemon/namespace/namespace_controller.go
+++ b/pkg/controllers/daemon/namespace/namespace_controller.go
@@ -71,6 +71,8 @@ func (r *NamespaceReconciler) Start(ctx context.Context) {
 		select {
 		case <-ticker.C:
 			ns := r.cache.GetAnnotatedNamespaces()
+			// Add kube-system namespace to the list of namespaces to be included in metrics
+			ns = append(ns, "kube-system")
 			r.l.Debug("Reconciling metrics module", zap.Any("namespaces", ns))
 			spec := (&api.MetricsSpec{}).
 				WithIncludedNamespaces(ns).


### PR DESCRIPTION
# Description

**Feature description**: when using option `enableAnnotation: true` advanced metrics should only be generated for pods annotated with `retina.sh: observe` or pods in a namespace with that annotation or pods in kube-system namespace.

**Bug**: When `enableAnnotation: true` advanced metrics are still being generated for all pods.

**Fix**:
- add filtering to metrics module based on IPs stored on its cache
- add `kube-system` to list of namespaces to get metrics from

## Related Issue

x

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
