### PR TITLE
chore(ciliumeventobserver): Remove warn for messageType not supported

### DIFF
--- a/pkg/plugin/ciliumeventobserver/parser_linux.go
+++ b/pkg/plugin/ciliumeventobserver/parser_linux.go
@@ -17,8 +17,7 @@ import (
 )
 
 var (
-	ErrNotImplemented = errors.New("Error, not implemented")
-	ErrEmptyData      = errors.New("empty data")
+	ErrEmptyData = errors.New("empty data")
 )
 
 func (p *parser) Init() error {
@@ -75,7 +74,7 @@ func (p *parser) Decode(pl *payload.Payload) (*v1.Event, error) {
 			// Log Records can be DNS traces for CNP related pods
 			// AccessLogs can also reflect kafka related metrics
 			monEvent.Payload = &observerTypes.AgentEvent{}
-			return nil, ErrNotImplemented //nolint:goerr113 //no specific handling expected
+			return nil, nil //nolint:goerr113 //no specific handling expected
 		// MessageTypeTraceSock and MessageTypeDebug are also perf events but have their own dedicated decoders in cilium.
 		case monitorAPI.MessageTypeDrop, monitorAPI.MessageTypeTrace, monitorAPI.MessageTypePolicyVerdict, monitorAPI.MessageTypeCapture:
 			perfEvent := &observerTypes.PerfEvent{}


### PR DESCRIPTION
# Description

This warning is being logged to many times.

![image](https://github.com/user-attachments/assets/2e52935d-e3af-44d8-b88c-243f9749b425)

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
