### PR TITLE
feat(fips): Fix Dropreason plugin in FIPS

### DIFF
--- a/deploy/hubble/manifests/controller/helm/retina/values.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/values.yaml
@@ -111,6 +111,7 @@ securityContext:
       - SYS_RESOURCE
       - NET_ADMIN # for packetparser plugin
       - IPC_LOCK # for mmap() calls made by NewReader(), ref: https://man7.org/linux/man-pages/man2/mmap.2.html
+      - SYS_RESOURCE # for setting rlimit
   windowsOptions:
     runAsUserName: "NT AUTHORITY\\SYSTEM"
 

--- a/deploy/standard/manifests/controller/helm/retina/values.yaml
+++ b/deploy/standard/manifests/controller/helm/retina/values.yaml
@@ -110,6 +110,7 @@ securityContext:
       - SYS_ADMIN
       - NET_ADMIN # for packetparser plugin
       - IPC_LOCK # for mmap() calls made by NewReader(), ref: https://man7.org/linux/man-pages/man2/mmap.2.html
+      - SYS_RESOURCE # for setting rlimit
   windowsOptions:
     runAsUserName: "NT AUTHORITY\\SYSTEM"
 


### PR DESCRIPTION
# Description

In FIPs complient *nix nodes, `dropreason` plugin was failing to install. Also, the `rlimit` command fails to run due to insufficient permission. This PR fixes the `dropreason` plugin and adds the necessary permission to run the `rlimit` command

## Related Issue

https://github.com/microsoft/retina/issues/1439

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
