### PR TITLE
chore(agent): Allow agent to watch endpoints on Hubble CP

### DIFF
--- a/deploy/hubble/manifests/controller/helm/retina/templates/agent/clusterrole.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/agent/clusterrole.yaml
@@ -22,7 +22,16 @@ rules:
       - get
       - list
       - watch
-  {{- if .Values.operator.enabled }}
+  - apiGroups:
+    - cilium.io
+    resources:
+    - ciliumnodes
+    - ciliumidentities
+    - ciliumendpoints
+    verbs:
+    - get
+    - list
+    - watch
   - apiGroups:
     - ""
     resources:
@@ -32,6 +41,7 @@ rules:
       - get
       - list
       - watch
+  {{- if .Values.operator.enabled }}
   - apiGroups:
       - retina.io
     resources:
@@ -74,16 +84,6 @@ rules:
     - discovery.k8s.io
     resources:
     - endpointslices
-    verbs:
-    - get
-    - list
-    - watch
-  - apiGroups:
-    - cilium.io
-    resources:
-    - ciliumnodes
-    - ciliumidentities
-    - ciliumendpoints
     verbs:
     - get
     - list


### PR DESCRIPTION
# Description

Please provide a brief description of the changes made in this pull request.

## Related Issue

Prevent this issue when running on Cilium CNI and no operator enabled

