### PR TITLE
fix(fips): Grant permissions to support FIPS on Ubuntu

### DIFF
--- a/deploy/hubble/manifests/controller/helm/retina/values.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/values.yaml
@@ -108,9 +108,9 @@ securityContext:
   capabilities:
     add:
       - SYS_ADMIN
-      - SYS_RESOURCE
+      - SYS_RESOURCE # for setting rlimit
       - NET_ADMIN # for packetparser plugin
-      - IPC_LOCK # for mmap() calls made by NewReader(), ref: https://man7.org/linux/man-pages/man2/mmap.2.html
+      - IPC_LOCK # for mmap() calls made by NewReader(), ref: https://man7.org/linux/man-pages/man2/mmap.2.html 
   windowsOptions:
     runAsUserName: "NT AUTHORITY\\SYSTEM"
 

--- a/deploy/standard/manifests/controller/helm/retina/values.yaml
+++ b/deploy/standard/manifests/controller/helm/retina/values.yaml
@@ -125,6 +125,7 @@ securityContext:
       - SYS_ADMIN
       - NET_ADMIN # for packetparser plugin
       - IPC_LOCK # for mmap() calls made by NewReader(), ref: https://man7.org/linux/man-pages/man2/mmap.2.html
+      - SYS_RESOURCE # for setting rlimit
   windowsOptions:
     runAsUserName: "NT AUTHORITY\\SYSTEM"
 


### PR DESCRIPTION
When running on the FIPS-compliant Ubuntu 20.04, Retina requires `SYS_RESOURCE` on top of `IPC_LOCK`.

Also, skip attaching to unavailable kernel hook points.

Merge after https://github.com/microsoft/retina/pull/1601 - otherwise the pod still fails, just at a later stage.
