### PR TITLE
chore: bump retina shell base image

### DIFF
--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -1,5 +1,5 @@
-# mcr.microsoft.com/azurelinux/base/core:3.0.20241203
-FROM mcr.microsoft.com/azurelinux/base/core@sha256:07540f424a12aa58f0de61aab38e9670c82f16b35a2ba3e449309596d422109b
+# skopeo inspect docker://mcr.microsoft.com/azurelinux/base/core:3.0 --format "{{.Name}}@{{.Digest}}"
+FROM mcr.microsoft.com/azurelinux/base/core@sha256:b46476be0b5c9691ad20f78871819950c01433bdfad81d72c61618f4a6202b25
 
 RUN tdnf install -y \
 	bind-utils \


### PR DESCRIPTION
# Description

As title. Resolved a couple of CVEs
Before
![image](https://github.com/user-attachments/assets/b54ab40d-5229-4d6e-8c3d-c228c26936dc)
After
![image](https://github.com/user-attachments/assets/11c10e4c-a3a1-4d51-8215-b2ba97ff7909)


## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
