### PR TITLE
feat(helm): Allow passing arbitrary env variables to the DaemonSet

### DIFF
--- a/deploy/standard/manifests/controller/helm/retina/templates/daemonset.yaml
+++ b/deploy/standard/manifests/controller/helm/retina/templates/daemonset.yaml
@@ -87,6 +87,9 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
+          {{- if .Values.daemonset.container.retina.env -}}
+          {{ toYaml .Values.daemonset.container.retina.env | nindent 10 }}
+          {{- end }}
           - name: POD_NAME
             valueFrom:
               fieldRef:
@@ -218,6 +221,9 @@ spec:
             - .\setkubeconfigpath.ps1; ./controller.exe --config ./retina/config.yaml --kubeconfig ./kubeconfig
             {{- end }}
           env:
+          {{- if .Values.daemonset.container.retina.env -}}
+          {{ toYaml .Values.daemonset.container.retina.env | nindent 10 }}
+          {{- end }}
           - name: POD_NAME
             valueFrom:
               fieldRef:

--- a/deploy/standard/manifests/controller/helm/retina/values.yaml
+++ b/deploy/standard/manifests/controller/helm/retina/values.yaml
@@ -98,6 +98,7 @@ daemonset:
       args:
         - "--config"
         - "/retina/config/config.yaml"
+      env: []
       healthProbeBindAddress: ":18081"
       metricsBindAddress: ":18080"
       ports:


### PR DESCRIPTION
# Description

Allows passing arbitrary environment variables to the DaemonSet in the standard Helm chart.

## Checklist

- [X] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [X] I have correctly attributed the author(s) of the code.
- [X] I have tested the changes locally.
- [X] I have followed the project's style guidelines.
- [X] I have updated the documentation, if necessary.
- [X] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

No diff between `helm template` with current chart with default values and that from this PR.

Diff with provided `env` values shows values added as expected.

```
          env:
          - name: test1
            value: test1
          - name: test2
            value: test2
          - name: POD_NAME
            valueFrom:
              fieldRef:
                apiVersion: v1
                fieldPath: metadata.name
          - name: NODE_NAME
            valueFrom:
                fieldRef:
                  apiVersion: v1
                  fieldPath: spec.nodeName
```

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
