### PR TITLE
feat: add imagePullSecrets and affinity/tolerations support to the standard chart

### DIFF
--- a/deploy/standard/manifests/controller/helm/retina/templates/daemonset.yaml
+++ b/deploy/standard/manifests/controller/helm/retina/templates/daemonset.yaml
@@ -155,6 +155,10 @@ spec:
       {{- if .Values.tolerations }}
       tolerations: {{- toYaml .Values.tolerations | nindent 8 }}
       {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}
 ---
 {{- if .Values.os.windows}}
@@ -259,6 +263,10 @@ spec:
         {{- end }}
       {{- if .Values.tolerations }}
       tolerations: {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
       {{- range $name, $mountPath := .Values.volumeMounts_win }}

--- a/deploy/standard/manifests/controller/helm/retina/templates/operator.yaml
+++ b/deploy/standard/manifests/controller/helm/retina/templates/operator.yaml
@@ -28,20 +28,16 @@ spec:
         app: {{ .Values.operator.name }}
         control-plane: {{ .Values.operator.name }}
     spec:
-      # TODO(user): Uncomment the following code to configure the nodeAffinity expression
-      # according to the platforms which are supported by your solution.
-      # It is considered best practice to support multiple architectures. You can
-      # build your manager image using the makefile target docker-buildx.
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/os
-                    operator: In
-                    values:
-                      - linux
-                      #- windows
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.operator.affinity }}
+      affinity: {{- toYaml .Values.operator.affinity | nindent 8 }}
+      {{- end }}
+      {{- if .Values.operator.tolerations }}
+      tolerations: {{- toYaml .Values.operator.tolerations | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
       containers:

--- a/deploy/standard/manifests/controller/helm/retina/values.yaml
+++ b/deploy/standard/manifests/controller/helm/retina/values.yaml
@@ -28,6 +28,20 @@ operator:
       - "--config"
       - "/retina/operator-config.yaml"
   telemetryInterval: "5m"
+  affinity:
+    # TODO(user): Override the following values to configure the nodeAffinity expression
+    # according to the platforms which are supported by your solution.
+    # It is considered best practice to support multiple architectures. You can
+    # build your manager image using the makefile target docker-buildx.
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/os
+                operator: In
+                values:
+                  - linux
+                  #- windows
 
 image:
   repository: ghcr.io/microsoft/retina/retina-agent


### PR DESCRIPTION
# Description

Adds missing `imagePullSecrets` and affinity/tolerations support to the legacy chart.

Maintains backwards compatibility with the exsting chart.
 
## Checklist

- [X] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [X] I have correctly attributed the author(s) of the code.
- [X] I have tested the changes locally.
- [X] I have followed the project's style guidelines.
- [X] I have updated the documentation, if necessary.
- [X] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

`helm template` of old and new charts with default values, no diff in generated manifests.

Provided `imagePullSecrets` and `tolerations`/`affinity` blocks to values and they render as expected.

## Additional Notes

None

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
