### PR TITLE
fix(DropReason): Do not load fexit programs on kernels below 5.5

### DIFF
--- a/pkg/plugin/dropreason/dropreason_linux.go
+++ b/pkg/plugin/dropreason/dropreason_linux.go
@@ -139,7 +139,7 @@ func (dr *dropReason) Init() error {
 		return err //nolint:wrapcheck // no additional context needed
 	}
 
-	objs, maps, isFexit, err := dr.getEbpfPayload()
+	objs, maps, supportsFexit, err := dr.getEbpfPayload()
 	if err != nil {
 		return err
 	}
@@ -167,14 +167,10 @@ func (dr *dropReason) Init() error {
 	progsKprobe, progsKprobeRet := buildKprobePrograms(objs)
 	progsFexit := buildFexitPrograms(objs)
 
-	if dr.cfg.EnablePodLevel {
-		err = dr.attachKprobes(progsKprobe, progsKprobeRet)
+	if supportsFexit {
+		err = dr.attachFexitPrograms(progsFexit)
 	} else {
-		if isFexit {
-			err = dr.attachFexitPrograms(progsFexit)
-		} else {
-			err = dr.attachKprobes(progsKprobe, progsKprobeRet)
-		}
+		err = dr.attachKprobes(progsKprobe, progsKprobeRet)
 	}
 
 	dr.metricsMapData = maps.RetinaDropreasonMetrics

--- a/pkg/plugin/dropreason/dropreason_linux.go
+++ b/pkg/plugin/dropreason/dropreason_linux.go
@@ -136,7 +136,7 @@ func (dr *dropReason) Init() error {
 	bpfOutputFile := fmt.Sprintf("%s/%s", dir, bpfObjectFileName)
 	spec, err := ebpf.LoadCollectionSpec(bpfOutputFile)
 	if err != nil {
-		return err
+		return err //nolint:wrapcheck // no additional context needed
 	}
 
 	objs, maps, isFexit, err := dr.getEbpfPayload()

--- a/pkg/plugin/dropreason/ebpfsetup_linux.go
+++ b/pkg/plugin/dropreason/ebpfsetup_linux.go
@@ -1,0 +1,209 @@
+package dropreason
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/cilium/cilium/pkg/version"
+	"github.com/cilium/cilium/pkg/versioncheck"
+	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
+	plugincommon "github.com/microsoft/retina/pkg/plugin/common"
+	"go.uber.org/zap"
+)
+
+const (
+	MinAmdVersionNum = "5.5"
+	MinArmVersionNum = "6.0"
+)
+
+/*
+getEbpfPayload() returns the ebpf program and map objects to load, based on the kernel version, architecture, and distro.
+We use fexit programs for better performance, and fall back to kprobes.
+
+eBPF Program Support Matrix
+===========================
+
+Program Type Selection:
+- If:
+  - Arch == amd64 and kernel >= 5.5
+  - Arch == arm64 and kernel >= 6.0
+    → Use `fexit`
+  - Else:
+    → Use `kprobe`
+
+Scope Selection:
+- If:
+  - Distro == Mariner
+    → Scope = core (only core kernel funcs)
+  - Else:
+    → Scope = all (core + module funcs)
+
++-----------+------------------------+--------------+--------+
+| Distro    | Arch + Kernel          | Prog         | Scope  |
++-----------+------------------------+--------------+--------+
+| Mariner   | amd64, kernel >= 5.5   | fexit        | core   |
+| Mariner   | arm64, kernel >= 6.0   | fexit        | core   |
+| Non-Marin | amd64, kernel >= 5.5   | fexit        | all    |
+| Non-Marin | arm64, kernel >= 6.0   | fexit        | all    |
+| *         | (otherwise)            | kprobe       | per OS |
++-----------+------------------------+--------------+--------+
+
+core kernel funcs:
+- tcp_v4_connect
+- inet_csk_accept
+- nf_hook_slow
+
+module funcs:
+- nf_conntrack_confirm
+- nf_nat_inet_fn
+*/
+func (dr *dropReason) getEbpfPayload() (interface{}, *kprobeMaps, bool, error) {
+	var objs interface{}
+	maps := &kprobeMaps{}
+	isMariner := plugincommon.IsAzureLinux()
+	dr.l.Info("Distro check:", zap.Bool("isMariner", isMariner))
+
+	// Check if the kernel version is >= 5.5 for amd64 and >= 6.0 for arm64
+	// This is needed to decide between attaching fexit and kprobe programs.
+	kv, err := version.GetKernelVersion()
+	if err != nil {
+		dr.l.Warn("Failed to get kernel version", zap.Error(err))
+
+		kv, err = plugincommon.GetKernelVersionMajMin()
+		if err != nil {
+			return nil, nil, false, fmt.Errorf("Failed to get kernel version: %w", err) //nolint:goerr113 //wrapping error from external module
+		}
+	}
+	dr.l.Info("Detected kernel >= ", zap.String("version", kv.String()))
+
+	minVersionAmd64, _ := versioncheck.Version(MinAmdVersionNum)
+	minVersionArm64, _ := versioncheck.Version(MinArmVersionNum)
+	isFexit := (runtime.GOARCH == "amd64" && kv.GTE(minVersionAmd64)) || (runtime.GOARCH == "arm64" && kv.GTE(minVersionArm64))
+
+	switch {
+	case !isFexit:
+		objs = &kprobeObjectsOld{} //nolint:typecheck // this is a generated struct
+		maps = &objs.(*kprobeObjectsOld).kprobeMaps
+	case !isMariner:
+		objs = &kprobeObjects{} //nolint:typecheck // this is a generated struct
+		maps = &objs.(*kprobeObjects).kprobeMaps
+	case isMariner:
+		objs = &kprobeObjectsMariner{} //nolint:typecheck // needs to match a generated struct until we fix Mariner
+		maps = &objs.(*kprobeObjectsMariner).kprobeMaps
+	}
+
+	return objs, maps, isFexit, nil
+}
+
+func (dr *dropReason) attachKprobes(kprobes, kprobesRet map[string]*ebpf.Program) error {
+	for name := range kprobes {
+		progLink, err := link.Kprobe(name, kprobes[name], nil)
+		if err != nil {
+			dr.l.Error("Failed to attach kprobe", zap.String("program", name), zap.Error(err))
+		} else {
+			dr.hooks = append(dr.hooks, progLink)
+			dr.l.Info("Attached kprobe", zap.String("program", name))
+		}
+	}
+
+	// The kretprobes set metric values. If none were attached, report an error.
+	retprobeCount := 0
+	for name := range kprobesRet {
+		progLink, err := link.Kretprobe(name, kprobesRet[name], nil)
+		if err != nil {
+			dr.l.Error("Failed to attach kretprobe", zap.String("program", name), zap.Error(err))
+		} else {
+			dr.hooks = append(dr.hooks, progLink)
+			retprobeCount++
+			dr.l.Info("Attached kretprobe", zap.String("program", name))
+		}
+	}
+	if retprobeCount == 0 {
+		dr.l.Error("No kretprobes attached, cannot collect drop metrics")
+		return fmt.Errorf("No kretprobes attached, cannot collect drop metrics") //nolint:goerr113 //wrapping error from external module
+	}
+
+	return nil
+}
+
+func (dr *dropReason) attachFexitPrograms(objs map[string]*ebpf.Program) error {
+	progCount := 0
+	for name, prog := range objs {
+		progLink, err := link.AttachTracing(link.TracingOptions{Program: prog, AttachType: ebpf.AttachTraceFExit})
+		if err != nil {
+			dr.l.Error("Failed to attach", zap.String("program", name), zap.Error(err))
+		} else {
+			dr.hooks = append(dr.hooks, progLink)
+			progCount++
+			dr.l.Info("Attached program", zap.String("program", name))
+		}
+	}
+
+	if progCount == 0 {
+		dr.l.Error("No programs attached, cannot collect drop metrics")
+		return fmt.Errorf("No programs attached, cannot collect drop metrics") //nolint:goerr113 //wrapping error from external module
+	}
+
+	return nil
+}
+
+func buildKprobePrograms(objs any) (progsKprobe, progsKprobeRet map[string]*ebpf.Program) {
+	progsKprobe = make(map[string]*ebpf.Program)
+	progsKprobeRet = make(map[string]*ebpf.Program)
+
+	switch o := objs.(type) {
+	case *kprobeObjects:
+		progsKprobe[inetCskAcceptFn] = o.InetCskAccept
+		progsKprobe[nfHookSlowFn] = o.NfHookSlow
+		progsKprobe[nfNatInetFn] = o.NfNatInetFn
+		progsKprobe[nfConntrackConfirmFn] = o.NfConntrackConfirm
+
+		progsKprobeRet[nfHookSlowFn] = o.NfHookSlowRet
+		progsKprobeRet[inetCskAcceptFn] = o.InetCskAcceptRet
+		progsKprobeRet[tcpConnectFn] = o.TcpV4ConnectRet
+		progsKprobeRet[nfNatInetFn] = o.NfNatInetFnRet
+		progsKprobeRet[nfConntrackConfirmFn] = o.NfConntrackConfirmRet
+
+	case *kprobeObjectsOld:
+		progsKprobe[inetCskAcceptFn] = o.InetCskAccept
+		progsKprobe[nfHookSlowFn] = o.NfHookSlow
+		progsKprobe[nfNatInetFn] = o.NfNatInetFn
+		progsKprobe[nfConntrackConfirmFn] = o.NfConntrackConfirm
+
+		progsKprobeRet[nfHookSlowFn] = o.NfHookSlowRet
+		progsKprobeRet[inetCskAcceptFn] = o.InetCskAcceptRet
+		progsKprobeRet[tcpConnectFn] = o.TcpV4ConnectRet
+		progsKprobeRet[nfNatInetFn] = o.NfNatInetFnRet
+		progsKprobeRet[nfConntrackConfirmFn] = o.NfConntrackConfirmRet
+
+	case *kprobeObjectsMariner:
+		progsKprobe[inetCskAcceptFn] = o.InetCskAccept
+		progsKprobe[nfHookSlowFn] = o.NfHookSlow
+
+		progsKprobeRet[nfHookSlowFn] = o.NfHookSlowRet
+		progsKprobeRet[inetCskAcceptFn] = o.InetCskAcceptRet
+		progsKprobeRet[tcpConnectFn] = o.TcpV4ConnectRet
+	}
+	return progsKprobe, progsKprobeRet
+}
+
+func buildFexitPrograms(objs any) map[string]*ebpf.Program {
+	progsFexit := make(map[string]*ebpf.Program)
+
+	switch o := objs.(type) {
+	case *kprobeObjects:
+		progsFexit[inetCskAcceptFnFexit] = o.InetCskAcceptFexit
+		progsFexit[nfHookSlowFnFexit] = o.NfHookSlowFexit
+		progsFexit[tcpV4ConnectFexit] = o.TcpV4ConnectFexit
+		progsFexit[nfNatInetFnFexit] = o.NfNatInetFnFexit
+		progsFexit[nfConntrackConfirmFnFexit] = o.NfConntrackConfirmFexit
+
+	case *kprobeObjectsMariner:
+		progsFexit[inetCskAcceptFnFexit] = o.InetCskAcceptFexit
+		progsFexit[nfHookSlowFnFexit] = o.NfHookSlowFexit
+		progsFexit[tcpV4ConnectFexit] = o.TcpV4ConnectFexit
+
+	}
+	return progsFexit
+}

--- a/pkg/plugin/dropreason/types_linux.go
+++ b/pkg/plugin/dropreason/types_linux.go
@@ -58,6 +58,23 @@ type kprobeProgramsMariner struct {
 	TcpV4ConnectFexit  *ebpf.Program `ebpf:"tcp_v4_connect_fexit"` // nolint:revive // needs to match generated code
 }
 
+type kprobeObjectsOld struct {
+	kprobeProgramsOld
+	kprobeMaps
+}
+
+type kprobeProgramsOld struct {
+	InetCskAccept         *ebpf.Program `ebpf:"inet_csk_accept"`
+	InetCskAcceptRet      *ebpf.Program `ebpf:"inet_csk_accept_ret"`
+	NfConntrackConfirm    *ebpf.Program `ebpf:"nf_conntrack_confirm"`
+	NfConntrackConfirmRet *ebpf.Program `ebpf:"nf_conntrack_confirm_ret"`
+	NfHookSlow            *ebpf.Program `ebpf:"nf_hook_slow"`
+	NfHookSlowRet         *ebpf.Program `ebpf:"nf_hook_slow_ret"`
+	NfNatInetFn           *ebpf.Program `ebpf:"nf_nat_inet_fn"`
+	NfNatInetFnRet        *ebpf.Program `ebpf:"nf_nat_inet_fn_ret"`
+	TcpV4ConnectRet       *ebpf.Program `ebpf:"tcp_v4_connect_ret"` // nolint:revive // needs to match generated code
+}
+
 type (
 	returnValue uint32
 )

--- a/pkg/plugin/dropreason/types_linux.go
+++ b/pkg/plugin/dropreason/types_linux.go
@@ -42,12 +42,12 @@ type dropReason struct {
 	externalChannel chan *hubblev1.Event
 }
 
-type fexitObjects struct {
-	fexitPrograms
+type allFexitObjects struct {
+	allFexitPrograms
 	kprobeMaps
 }
 
-type fexitPrograms struct {
+type allFexitPrograms struct {
 	InetCskAcceptFexit      *ebpf.Program `ebpf:"inet_csk_accept_fexit"`
 	NfConntrackConfirmFexit *ebpf.Program `ebpf:"nf_conntrack_confirm_fexit"`
 	NfHookSlowFexit         *ebpf.Program `ebpf:"nf_hook_slow_fexit"`
@@ -61,22 +61,17 @@ type marinerObjects struct {
 }
 
 type marinerPrograms struct {
-	InetCskAccept      *ebpf.Program `ebpf:"inet_csk_accept"`
-	InetCskAcceptRet   *ebpf.Program `ebpf:"inet_csk_accept_ret"`
 	InetCskAcceptFexit *ebpf.Program `ebpf:"inet_csk_accept_fexit"`
-	NfHookSlow         *ebpf.Program `ebpf:"nf_hook_slow"`
-	NfHookSlowRet      *ebpf.Program `ebpf:"nf_hook_slow_ret"`
 	NfHookSlowFexit    *ebpf.Program `ebpf:"nf_hook_slow_fexit"`
-	TcpV4ConnectRet    *ebpf.Program `ebpf:"tcp_v4_connect_ret"`   // nolint:revive // needs to match generated code
 	TcpV4ConnectFexit  *ebpf.Program `ebpf:"tcp_v4_connect_fexit"` // nolint:revive // needs to match generated code
 }
 
-type kprobeObjectsOld struct {
-	kprobeProgramsOld
+type allKprobeObjects struct {
+	allKprobePrograms
 	kprobeMaps
 }
 
-type kprobeProgramsOld struct {
+type allKprobePrograms struct {
 	InetCskAccept         *ebpf.Program `ebpf:"inet_csk_accept"`
 	InetCskAcceptRet      *ebpf.Program `ebpf:"inet_csk_accept_ret"`
 	NfConntrackConfirm    *ebpf.Program `ebpf:"nf_conntrack_confirm"`

--- a/pkg/plugin/dropreason/types_linux.go
+++ b/pkg/plugin/dropreason/types_linux.go
@@ -42,12 +42,25 @@ type dropReason struct {
 	externalChannel chan *hubblev1.Event
 }
 
-type kprobeObjectsMariner struct {
-	kprobeProgramsMariner
+type fexitObjects struct {
+	fexitPrograms
 	kprobeMaps
 }
 
-type kprobeProgramsMariner struct {
+type fexitPrograms struct {
+	InetCskAcceptFexit      *ebpf.Program `ebpf:"inet_csk_accept_fexit"`
+	NfConntrackConfirmFexit *ebpf.Program `ebpf:"nf_conntrack_confirm_fexit"`
+	NfHookSlowFexit         *ebpf.Program `ebpf:"nf_hook_slow_fexit"`
+	NfNatInetFnFexit        *ebpf.Program `ebpf:"nf_nat_inet_fn_fexit"`
+	TcpV4ConnectFexit       *ebpf.Program `ebpf:"tcp_v4_connect_fexit"` // nolint:revive // needs to match generated code
+}
+
+type marinerObjects struct {
+	marinerPrograms
+	kprobeMaps
+}
+
+type marinerPrograms struct {
 	InetCskAccept      *ebpf.Program `ebpf:"inet_csk_accept"`
 	InetCskAcceptRet   *ebpf.Program `ebpf:"inet_csk_accept_ret"`
 	InetCskAcceptFexit *ebpf.Program `ebpf:"inet_csk_accept_fexit"`


### PR DESCRIPTION
In #1458 I added a kernel version check to only attach `fexit` programs when they're supported.
We also need to ensure we don't even load them into the kernel.