### PR TITLE
test: enable Mariner pool for E2E

### DIFF
--- a/test/e2e/framework/azure/create-cluster-with-npm.go
+++ b/test/e2e/framework/azure/create-cluster-with-npm.go
@@ -66,7 +66,6 @@ func (c *CreateNPMCluster) Run() error {
 		MaxPods:            to.Ptr(int32(MaxPodsPerNode)),
 	})
 
-	/* todo: add azlinux node pool
 	//nolint:appendCombine // separate for verbosity
 	npmCluster.Properties.AgentPoolProfiles = append(npmCluster.Properties.AgentPoolProfiles, &armcontainerservice.ManagedClusterAgentPoolProfile{
 		Type:               to.Ptr(armcontainerservice.AgentPoolTypeVirtualMachineScaleSets),
@@ -77,11 +76,11 @@ func (c *CreateNPMCluster) Run() error {
 		OSType:             to.Ptr(armcontainerservice.OSTypeLinux),
 		OSSKU:              to.Ptr(armcontainerservice.OSSKUAzureLinux),
 		ScaleDownMode:      to.Ptr(armcontainerservice.ScaleDownModeDelete),
-		VMSize:             to.Ptr(azure.AgentSKU),
+		VMSize:             to.Ptr(AgentSKU),
 		Name:               to.Ptr("azlinux"),
-		MaxPods:            to.Ptr(int32(azure.MaxPodsPerNode)),
+		MaxPods:            to.Ptr(int32(MaxPodsPerNode)),
 	})
-	*/
+
 	//nolint:appendCombine // separate for verbosity
 	npmCluster.Properties.AgentPoolProfiles = append(npmCluster.Properties.AgentPoolProfiles, &armcontainerservice.ManagedClusterAgentPoolProfile{ //nolint:all
 		Type: to.Ptr(armcontainerservice.AgentPoolTypeVirtualMachineScaleSets),


### PR DESCRIPTION
We have distro-dependent eBPF code that needs ongoing validation.