### PR TITLE
chore: Mark retina directory as safe in windows Dockerfile

### DIFF
--- a/controller/Dockerfile.windows-native
+++ b/controller/Dockerfile.windows-native
@@ -15,6 +15,7 @@ ARG APP_INSIGHTS_ID
 SHELL ["cmd", "/S", "/C"]
 ENV VERSION=$VERSION
 
+RUN git config --global --add safe.directory C:\\retina
 ENV APP_INSIGHTS_ID=$APP_INSIGHTS_ID
 RUN go build -v -o controller.exe -ldflags="-X github.com/microsoft/retina/internal/buildinfo.Version=%VERSION% -X github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID=%APP_INSIGHTS_ID%" .\controller
 RUN go build -v -o captureworkload.exe -ldflags="-X github.com/microsoft/retina/internal/buildinfo.Version=%VERSION% -X github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID=%APP_INSIGHTS_ID%" .\captureworkload


### PR DESCRIPTION
# Description

Adds a line to the Windows native Dockerfile to mark the Retina directory as safe.

## Related Issue

N/A

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [] I have added tests, if applicable.
