### PR TITLE
docs: Remove duplicate docs

### DIFF
--- a/docs/08-Contributing/02-development.md
+++ b/docs/08-Contributing/02-development.md
@@ -215,11 +215,3 @@ The diagrams used are created with [Excalidraw](https://excalidraw.com/). The so
 
 You can find the open issues on the repo's [GitHub issues board](https://github.com/microsoft/retina/issues)
 If you are a first-time contributor, you can find the issues that are suitable for newcomers by finding the [issues labeled as "good first issue"](https://github.com/microsoft/retina/labels/good%20first%20issue)
-
-### Code of Conduct
-
-This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
-
-### License
-
-See [LICENSE](../../LICENSE).


### PR DESCRIPTION
# Description

Removing duplicate docs from the Development page, which are already present on the Overview.

## Related Issue

NA

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [] I have added tests, if applicable.

## Screenshots

![image](https://github.com/user-attachments/assets/af433140-6418-4f58-b4f1-585e0e1bb15f)
---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
