### PR TITLE
feat: additional apiserver IPs from service and endpoint

### DIFF
--- a/pkg/k8s/apiserver_linux.go
+++ b/pkg/k8s/apiserver_linux.go
@@ -54,14 +54,12 @@ func (a *APIServerEventHandler) handleAPIServerEvent(event interface{}) {
 			_, err := a.c.Upsert(ip.String(), nil, 0, nil, ipcache.Identity{ID: identity.ReservedIdentityKubeAPIServer, Source: source.Kubernetes})
 			if err != nil {
 				a.l.WithError(err).WithFields(logrus.Fields{
-					"IP": ips[0].String(),
+					"IP": ip.String(),
 				}).Error("Failed to add API server IPs to ipcache")
 				return
 			}
 		}
-		a.l.WithFields(logrus.Fields{
-			"IP": ips[0].String(),
-		}).Info("Added API server IPs to ipcache")
+		a.l.Infof("Added API server IPs %v to ipcache", ips)
 	case cc.EventTypeDeleteAPIServerIPs:
 		apiserverObj, ok := cacheEvent.Obj.(*common.APIServerObject)
 		if !ok {
@@ -77,9 +75,7 @@ func (a *APIServerEventHandler) handleAPIServerEvent(event interface{}) {
 			//nolint:staticcheck // TODO(timraymond): unclear how to migrate this
 			a.c.Delete(ip.String(), source.Kubernetes)
 		}
-		a.l.WithFields(logrus.Fields{
-			"IP": ips[0].String(),
-		}).Info("Deleted API server IPs from ipcache")
+		a.l.Infof("Deleted API server IPs %v from ipcache", ips)
 	default:
 		a.l.WithFields(logrus.Fields{
 			"Cache Event": cacheEvent,


### PR DESCRIPTION
# Description

In some cases the flows incorrectly assumed APIServer IPs as world.
This PR adds functionality to the watcher to extract IPs from the Kubernetes service and endpoints. In some managed Kubernetes offerings these IPs are used to establish connections from and to the kube-apiserver.


## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed


![image](https://github.com/user-attachments/assets/47319020-c030-4f33-9cdd-1cded2daccd6)

Before:
![image](https://github.com/user-attachments/assets/8e7a80f7-8715-47ba-9728-fc9d18cd550f)

After:
![image](https://github.com/user-attachments/assets/d9ba7efa-3eac-4506-9467-fa1ba8063549)

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
