### PR TITLE
fix(image): Adding ARM64 Operator image release

### DIFF
--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -112,7 +112,7 @@ jobs:
     strategy:
       matrix:
         platform: ["linux"]
-        arch: ["amd64"]
+        arch: ["amd64", "arm64"]
 
     steps:
       - name: Checkout code

--- a/Makefile
+++ b/Makefile
@@ -349,7 +349,7 @@ manifest-retina-image: ## create a multiplatform manifest for the retina image
 
 manifest-operator-image: ## create a multiplatform manifest for the operator image
 	$(eval FULL_IMAGE_NAME=$(IMAGE_REGISTRY)/$(RETINA_OPERATOR_IMAGE):$(TAG))
-	docker buildx imagetools create -t $(FULL_IMAGE_NAME) $(foreach platform,linux/amd64, $(FULL_IMAGE_NAME)-$(subst /,-,$(platform)))
+	docker buildx imagetools create -t $(FULL_IMAGE_NAME) $(foreach platform,linux/amd64 linux/arm64, $(FULL_IMAGE_NAME)-$(subst /,-,$(platform)))
 
 manifest-shell-image:
 	$(eval FULL_IMAGE_NAME=$(IMAGE_REGISTRY)/$(RETINA_SHELL_IMAGE):$(TAG))


### PR DESCRIPTION
# Description

This PR is a follow up from: https://github.com/microsoft/retina/pull/1538/files#diff-fb3f33cdd2a5865385222d244e9bdc9a7ebee2756d506f6495f83a5cff42b25a

The ARM64 Operator image was added to the test workflow, and the ADO (Microsoft internal release) pipeline, but not to GHCR release flow. This PR fixes that.

## Related Issue

https://github.com/microsoft/retina/issues/1582

## Checklist

- [X] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [X] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [X] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

This flow was tested here: https://github.com/microsoft/retina/actions/runs/15065640778/job/42350022052

![image](https://github.com/user-attachments/assets/6d74dbb0-4455-45e1-96cf-a890d9e88b78)

![image](https://github.com/user-attachments/assets/4c51ab47-2ba9-477a-910c-b2a1b0b9f849)

![image](https://github.com/user-attachments/assets/9b2da4bc-3208-4fb2-8063-430039cfff27)

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
