### PR TITLE
fix: revert: test: add FIPS-enabled Mariner node pool to E2E

### DIFF
--- a/test/e2e/framework/azure/create-cluster-with-npm.go
+++ b/test/e2e/framework/azure/create-cluster-with-npm.go
@@ -82,22 +82,6 @@ func (c *CreateNPMCluster) Run() error {
 	})
 
 	//nolint:appendCombine // separate for verbosity
-	npmCluster.Properties.AgentPoolProfiles = append(npmCluster.Properties.AgentPoolProfiles, &armcontainerservice.ManagedClusterAgentPoolProfile{
-		Type:               to.Ptr(armcontainerservice.AgentPoolTypeVirtualMachineScaleSets),
-		AvailabilityZones:  []*string{to.Ptr("1")},
-		Count:              to.Ptr[int32](AuxilaryNodeCount),
-		EnableNodePublicIP: to.Ptr(false),
-		EnableFIPS:         to.Ptr(true),
-		Mode:               to.Ptr(armcontainerservice.AgentPoolModeUser),
-		OSType:             to.Ptr(armcontainerservice.OSTypeLinux),
-		OSSKU:              to.Ptr(armcontainerservice.OSSKUCBLMariner),
-		ScaleDownMode:      to.Ptr(armcontainerservice.ScaleDownModeDelete),
-		VMSize:             to.Ptr(AgentSKU),
-		Name:               to.Ptr("fipsmariner"),
-		MaxPods:            to.Ptr(int32(MaxPodsPerNode)),
-	})
-
-	//nolint:appendCombine // separate for verbosity
 	npmCluster.Properties.AgentPoolProfiles = append(npmCluster.Properties.AgentPoolProfiles, &armcontainerservice.ManagedClusterAgentPoolProfile{ //nolint:all
 		Type: to.Ptr(armcontainerservice.AgentPoolTypeVirtualMachineScaleSets),
 		// AvailabilityZones:  []*string{to.Ptr("1")},


### PR DESCRIPTION
Reverting #1602 that added a stale OSSKU tag which is failing in merge queue now.
This was merged due to a GH a race condition in a skipped job.

Will follow-up with another PR just enabling FIPS on the existing AzureLinux node pool.