### PR TITLE
fix: e2e job skipped due to yaml syntax error

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -264,8 +264,8 @@ jobs:
           IS_MERGE_GROUP: ${{ github.event_name == 'merge_group' }}
 
   manifests:
-    if: ${{ github.event_name == 'merge_group' && success('retina-images') && success('retina-win-images') && success('operator-images') && success('retina-shell-images')}}
     name: Generate Manifests
+    if: ${{ github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     needs:
       [
@@ -303,10 +303,10 @@ jobs:
           IMAGE_REGISTRY=${{ vars.ACR_NAME }}  \
 
   e2e:
-    if: ${{ github.event_name == 'merge_group' && success('manifests')}}
     name: Run E2E Tests
-    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'merge_group' }}
     needs: [manifests]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
@@ -336,7 +336,7 @@ jobs:
           go test -v ./test/e2e/. -timeout 60m -tags=e2e -count=1  -args -image-tag=$(make version) -image-registry=${{ vars.ACR_NAME }}  -image-namespace=${{ github.repository}}
 
   perf-test-basic:
-    if: ${{ github.event_name == 'merge_group' && success('manifests')}}
+    if: ${{ github.event_name == 'merge_group'}}
     needs: [manifests]
     uses: ./.github/workflows/perf-template.yaml
     with:
@@ -352,7 +352,7 @@ jobs:
       azure-app-insights-key: ${{ secrets.AZURE_APP_INSIGHTS_KEY }}
   
   perf-test-advanced:
-    if: ${{ github.event_name == 'merge_group' && success('manifests')}}
+    if: ${{ github.event_name == 'merge_group'}}
     needs: [manifests]
     uses: ./.github/workflows/perf-template.yaml
     with:


### PR DESCRIPTION
Our E2e job is getting skipped in the merge queue, because of YAML parsing errors.
We have invalid syntax in the if-statements checking for success of prerequisite jobs that need to run for `manifests` and `E2E` to run. 
Looks like this used to be ignored and those jobs just ran, while recently Github started enforcing stricter YAML syntax validation which is causing these jobs to get skipped! 
It started about a week ago, example errors at the bottom of the page:
https://github.com/microsoft/retina/actions/runs/14842770818
![image](https://github.com/user-attachments/assets/1906d486-e581-4ed3-8c93-baa8b3f15e0d)
