### PR TITLE
deps: update network performance test image version to v20250402

### DIFF
--- a/test/e2e/scenarios/perf/get-network-performance-measures.go
+++ b/test/e2e/scenarios/perf/get-network-performance-measures.go
@@ -21,7 +21,7 @@ func (v *GetNetworkPerformanceMeasures) Prevalidate() error {
 func (v *GetNetworkPerformanceMeasures) Run() error {
 	results, err := lib.PerformTests(lib.TestParams{
 		Iterations:    1,
-		Image:         "ghcr.io/azure/nptest:v20241002",
+		Image:         "ghcr.io/azure/nptest:v20250402",
 		TestNamespace: "netperf",
 		TestFrom:      13,
 		TestTo:        17,


### PR DESCRIPTION
# Description

This pull request includes a small change to the `test/e2e/scenarios/perf/get-network-performance-measures.go` file. The change updates the Docker image version used in the `Run` method from `v20241002` to `v20250402` to ensure the latest version is utilized for network performance tests.

* [`test/e2e/scenarios/perf/get-network-performance-measures.go`](diffhunk://#diff-552021fa11b21d2818ffec68ed586178c09389024331b93f0425b6218c068be8L24-R24): Updated the Docker image version in the `Run` method from `v20241002` to `v20250402`.

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