```
ts=2025-05-30T08:34:19.360Z level=warn caller=logrus-zap-hook@v0.1.0/zap.go:51 msg="pkg/mod/k8s.io/client-go@v0.32.4/tools/cache/reflector.go:251: failed to list *v2.CiliumEndpoint: ciliumendpoints.cilium.io is forbidden: User \"system:serviceaccount:kube-system:retina-agent\" cannot list resource \"ciliumendpoints\" in API group \"cilium.io\" at the cluster scope" subsys=klog
ts=2025-05-30T08:34:19.360Z level=error caller=k8s/watcher_linux.go:51 msg="Error watching k8s resource" subsys=k8s-watcher resource=v2.CiliumEndpoint underlyingError="pkg/mod/k8s.io/client-go@v0.32.4/tools/cache/reflector.go:251: Failed to watch *v2.CiliumEndpoint: failed to list *v2.CiliumEndpoint: ciliumendpoints.cilium.io is forbidden: User \"system:serviceaccount:kube-system:retina-agent\" cannot list resource \"ciliumendpoints\" in API group \"cilium.io\" at the cluster scope"
ts=2025-05-30T08:34:24.685Z level=warn caller=logrus-zap-hook@v0.1.0/zap.go:51 msg="pkg/mod/k8s.io/client-go@v0.32.4/tools/cache/reflector.go:251: failed to list *v2.CiliumEndpoint: ciliumendpoints.cilium.io is forbidden: User \"system:serviceaccount:kube-system:retina-agent\" cannot list resource \"ciliumendpoints\" in API group \"cilium.io\" at the cluster scope" subsys=klog
ts=2025-05-30T08:34:24.685Z level=error caller=k8s/watcher_linux.go:51 msg="Error watching k8s resource" resource=v2.CiliumEndpoint subsys=k8s-watcher underlyingError="pkg/mod/k8s.io/client-go@v0.32.4/tools/cache/reflector.go:251: Failed to watch *v2.CiliumEndpoint: failed to list *v2.CiliumEndpoint: ciliumendpoints.cilium.io is forbidden: User \"system:serviceaccount:kube-system:retina-agent\" cannot list resource \"ciliumendpoints\" in API group \"cilium.io\" at the cluster scope"
ts=2025-05-30T08:34:27.605Z level=info caller=ciliumeventobserver/ciliumeventobserver_linux.go:146 msg="Connected to cilium monitor"
ts=2025-05-30T08:34:36.368Z level=warn caller=logrus-zap-hook@v0.1.0/zap.go:51 msg="pkg/mod/k8s.io/client-go@v0.32.4/tools/cache/reflector.go:251: failed to list *v2.CiliumEndpoint: ciliumendpoints.cilium.io is forbidden: User \"system:serviceaccount:kube-system:retina-agent\" cannot list resource \"ciliumendpoints\" in API group \"cilium.io\" at the cluster scope" subsys=klog
ts=2025-05-30T08:34:36.368Z level=error caller=k8s/watcher_linux.go:51 msg="Error watching k8s resource" underlyingError="pkg/mod/k8s.io/client-go@v0.32.4/tools/cache/reflector.go:251: Failed to watch *v2.CiliumEndpoint: failed to list *v2.CiliumEndpoint: ciliumendpoints.cilium.io is forbidden: User \"system:serviceaccount:kube-system:retina-agent\" cannot list resource \"ciliumendpoints\" in API group \"cilium.io\" at the cluster scope" resource=v2.CiliumEndpoint subsys=k8s-watcher
ts=2025-05-30T08:34:45.633Z level=error caller=apiserver/apiserver.go:120 msg="failed to initialize new cache" error="failed to retrieve ips from kubernetes endpoint: retrieving kubernetes endpoint: endpoints \"kubernetes\" is forbidden: User \"system:serviceaccount:kube-system:retina-agent\" cannot get resource \"endpoints\" in API group \"\" in the namespace \"default\""
ts=2025-05-30T08:34:45.634Z level=error caller=watchermanager/watchermanager.go:76 msg="refresh failed" error="failed to retrieve ips from kubernetes endpoint: retrieving kubernetes endpoint: endpoints \"kubernetes\" is forbidden: User \"system:serviceaccount:kube-system:retina-agent\" cannot get resource \"endpoints\" in API group \"\" in the namespace \"default\""
ts=2025-05-30T08:34:51.451Z level=warn caller=logrus-zap-hook@v0.1.0/zap.go:51 msg="pkg/mod/k8s.io/client-go@v0.32.4/tools/cache/reflector.go:251: failed to list *v2.CiliumEndpoint: ciliumendpoints.cilium.io is forbidden: User \"system:serviceaccount:kube-system:retina-agent\" cannot list resource \"ciliumendpoints\" in API group \"cilium.io\" at the cluster scope" subsys=klog
ts=2025-05-30T08:34:51.452Z level=error caller=k8s/watcher_linux.go:51 msg="Error watching k8s resource" underlyingError="pkg/mod/k8s.io/client-go@v0.32.4/tools/cache/reflector.go:251: Failed to watch *v2.CiliumEndpoint: failed to list *v2.CiliumEndpoint: ciliumendpoints.cilium.io is forbidden: User \"system:serviceaccount:kube-system:retina-agent\" cannot list resource \"ciliumendpoints\" in API group \"cilium.io\" at the cluster scope" subsys=k8s-watcher resource=v2.CiliumEndpoint
ts=2025-05-30T08:35:17.368Z level=warn caller=logrus-zap-hook@v0.1.0/zap.go:51 msg="pkg/mod/k8s.io/client-go@v0.32.4/tools/cache/reflector.go:251: failed to list *v2.CiliumEndpoint: ciliumendpoints.cilium.io is forbidden: User \"system:serviceaccount:kube-system:retina-agent\" cannot list resource \"ciliumendpoints\" in API group \"cilium.io\" at the cluster scope" subsys=klog
ts=2025-05-30T08:35:17.368Z level=error caller=k8s/watcher_linux.go:51 msg="Error watching k8s resource" resource=v2.CiliumEndpoint subsys=k8s-watcher underlyingError="pkg/mod/k8s.io/client-go@v0.32.4/tools/cache/reflector.go:251: Failed to watch *v2.CiliumEndpoint: failed to list *v2.CiliumEndpoint: ciliumendpoints.cilium.io is forbidden: User \"system:serviceaccount:kube-system:retina-agent\" cannot list resource \"ciliumendpoints\" in API group \"cilium.io\" at the cluster scope"
ts=2025-05-30T08:35:48.126Z level=warn caller=logrus-zap-hook@v0.1.0/zap.go:51 msg="pkg/mod/k8s.io/client-go@v0.32.4/tools/cache/reflector.go:251: failed to list *v2.CiliumEndpoint: ciliumendpoints.cilium.io is forbidden: User \"system:serviceaccount:kube-system:retina-agent\" cannot list resource \"ciliumendpoints\" in API group \"cilium.io\" at the cluster scope" subsys=klog
ts=2025-05-30T08:35:48.126Z level=error caller=k8s/watcher_linux.go:51 msg="Error watching k8s resource" subsys=k8s-watcher underlyingError="pkg/mod/k8s.io/client-go@v0.32.4/tools/cache/reflector.go:251: Failed to watch *v2.CiliumEndpoint: failed to list *v2.CiliumEndpoint: ciliumendpoints.cilium.io is forbidden: User \"system:serviceaccount:kube-system:retina-agent\" cannot list resource \"ciliumendpoints\" in API group \"cilium.io\" at the cluster scope" resource=v2.CiliumEndpoint
ts=2025-05-30T08:36:15.604Z level=info caller=endpointmanager/manager.go:588 msg="regenerating all endpoints" subsys=endpoint-manager reason="periodic endpoint regeneration"
```

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
