### PR TITLE
fix(perf-workflow): add secrets to the template

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -344,6 +344,12 @@ jobs:
       tag: $(make version)
       image-namespace: ${{ github.repository }}
       retina-mode: basic
+      azure-location: ${{ vars.AZURE_LOCATION }}
+    secrets:
+      azure-subscription: ${{ secrets.AZURE_SUBSCRIPTION }}
+      azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+      azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+      azure-app-insights-key: ${{ secrets.AZURE_APP_INSIGHTS_KEY }}
   
   perf-test-advanced:
     if: ${{ github.event_name == 'merge_group' && success('manifests')}}
@@ -354,3 +360,9 @@ jobs:
       tag: $(make version)
       image-namespace: ${{ github.repository }}
       retina-mode: advanced
+      azure-location: ${{ vars.AZURE_LOCATION }}
+    secrets:
+      azure-subscription: ${{ secrets.AZURE_SUBSCRIPTION }}
+      azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+      azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+      azure-app-insights-key: ${{ secrets.AZURE_APP_INSIGHTS_KEY }}

--- a/.github/workflows/perf-manual.yaml
+++ b/.github/workflows/perf-manual.yaml
@@ -1,0 +1,42 @@
+name: Network Performance Measurement Manually
+
+on:
+  workflow_dispatch:
+    inputs:
+      image-registry:
+        description: 'Image Registry to use for the performance test'
+        required: true
+        default: 'ghcr.io'
+        type: string
+      tag:
+        description: 'Image Tag to use for the performance test'
+        required: true
+        type: string
+      image-namespace:
+        description: 'Image Namespace to use for the performance test'
+        required: false
+        type: string
+      retina-mode:
+        description: 'Retina mode (basic or advanced)'
+        required: true
+        type: string
+        default: 'basic'
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  perf-test:
+    uses: ./.github/workflows/perf-template.yaml
+    with:
+      image-registry: ${{ inputs.image-registry }}
+      tag: ${{ inputs.tag }}
+      image-namespace: ${{ inputs.image-namespace || github.repository }}
+      retina-mode: ${{ inputs.retina-mode }}
+      azure-location: ${{ vars.AZURE_LOCATION }}
+    secrets:
+      azure-subscription: ${{ secrets.AZURE_SUBSCRIPTION }}
+      azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+      azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+      azure-app-insights-key: ${{ secrets.AZURE_APP_INSIGHTS_KEY }}

--- a/.github/workflows/perf-schedule.yaml
+++ b/.github/workflows/perf-schedule.yaml
@@ -17,6 +17,13 @@ jobs:
       tag: $(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r .tag_name)
       image-namespace: ${{ github.repository }}
       retina-mode: basic
+      azure-location: ${{ vars.AZURE_LOCATION }}
+    secrets:
+      azure-subscription: ${{ secrets.AZURE_SUBSCRIPTION }}
+      azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+      azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+      azure-app-insights-key: ${{ secrets.AZURE_APP_INSIGHTS_KEY }}
+
   perf-test-advanced:
     uses: ./.github/workflows/perf-template.yaml
     with:
@@ -24,3 +31,9 @@ jobs:
       tag: $(curl -s https://api.github.com/repos/${{ github.repository }}/releases/latest | jq -r .tag_name)
       image-namespace: ${{ github.repository }}
       retina-mode: advanced
+      azure-location: ${{ vars.AZURE_LOCATION }}
+    secrets:
+      azure-subscription: ${{ secrets.AZURE_SUBSCRIPTION }}
+      azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+      azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+      azure-app-insights-key: ${{ secrets.AZURE_APP_INSIGHTS_KEY }}

--- a/.github/workflows/perf-template.yaml
+++ b/.github/workflows/perf-template.yaml
@@ -14,32 +14,29 @@ on:
         type: string
       image-namespace:
         description: 'Image Namespace to use for the performance test'
-        required: false
+        required: true
         type: string
       retina-mode:
         description: 'Retina mode (basic or advanced)'
         required: true
         type: string
-  workflow_dispatch:
-    inputs:
-      image-registry:
-        description: 'Image Registry to use for the performance test'
-        required: true
-        default: 'ghcr.io'
-        type: string
-      tag:
-        description: 'Image Tag to use for the performance test'
+      azure-location:
+        description: 'Azure location for the performance test'
         required: true
         type: string
-      image-namespace:
-        description: 'Image Namespace to use for the performance test'
-        required: false
-        type: string
-      retina-mode:
-        description: 'Retina mode (basic or advanced)'
-        required: true
-        type: string
-        default: 'basic'
+    secrets:
+        azure-subscription:
+          description: 'Azure subscription ID'
+          required: true
+        azure-tenant-id:
+          description: 'Azure tenant ID'
+          required: true
+        azure-client-id:
+          description: 'Azure client ID'
+          required: true
+        azure-app-insights-key:
+          description: 'Azure Application Insights key'
+          required: true
 
 permissions:
   contents: read
@@ -62,22 +59,22 @@ jobs:
       - name: Az CLI login
         uses: azure/login@v2
         with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION }}
+          client-id: ${{ secrets.azure-client-id }}
+          tenant-id: ${{ secrets.azure-tenant-id }}
+          subscription-id: ${{ secrets.azure-subscription }}
 
       - name: Run performance measurement for Retina
         env:
-          AZURE_APP_INSIGHTS_KEY: ${{ secrets.AZURE_APP_INSIGHTS_KEY }}
-          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION }}
-          AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
+          AZURE_APP_INSIGHTS_KEY: ${{ secrets.azure-app-insights-key }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.azure-subscription }}
+          AZURE_LOCATION: ${{ inputs.azure-location }}
         shell: bash
         run: |
           set -euo pipefail
           
           TAG="${{ inputs.tag }}"
           REGISTRY="${{ inputs.image-registry }}"
-          NAMESPACE="${{ inputs.image-namespace || github.repository }}"
+          NAMESPACE="${{ inputs.image-namespace }}"
           MODE="${{ inputs.retina-mode }}"
           
           echo "Running in $MODE mode..."


### PR DESCRIPTION
# Description

The workflow was failing after templating it as workflow call cannot process runtime variables. We need to pass in the secrets through the workflow as variables.

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
