### PR TITLE
feat: update ethtool dependency and modify Stats method to use buffer

### DIFF
--- a/pkg/plugin/linuxutil/ethtool_handle_linux.go
+++ b/pkg/plugin/linuxutil/ethtool_handle_linux.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/safchain/ethtool"
 
 	lru "github.com/hashicorp/golang-lru/v2"
 
@@ -26,13 +27,13 @@ func NewCachedEthtool(ethHandle EthtoolInterface, unsupportedInterfacesCache *lr
 
 var errskip = errors.New("skip interface")
 
-func (ce *CachedEthtool) Stats(intf string) (map[string]uint64, error) {
+func (ce *CachedEthtool) StatsWithBuffer(intf string, gstring *ethtool.EthtoolGStrings, stats *ethtool.EthtoolStats) (map[string]uint64, error) {
 	// Skip unsupported interfaces
 	if _, ok := ce.unsupported.Get(intf); ok {
 		return nil, errskip
 	}
 
-	ifaceStats, err := ce.EthtoolInterface.Stats(intf)
+	ifaceStats, err := ce.EthtoolInterface.StatsWithBuffer(intf, gstring, stats)
 	if err != nil {
 		if strings.Contains(err.Error(), "operation not supported") {
 			ce.unsupported.Add(intf, struct{}{})

--- a/pkg/plugin/linuxutil/linuxutil_linux.go
+++ b/pkg/plugin/linuxutil/linuxutil_linux.go
@@ -69,6 +69,9 @@ func (lu *linuxUtil) run(ctx context.Context) error {
 		return err
 	}
 
+	gstrings := new(ethtool.EthtoolGStrings)
+	stats := new(ethtool.EthtoolStats)
+
 	ticker := time.NewTicker(lu.cfg.MetricsInterval)
 	defer ticker.Stop()
 
@@ -109,7 +112,7 @@ func (lu *linuxUtil) run(ctx context.Context) error {
 				return fmt.Errorf("failed to create ethHandle: %w", err)
 			}
 
-			ethReader := NewEthtoolReader(ethtoolOpts, ethHandle, unsupportedInterfacesCache)
+			ethReader := NewEthtoolReader(ethtoolOpts, ethHandle, unsupportedInterfacesCache, gstrings, stats)
 			if ethReader == nil {
 				lu.l.Error("Error while creating ethReader")
 				return errors.New("error while creating ethReader")

--- a/pkg/plugin/linuxutil/linuxutil_mock_generated_linux.go
+++ b/pkg/plugin/linuxutil/linuxutil_mock_generated_linux.go
@@ -13,6 +13,7 @@ import (
 	reflect "reflect"
 
 	netstat "github.com/cakturk/go-netstat/netstat"
+	ethtool "github.com/safchain/ethtool"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -51,19 +52,19 @@ func (mr *MockEthtoolInterfaceMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockEthtoolInterface)(nil).Close))
 }
 
-// Stats mocks base method.
-func (m *MockEthtoolInterface) Stats(intf string) (map[string]uint64, error) {
+// StatsWithBuffer mocks base method.
+func (m *MockEthtoolInterface) StatsWithBuffer(intf string, gstrings *ethtool.EthtoolGStrings, stats *ethtool.EthtoolStats) (map[string]uint64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Stats", intf)
+	ret := m.ctrl.Call(m, "StatsWithBuffer", intf, gstrings, stats)
 	ret0, _ := ret[0].(map[string]uint64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Stats indicates an expected call of Stats.
-func (mr *MockEthtoolInterfaceMockRecorder) Stats(intf any) *gomock.Call {
+// StatsWithBuffer indicates an expected call of StatsWithBuffer.
+func (mr *MockEthtoolInterfaceMockRecorder) StatsWithBuffer(intf, gstrings, stats any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stats", reflect.TypeOf((*MockEthtoolInterface)(nil).Stats), intf)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StatsWithBuffer", reflect.TypeOf((*MockEthtoolInterface)(nil).StatsWithBuffer), intf, gstrings, stats)
 }
 
 // MockNetstatInterface is a mock of NetstatInterface interface.

--- a/pkg/plugin/linuxutil/types_linux.go
+++ b/pkg/plugin/linuxutil/types_linux.go
@@ -6,6 +6,7 @@ import (
 	"github.com/cakturk/go-netstat/netstat"
 	kcfg "github.com/microsoft/retina/pkg/config"
 	"github.com/microsoft/retina/pkg/log"
+	"github.com/safchain/ethtool"
 )
 
 const name = "linuxutil"
@@ -106,7 +107,8 @@ type EthtoolOpts struct {
 }
 
 type EthtoolInterface interface {
-	Stats(intf string) (map[string]uint64, error)
+	// the buffer is used internally by the ethtool package to avoid memory allocation churn
+	StatsWithBuffer(intf string, gstrings *ethtool.EthtoolGStrings, stats *ethtool.EthtoolStats) (map[string]uint64, error)
 	Close()
 }
 


### PR DESCRIPTION
# Description

This pull request updates the `ethtool` dependency to version `v0.6.1` and introduces significant changes to the `EthtoolInterface` implementation and related code. The most notable updates include replacing the `Stats` method with `StatsWithBuffer`, modifying constructors and functions to handle additional buffer parameters, and updating tests accordingly.

### Dependency Update:
* Updated `ethtool` dependency from version `v0.6.0` to `v0.6.1` in `go.mod`.

### Changes to `EthtoolInterface`:
* Replaced the `Stats` method with `StatsWithBuffer`, which accepts additional buffer parameters (`gstring` and `stats`) for improved handling of interface statistics. [[1]](diffhunk://#diff-07973045315381e9cfea6512cdcb566c022108b90e3df891715422ca3598735cL29-R36) [[2]](diffhunk://#diff-ab186a8a488c84ccab2df9bfed9f5c0412cf4c45ff62c184a7b661e0873add61L109-R110)

### Updates to Constructors and Functions:
* Modified the `NewEthtoolReader` constructor in `ethtool_stats_linux.go` to include `gstring` and `stats` parameters, and updated the `EthtoolReader` struct to store these buffers. [[1]](diffhunk://#diff-5af3df7bd20ddc8cff54f839bbe143b959d17b3dbabf03ebb641b757bda3e53dR23-R33) [[2]](diffhunk://#diff-5af3df7bd20ddc8cff54f839bbe143b959d17b3dbabf03ebb641b757bda3e53dR49-R50)
* Updated the `readInterfaceStats` method in `ethtool_stats_linux.go` to use the new `StatsWithBuffer` method.
* Adjusted the `linuxUtil` plugin's `run` method in `linuxutil_linux.go` to create and pass `gstring` and `stats` buffers when initializing `EthtoolReader`. [[1]](diffhunk://#diff-b6f651749c3bf6ea907b4c65d0586b88fcd556b2debfccde42bc5e7f0300546cR72-R76) [[2]](diffhunk://#diff-b6f651749c3bf6ea907b4c65d0586b88fcd556b2debfccde42bc5e7f0300546cL112-R117)

### Test Updates:
* Updated test cases in `ethtool_stats_linux_test.go` to accommodate the new `StatsWithBuffer` method and added mock objects for `gstring` and `stats` buffers. [[1]](diffhunk://#diff-9c5fe736fcf6bf9c090bf151701d8c765d0308c50a3091f23f9b7442bd712046R42-R46) [[2]](diffhunk://#diff-9c5fe736fcf6bf9c090bf151701d8c765d0308c50a3091f23f9b7442bd712046L59-R63) [[3]](diffhunk://#diff-9c5fe736fcf6bf9c090bf151701d8c765d0308c50a3091f23f9b7442bd712046R134-R138) [[4]](diffhunk://#diff-9c5fe736fcf6bf9c090bf151701d8c765d0308c50a3091f23f9b7442bd712046L138-R151)

### Mock Interface Changes:
* Updated the mock implementation in `linuxutil_mock_generated_linux.go` to reflect the changes in `EthtoolInterface`, replacing `Stats` with `StatsWithBuffer`.

These changes enhance the functionality and flexibility of the `EthtoolInterface` implementation, allowing for more efficient handling of interface statistics.

## Related Issue

This will reduce the overall memory churn, leading to lower chances of memory spill.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed
Memory profile with this fix compared to with previous fix.
![image](https://github.com/user-attachments/assets/5265b2d5-985f-415a-9652-fbed3a77f485)

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
