### PR TITLE
deps: Update Go version to 1.24.2-2

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,5 +1,5 @@
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24.1-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:605d0a6f05734845927f450a62e081bd19c03dbe1fdbf993cfedc8506c9192b4 AS builder
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24.2-2-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:5341a0010ecff114ee2f11f5eaa4f73b721b54142954041523f3e785d5c4b978 AS builder
 
 ARG VERSION
 ARG APP_INSIGHTS_ID

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -2,8 +2,8 @@
 ARG OS_VERSION=ltsc2022
 # pinned base images
 
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24.1-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:605d0a6f05734845927f450a62e081bd19c03dbe1fdbf993cfedc8506c9192b4 AS golang
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24.2-2-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:5341a0010ecff114ee2f11f5eaa4f73b721b54142954041523f3e785d5c4b978 AS golang
 
 # skopeo inspect docker://mcr.microsoft.com/cbl-mariner/base/core:2.0 --format "{{.Name}}@{{.Digest}}"
 FROM mcr.microsoft.com/cbl-mariner/base/core@sha256:8deab931d4af66264253cce66471a04742dc6f8d5d175d4c18e930eda615c0aa AS mariner-core

--- a/controller/Dockerfile.gogen
+++ b/controller/Dockerfile.gogen
@@ -1,5 +1,5 @@
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24.1-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:605d0a6f05734845927f450a62e081bd19c03dbe1fdbf993cfedc8506c9192b4
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24.2-2-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:5341a0010ecff114ee2f11f5eaa4f73b721b54142954041523f3e785d5c4b978
 
 # Default linux/architecture.
 ARG GOOS=linux

--- a/controller/Dockerfile.proto
+++ b/controller/Dockerfile.proto
@@ -1,5 +1,5 @@
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24.1-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:605d0a6f05734845927f450a62e081bd19c03dbe1fdbf993cfedc8506c9192b4
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24.2-2-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:5341a0010ecff114ee2f11f5eaa4f73b721b54142954041523f3e785d5c4b978
 
 LABEL Name=retina-builder Version=0.0.1
 

--- a/controller/Dockerfile.windows-2019
+++ b/controller/Dockerfile.windows-2019
@@ -1,5 +1,5 @@
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24.1-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:605d0a6f05734845927f450a62e081bd19c03dbe1fdbf993cfedc8506c9192b4 AS builder
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24.2-2-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:5341a0010ecff114ee2f11f5eaa4f73b721b54142954041523f3e785d5c4b978 AS builder
 
 # Build args
 ARG VERSION

--- a/controller/Dockerfile.windows-2022
+++ b/controller/Dockerfile.windows-2022
@@ -1,5 +1,5 @@
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24.1-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:605d0a6f05734845927f450a62e081bd19c03dbe1fdbf993cfedc8506c9192b4 AS builder
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24.2-2-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:5341a0010ecff114ee2f11f5eaa4f73b721b54142954041523f3e785d5c4b978 AS builder
 
 # Build args
 ARG VERSION

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/microsoft/retina
 
-go 1.24.1
+go 1.24.2
 
 require (
 	github.com/go-chi/chi/v5 v5.2.1

--- a/hack/tools/kapinger/go.mod
+++ b/hack/tools/kapinger/go.mod
@@ -1,6 +1,6 @@
 module github.com/microsoft/retina/hack/tools/kapinger
 
-go 1.24.1
+go 1.24.2
 
 require (
 	golang.org/x/sync v0.12.0

--- a/hack/tools/toolbox/go.mod
+++ b/hack/tools/toolbox/go.mod
@@ -1,6 +1,6 @@
 module github.com/microsoft/retina/hack/tools/toolbox
 
-go 1.24.1
+go 1.24.2
 
 replace github.com/microsoft/retina/hack/tools/kapinger => ../kapinger
 

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,5 +1,5 @@
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24.1-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:605d0a6f05734845927f450a62e081bd19c03dbe1fdbf993cfedc8506c9192b4 AS builder
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24.2-2-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:5341a0010ecff114ee2f11f5eaa4f73b721b54142954041523f3e785d5c4b978 AS builder
 
 ARG VERSION
 ARG APP_INSIGHTS_ID

--- a/operator/Dockerfile.windows-2019
+++ b/operator/Dockerfile.windows-2019
@@ -1,5 +1,5 @@
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24.1-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:605d0a6f05734845927f450a62e081bd19c03dbe1fdbf993cfedc8506c9192b4 AS builder
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24.2-2-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:5341a0010ecff114ee2f11f5eaa4f73b721b54142954041523f3e785d5c4b978 AS builder
 
 # Build args
 ARG VERSION

--- a/operator/Dockerfile.windows-2022
+++ b/operator/Dockerfile.windows-2022
@@ -1,5 +1,5 @@
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24.1-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:605d0a6f05734845927f450a62e081bd19c03dbe1fdbf993cfedc8506c9192b4 AS builder
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24.2-2-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:5341a0010ecff114ee2f11f5eaa4f73b721b54142954041523f3e785d5c4b978 AS builder
 
 # Build args
 ARG VERSION

--- a/test/multicloud/test/go.mod
+++ b/test/multicloud/test/go.mod
@@ -1,6 +1,6 @@
 module github.com/microsoft/retina/test/multicloud/test
 
-go 1.24.1
+go 1.24.2
 
 require (
 	github.com/gruntwork-io/terratest v0.48.1


### PR DESCRIPTION
# Description

This PR updates the version of Go, to deal with [CVE-2025-22871](https://www.cve.org/CVERecord?id=CVE-2025-22871).

## Related Issue

[CVE-2025-22871](https://www.cve.org/CVERecord?id=CVE-2025-22871)

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

No more issues detected on the retina-agent image.

![{9C51DC1F-DCBA-477D-A727-CF8105B0803E}](https://github.com/user-attachments/assets/e1cd5fb8-6e5b-4ec6-9018-8ef764a8536c)

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
