### PR TITLE
fix: Allow RBAC for endpoints to the standard chart

### DIFF
--- a/deploy/standard/manifests/controller/helm/retina/templates/rbac.yaml
+++ b/deploy/standard/manifests/controller/helm/retina/templates/rbac.yaml
@@ -9,7 +9,7 @@ metadata:
   name: retina-cluster-reader
 rules:
   - apiGroups: [""] # "" indicates the core API group
-    resources: ["pods", "services", "replicationcontrollers", "nodes", "namespaces"]
+    resources: ["endpoints", "pods", "services", "replicationcontrollers", "nodes", "namespaces"]
     verbs: ["get", "watch", "list"]
   - apiGroups: ["apps"]
     resources: ["deployments", "replicasets"]
@@ -30,6 +30,7 @@ rules:
     - ""
     resources:
       - namespaces
+      - endpoints
     verbs:
       - get
       - list


### PR DESCRIPTION
# Description

Adds RBAC to allow querying `endpoints` in the standard chart.

Fixes errors introduced by https://github.com/microsoft/retina/pull/1573 for failures to query for `endpoints` when the legacy control plane is deployed.

## Checklist

- [X] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [X] I have correctly attributed the author(s) of the code.
- [X] I have tested the changes locally.
- [X] I have followed the project's style guidelines.
- [X] I have updated the documentation, if necessary.
- [X] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Deployed with new version of the chart, no longer receive errors like

```
retina ts=2025-05-20T20:23:52.758Z level=error caller=apiserver/apiserver.go:120 msg="failed to initialize new cache" error="failed to retrieve ips from kubernetes endpoint: retrieving kubernetes endpoint: endpoints \"kubernetes\" is forbidden
retina ts=2025-05-20T20:23:52.758Z level=error caller=watchermanager/watchermanager.go:76 msg="refresh failed" error="failed to retrieve ips from kubernetes endpoint: retrieving kubernetes endpoint: endpoints \"kubernetes\" is forbidden
```

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
