### PR TITLE
fix(retina capture): bug fix for nil pointer error

### DIFF
--- a/cli/cmd/capture/create.go
+++ b/cli/cmd/capture/create.go
@@ -159,19 +159,23 @@ var createCapture = &cobra.Command{
 				retinacmd.Logger.Info("Please manually delete capture jobs failed to delete", zap.String("namespace", *opts.Namespace), zap.String("job list", strings.Join(jobsFailedToDelete, ",")))
 			}
 
-			err = deleteSecret(ctx, kubeClient, capture.Spec.OutputConfiguration.BlobUpload)
-			if err != nil {
-				retinacmd.Logger.Error("Failed to delete capture secret, please manually delete it",
-					zap.String("namespace", *opts.Namespace), zap.String("secret name", *capture.Spec.OutputConfiguration.BlobUpload), zap.Error(err))
+			if capture.Spec.OutputConfiguration.BlobUpload != nil {
+				err = deleteSecret(ctx, kubeClient, capture.Spec.OutputConfiguration.BlobUpload)
+				if err != nil {
+					retinacmd.Logger.Error("Failed to delete capture secret, please manually delete it",
+						zap.String("namespace", *opts.Namespace), zap.String("secret name", *capture.Spec.OutputConfiguration.BlobUpload), zap.Error(err))
+				}
 			}
 
-			err = deleteSecret(ctx, kubeClient, &capture.Spec.OutputConfiguration.S3Upload.SecretName)
-			if err != nil {
-				retinacmd.Logger.Error("Failed to delete capture secret, please manually delete it",
-					zap.String("namespace", *opts.Namespace),
-					zap.String("secret name", capture.Spec.OutputConfiguration.S3Upload.SecretName),
-					zap.Error(err),
-				)
+			if capture.Spec.OutputConfiguration.S3Upload != nil && capture.Spec.OutputConfiguration.S3Upload.SecretName != "" {
+				err = deleteSecret(ctx, kubeClient, &capture.Spec.OutputConfiguration.S3Upload.SecretName)
+				if err != nil {
+					retinacmd.Logger.Error("Failed to delete capture secret, please manually delete it",
+						zap.String("namespace", *opts.Namespace),
+						zap.String("secret name", capture.Spec.OutputConfiguration.S3Upload.SecretName),
+						zap.Error(err),
+					)
+				}
 			}
 
 			if len(jobsFailedToDelete) == 0 && err == nil {


### PR DESCRIPTION
# Description

Added nil check for S3 storage properties so that the retina cli doesn't throw nil pointer error when azure blob storage is used instead of S3 storage.

## Related Issue

This PR addresses issue https://github.com/microsoft/retina/issues/1425

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
