### PR TITLE
fix: include Mariner check for Hubble scenario

### DIFF
--- a/deploy/hubble/manifests/controller/helm/retina/templates/agent/daemonset.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/agent/daemonset.yaml
@@ -120,6 +120,8 @@ spec:
               mountPath: /sys/kernel/tracing
             - name: cilium
               mountPath: /var/run/cilium
+            - name: host-os-release
+              mountPath: /etc/os-release  
           {{- if .Values.hubble.tls.enabled }}
             - name: tls
               mountPath: /var/lib/cilium/tls/hubble
@@ -146,6 +148,10 @@ spec:
         hostPath:
           path: /var/run/cilium
           type: DirectoryOrCreate
+      - name: host-os-release
+        hostPath:
+          path: /etc/os-release
+          type: FileOrCreate   
       {{- if .Values.hubble.tls.enabled }}
       - name: tls
         projected:


### PR DESCRIPTION
Fixes https://github.com/microsoft/retina/pull/1458

In the PR above, I only added the `/etc/host-os-release` volumeMount in 
`deploy/standard/manifests/controller/helm/retina/templates/daemonset.yaml`
but not in 
`deploy/hubble/manifests/controller/helm/retina/templates/agent/daemonset.yaml`

The omission was because in the former we iterate over the volume mount list defined in values.yaml, while the latter defines them explicitly in the daemonset.