### PR TITLE
fix(log): set logrus logLevel according to the global log level

### DIFF
--- a/cmd/hubble/daemon_main_linux.go
+++ b/cmd/hubble/daemon_main_linux.go
@@ -219,7 +219,7 @@ func initLogging() {
 	k8sCfg, _ := sharedconfig.GetK8sConfig()
 	zapLogger := setupZapLogger(retinaConfig, k8sCfg)
 	setupLoggingHooks(logger, zapLogger)
-	bootstrapLogging(logger)
+	bootstrapLogging(retinaConfig, logger)
 }
 
 func setupDefaultLogger() *logrus.Logger {
@@ -280,10 +280,16 @@ func setupLoggingHooks(logger *logrus.Logger, zapLogger *log.ZapLogger) {
 	}
 }
 
-func bootstrapLogging(logger *logrus.Logger) {
+func bootstrapLogging(retinaConfig *config.Config, logger *logrus.Logger) {
 	if err := logging.SetupLogging(option.Config.LogDriver, logging.LogOptions(option.Config.LogOpt), "retina-agent", option.Config.Debug); err != nil {
 		logger.Fatal(err)
 	}
+
+	logLevel, err := logrus.ParseLevel(retinaConfig.LogLevel)
+	if err != nil {
+		logLevel = logrus.InfoLevel
+	}
+	logger.SetLevel(logLevel)
 }
 
 func initDaemonConfig(vp *viper.Viper) {

--- a/operator/cmd/cilium-crds/zap_linux.go
+++ b/operator/cmd/cilium-crds/zap_linux.go
@@ -46,6 +46,13 @@ func setupZapHook(p params) {
 	// discard default logger output in favor of zap
 	logging.DefaultLogger.SetOutput(io.Discard)
 
+	level, err := logrus.ParseLevel(p.DaemonCfg.LogOpt[logging.LevelOpt])
+	if err != nil {
+		p.Logger.WithError(err).Error("failed to parse log level")
+	} else {
+		logging.DefaultLogger.SetLevel(level)
+	}
+
 	lOpts := &log.LogOpts{
 		Level:                 p.DaemonCfg.LogOpt[logging.LevelOpt],
 		File:                  false,
@@ -62,7 +69,7 @@ func setupZapHook(p params) {
 		zap.String("apiserver", p.K8sCfg.Host),
 	}
 
-	_, err := log.SetupZapLogger(lOpts, persistentFields...)
+	_, err = log.SetupZapLogger(lOpts, persistentFields...)
 	if err != nil {
 		fmt.Printf("failed to setup zap logger: %v", err)
 	}


### PR DESCRIPTION
# Description
After setting logLevel: debug in the ConfigMap, some agent loggers are still on info level.

This is not consistent. For instance, this logger DOES correctly use debug level

level=debug caller=packetparser/packetparser_linux.go
whereas components like payload parser will NOT ever send debug logs.

This PR sets the logrus logLevel according to the global log level.

## Related Issue
https://github.com/microsoft/retina/issues/597

## Checklist

- [X] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [X] I have correctly attributed the author(s) of the code.
- [X] I have tested the changes locally.
- [X] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
