### PR TITLE
fix: Remove unnecessary allocations from debug log

### DIFF
--- a/pkg/common/endpoint.go
+++ b/pkg/common/endpoint.go
@@ -19,6 +19,10 @@ func NewRetinaEndpoint(name, namespace string, ips *IPAddresses) *RetinaEndpoint
 	}
 }
 
+func (ep *RetinaEndpoint) String() string {
+	return ep.NamespacedName()
+}
+
 func (ep *RetinaEndpoint) DeepCopy() interface{} {
 	ep.RLock()
 	defer ep.RUnlock()

--- a/pkg/controllers/cache/cache.go
+++ b/pkg/controllers/cache/cache.go
@@ -153,7 +153,7 @@ func (c *Cache) getObjByIPType(ip string, t objectType) interface{} {
 // GetObjByIP returns the retina object for the given IP.
 func (c *Cache) GetObjByIP(ip string) interface{} {
 	if ep := c.GetPodByIP(ip); ep != nil {
-		c.l.Debug("pod found for IP", zap.String("ip", ip), zap.String("pod Name", ep.Key()))
+		c.l.Debug("pod found for IP", zap.String("ip", ip), zap.Stringer("pod", ep))
 		return ep
 	}
 


### PR DESCRIPTION
# Description

In this hot code path computing the key for the debug log does a bunch of unnecessary string  allocations.

Refactor to use `zap` lazy serialization so we only incur this cost when debug logging is turned on.

## Checklist

- [X] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [X] I have correctly attributed the author(s) of the code.
- [X] I have tested the changes locally.
- [X] I have followed the project's style guidelines.
- [X] I have updated the documentation, if necessary.
- [X] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Deployed with debug logging turned on, logs as expected.

```
retina-agent-q9525 retina ts=2025-05-22T22:50:39.044Z level=debug caller=cache/cache.go:100 msg="pod found for IP" ip=172.26.11.226 pod=platform/thanos-rule-remote-1
retina-agent-q9525 retina ts=2025-05-22T22:50:39.044Z level=debug caller=cache/cache.go:140 msg="pod found for IP" ip=172.26.11.226 pod=platform/thanos-rule-remote-1
retina-agent-q9525 retina ts=2025-05-22T22:50:39.044Z level=debug caller=cache/cache.go:94 msg="pod not found for IP" ip=172.27.12.108
retina-agent-q9525 retina ts=2025-05-22T22:50:39.044Z level=debug caller=cache/cache.go:116 msg="service found for IP" ip=172.27.12.108 svc=platform/thanos-query
```