### PR TITLE
fix(helm): Missing helper template for ingress resource

### DIFF
--- a/deploy/hubble/manifests/controller/helm/retina/templates/_helpers.tpl
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/_helpers.tpl
@@ -80,3 +80,21 @@ Return the appropriate apiVersion for cronjob.
 {{- print "batch/v1beta1" -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return the appropriate backend for Hubble UI ingress.
+*/}}
+{{- define "ingress.paths" -}}
+{{ if semverCompare ">=1.4-0, <1.19-0" .Capabilities.KubeVersion.Version -}}
+backend:
+  serviceName: hubble-ui
+  servicePort: http
+{{- else if semverCompare "^1.19-0" .Capabilities.KubeVersion.Version -}}
+pathType: Prefix
+backend:
+  service:
+    name: hubble-ui
+    port:
+      name: http
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
# Description

Fix ingress helm template issue due to missing helper script:

- The hubble-ui subchart of retina doesn't include the `ingress.paths` definition from the cilium chart, so it needs to be defined instead in the _helpers.tpl helper script of retina.
- Root cause line in `ingress.yaml` template:

https://github.com/microsoft/retina/blob/7e2fc3346eaabf3ece23c1d181a1de7dcac2bd82/deploy/hubble/manifests/controller/helm/retina/templates/hubble-ui/ingress.yaml#L38

## Related Issue

- https://github.com/cilium/cilium/pull/13682

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Ingress completly created (screenshot from k9s):

<img width="859" alt="붙여넣은_이미지_2025__4__30__오후_5_27" src="https://github.com/user-attachments/assets/cc727bf6-591f-4f88-a7a1-559210a8f3df" />

## Additional Notes

N/A

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
