### PR TITLE
deps: bump cilium to v1.18.0-pre.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -277,7 +277,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.67
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.79.2
 	github.com/cakturk/go-netstat v0.0.0-20200220111822-e5b49efee7a5
-	github.com/cilium/cilium v1.18.0-pre.0.0.20250331121417-b4508ebd8be7
+	github.com/cilium/cilium v1.18.0-pre.1
 	github.com/cilium/ebpf v0.18.0
 	github.com/cilium/hive v0.0.0-20250328192914-7f3c86c9c25e
 	github.com/cilium/proxy v0.0.0-20250318065604-173988fc0adb

--- a/go.sum
+++ b/go.sum
@@ -373,8 +373,8 @@ github.com/chavacava/garif v0.1.0 h1:2JHa3hbYf5D9dsgseMKAmc/MZ109otzgNFk5s87H9Pc
 github.com/chavacava/garif v0.1.0/go.mod h1:XMyYCkEL58DF0oyW4qDjjnPWONs2HBqYKI+UIPD+Gww=
 github.com/chrismellard/docker-credential-acr-env v0.0.0-20230304212654-82a0ddb27589 h1:krfRl01rzPzxSxyLyrChD+U+MzsBXbm0OwYYB67uF+4=
 github.com/chrismellard/docker-credential-acr-env v0.0.0-20230304212654-82a0ddb27589/go.mod h1:OuDyvmLnMCwa2ep4Jkm6nyA0ocJuZlGyk2gGseVzERM=
-github.com/cilium/cilium v1.18.0-pre.0.0.20250331121417-b4508ebd8be7 h1:GhDwF7QtQFuawiKHqJIr4v0B3hWSVgtU7f9dKiNm1wQ=
-github.com/cilium/cilium v1.18.0-pre.0.0.20250331121417-b4508ebd8be7/go.mod h1:xNfreZ/3t6IxynTSSqJRr8hZd2dhX0dns+ae/WDYwWk=
+github.com/cilium/cilium v1.18.0-pre.1 h1:ZE+fNsr6QAVcKsvnO1WmMQF4Jo/aztYF1IGy77kb6i0=
+github.com/cilium/cilium v1.18.0-pre.1/go.mod h1:xNfreZ/3t6IxynTSSqJRr8hZd2dhX0dns+ae/WDYwWk=
 github.com/cilium/dns v1.1.51-0.20240603182237-af788769786a h1:PRGN7B+72mj3OtLL2DM3F/9jp+ItgqgNS7mecgCmwsQ=
 github.com/cilium/dns v1.1.51-0.20240603182237-af788769786a/go.mod h1:/7LC2GOgyXJ7maupZlaVIumYQiGPIgllSf6mA9sg6RU=
 github.com/cilium/ebpf v0.5.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=


### PR DESCRIPTION
# Description

This pull request updates the dependency version for `github.com/cilium/cilium` in the `go.mod` file. The version has been incremented from `v1.18.0-pre.0.0.20250331121417-b4508ebd8be7` to `v1.18.0-pre.1`.

Dependency update:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L280-R280): Updated `github.com/cilium/cilium` to `v1.18.0-pre.1` to align with the latest pre-release version.

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
