### PR TITLE
fix(controller): add warning for nodes with no addresses in reconciliation

### DIFF
--- a/pkg/controllers/daemon/node/controller.go
+++ b/pkg/controllers/daemon/node/controller.go
@@ -75,6 +75,11 @@ func (r *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		return ctrl.Result{}, nil
 	}
 
+	if len(node.Status.Addresses) == 0 {
+		r.l.Warn("Node has no addresses", zap.String("Node", req.NamespacedName.String()))
+		return ctrl.Result{}, nil
+	}
+
 	retinaNodeCommon := retinaCommon.NewRetinaNode(node.Name, net.ParseIP(node.Status.Addresses[0].Address))
 	if err := r.cache.UpdateRetinaNode(retinaNodeCommon); err != nil {
 		r.l.Error("Failed to update RetinaNode in Cache", zap.Error(err), zap.String("Node", req.NamespacedName.String()))


### PR DESCRIPTION
# Description

This PR improves the `NodeReconciler` logic in `controller.go` by adding a safeguard for nodes with no addresses.
Specifically, it ensures that if a node has an empty `Status.Addresses` field, a warning is logged, and the reconciliation process exits gracefully without further processing.

This prevents potential runtime errors when attempting to access an address that does not exist.

## Related Issue

resolve #1541

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

The following scenarios were tested:
1. **Node with no addresses**: Verified that a warning is logged, and the reconciliation exits without errors.
2. **Node with valid addresses**: Verified that the `RetinaNode` is created and updated in the cache correctly.
3. **Node being deleted**: Verified that the `RetinaNode` is removed from the cache as expected.

All tests passed successfully.

## Additional Notes

This change ensures that the `NodeReconciler` handles edge cases more robustly, improving the stability of the controller. The added safeguard prevents potential issues when interacting with nodes that lack address information.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.