### PR TITLE
test: keep infra settings in struct

### DIFF
--- a/test/e2e/common/common.go
+++ b/test/e2e/common/common.go
@@ -7,7 +7,6 @@ package common
 import (
 	"flag"
 	"os/user"
-	"path/filepath"
 	"strconv"
 	"testing"
 	"time"
@@ -27,10 +26,6 @@ const (
 )
 
 var (
-	AzureLocations = []string{"eastus2", "northeurope", "uksouth", "centralindia", "westus2"}
-	Architectures  = []string{"amd64", "arm64"}
-	CreateInfra    = flag.Bool("create-infra", true, "create a Resource group, vNET and AKS cluster for testing")
-	DeleteInfra    = flag.Bool("delete-infra", true, "delete a Resource group, vNET and AKS cluster for testing")
 	ScaleTestInfra = ScaleTestInfraHandler{
 		location:       params.Location,
 		subscriptionID: params.SubscriptionID,
@@ -42,18 +37,6 @@ var (
 	// kubeconfig: path to kubeconfig file, in not provided,
 	// a new k8s cluster will be created
 	KubeConfig = flag.String("kubeConfig", "", "Path to kubeconfig file")
-)
-
-var (
-	RetinaChartPath = func(rootDir string) string {
-		return filepath.Join(rootDir, "deploy", "standard", "manifests", "controller", "helm", "retina")
-	}
-	RetinaAdvancedProfilePath = func(rootDir string) string {
-		return filepath.Join(rootDir, "test", "profiles", "advanced", "values.yaml")
-	}
-	KubeConfigFilePath = func(rootDir string) string {
-		return filepath.Join(rootDir, "test", "e2e", "test.pem")
-	}
 )
 
 type ScaleTestInfraHandler struct {

--- a/test/e2e/common/settings.go
+++ b/test/e2e/common/settings.go
@@ -1,0 +1,108 @@
+package common
+
+import (
+	"crypto/rand"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"math/big"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strconv"
+	"time"
+)
+
+var (
+	clusterName   = os.Getenv("CLUSTER_NAME")
+	subID         = os.Getenv("AZURE_SUBSCRIPTION_ID")
+	location      = os.Getenv("AZURE_LOCATION")
+	resourceGroup = os.Getenv("AZURE_RESOURCE_GROUP")
+
+	errAzureSubscriptionIDNotSet = errors.New("AZURE_SUBSCRIPTION_ID is not set")
+)
+
+var (
+	locations     = []string{"eastus2", "centralus", "southcentralus", "uksouth", "centralindia", "westus2"}
+	architectures = []string{"amd64", "arm64"}
+	createInfra   = flag.Bool("create-infra", true, "create a Resource group, vNET and AKS cluster for testing")
+	deleteInfra   = flag.Bool("delete-infra", true, "delete a Resource group, vNET and AKS cluster for testing")
+)
+
+type TestInfraSettings struct {
+	CreateInfra         bool
+	DeleteInfra         bool
+	ChartPath           string
+	ProfilePath         string
+	AdvancedProfilePath string
+	KubeConfigFilePath  string
+
+	ClusterName   string
+	SubID         string
+	Location      string
+	ResourceGroup string
+
+	AzureLocations []string
+	Architectures  []string
+}
+
+func LoadInfraSettings() (*TestInfraSettings, error) {
+	curuser, err := user.Current()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get current user: %w", err)
+	}
+
+	flag.Parse()
+
+	if clusterName == "" {
+		clusterName = curuser.Username + NetObsRGtag + strconv.FormatInt(time.Now().Unix(), 10)
+		log.Printf("CLUSTER_NAME is not set, generating a random cluster name: %s", clusterName)
+	}
+
+	if subID == "" {
+		return nil, errAzureSubscriptionIDNotSet
+	}
+
+	if location == "" {
+		var nBig *big.Int
+		nBig, err = rand.Int(rand.Reader, big.NewInt(int64(len(locations))))
+		if err != nil {
+			return nil, fmt.Errorf("Failed to generate a secure random index: %w", err)
+		}
+		location = locations[nBig.Int64()]
+	}
+
+	if resourceGroup == "" {
+		log.Printf("AZURE_RESOURCE_GROUP is not set, using the cluster name as the resource group name by default")
+		resourceGroup = clusterName
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get current working directory: %w", err)
+	}
+
+	// Get to root of the repo by going up two directories
+	rootDir := filepath.Dir(filepath.Dir(cwd))
+
+	chartPath := filepath.Join(rootDir, "deploy", "legacy", "manifests", "controller", "helm", "retina")
+	profilePath := filepath.Join(rootDir, "test", "profiles", "advanced", "values.yaml")
+	advancedProfilePath := filepath.Join(rootDir, "test", "profiles", "advanced", "values.yaml")
+	kubeConfigFilePath := filepath.Join(rootDir, "test", "e2e", "test.pem")
+
+	return &TestInfraSettings{
+		CreateInfra:         *createInfra,
+		DeleteInfra:         *deleteInfra,
+		ChartPath:           chartPath,
+		ProfilePath:         profilePath,
+		AdvancedProfilePath: advancedProfilePath,
+		KubeConfigFilePath:  kubeConfigFilePath,
+		ClusterName:         clusterName,
+		SubID:               subID,
+		Location:            location,
+		ResourceGroup:       resourceGroup,
+		AzureLocations:      locations,
+		Architectures:       architectures,
+	}, nil
+}

--- a/test/e2e/jobs/jobs.go
+++ b/test/e2e/jobs/jobs.go
@@ -58,16 +58,13 @@ func CreateTestInfra(subID, rg, clusterName, location, kubeConfigFilePath string
 	return job
 }
 
-func DeleteTestInfra(subID, rg, location string, deleteInfra bool) *types.Job {
+func DeleteTestInfra(subID, rg, location string) *types.Job {
 	job := types.NewJob("Delete e2e test infrastructure")
-
-	if deleteInfra {
-		job.AddStep(&azure.DeleteResourceGroup{
-			SubscriptionID:    subID,
-			ResourceGroupName: rg,
-			Location:          location,
-		}, nil)
-	}
+	job.AddStep(&azure.DeleteResourceGroup{
+		SubscriptionID:    subID,
+		ResourceGroupName: rg,
+		Location:          location,
+	}, nil)
 
 	return job
 }


### PR DESCRIPTION
# Description

Keep settings in struct to avoid global variables, allow create and delete to be passed as flags

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
