### PR TITLE
fix(deps): gRPC was removed from dependabot ignore list

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -31,5 +31,4 @@ updates:
     labels: ["lang/go", "area/dependencies"]
     ignore:
       - dependency-name: "github.com/inspektor-gadget/inspektor-gadget"
-      - dependency-name: "google.golang.org/grpc"
     open-pull-requests-limit: 10


### PR DESCRIPTION
# Description

Previously, we have had an issue with upgrading gRPC up from the version 1.66.2. The gRPC was successfully updated to 1.71 and was confirmed that the update is no longer has any issues. This PR removes gRPC from the Dependabot's ignore list.


## Related Issue
https://github.com/microsoft/retina/issues/934

## Checklist

- [X] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [X] I have correctly attributed the author(s) of the code.
- [X] I have tested the changes locally.
- [X] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
