### PR TITLE
fix: node watcher should only reconcile on important events

### DIFF
--- a/pkg/controllers/daemon/nodereconciler/cell_linux.go
+++ b/pkg/controllers/daemon/nodereconciler/cell_linux.go
@@ -34,7 +34,6 @@ type params struct {
 	cell.In
 
 	Config  config.RetinaHubbleConfig
-	Logger  logrus.FieldLogger
 	Client  client.Client
 	IPCache *ipcache.IPCache
 }
@@ -51,7 +50,7 @@ func newNodeController(params params) (*NodeReconciler, error) {
 	n := &NodeReconciler{
 		Client:      params.Client,
 		clusterName: params.Config.ClusterName,
-		l:           params.Logger.WithField("component", "node-controller"),
+		l:           log.Logger().Named("node-controller"),
 		nodes:       make(map[string]types.Node),
 		handlers:    make(map[string]datapath.NodeHandler),
 		c:           params.IPCache,


### PR DESCRIPTION
# Description

Add predicates to filter out node events that are not important for Retina agent.

## Related Issue

Fixed https://github.com/microsoft/retina/issues/1453
## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
