### PR TITLE
fix: Missing website description meta tag

### DIFF
--- a/site/docusaurus.config.ts
+++ b/site/docusaurus.config.ts
@@ -98,6 +98,7 @@ const config = {
       { name: "og:site_name", content: "Retina" },
       { name: "og:image:width", content: "1200" },
       { name: "og:image:height", content: "600" },
+      { name: "og:description", content: "Retina is a cloud-agnostic, open-source eBPF-based Kubernetes network observability platform that provides a centralized hub for monitoring application health, network health, and security." },
     ],
     navbar: {
       logo: {


### PR DESCRIPTION
# Description

Adds a `og:description` meta tag to the retina.sh website with a description from the official README.

This will aid in the generation of complete webpage/weblink previews of retina.sh in private messaging platforms.

## Related Issue

N/A

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

N/A

## Additional Notes

N/A

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
