### PR TITLE
test: Enable FIPS using existing AzureLinux node pool.

### DIFF
--- a/test/e2e/framework/azure/create-cluster-with-npm.go
+++ b/test/e2e/framework/azure/create-cluster-with-npm.go
@@ -72,6 +72,7 @@ func (c *CreateNPMCluster) Run() error {
 		AvailabilityZones:  []*string{to.Ptr("1")},
 		Count:              to.Ptr[int32](AuxilaryNodeCount),
 		EnableNodePublicIP: to.Ptr(false),
+		EnableFIPS:         to.Ptr(true),
 		Mode:               to.Ptr(armcontainerservice.AgentPoolModeUser),
 		OSType:             to.Ptr(armcontainerservice.OSTypeLinux),
 		OSSKU:              to.Ptr(armcontainerservice.OSSKUAzureLinux),


### PR DESCRIPTION
#1602 used a stale SKU tag, and somehow slipped through the CI.
Submitting this again with the up-to-date AzureLinux tag.