### PR TITLE
chore(shell): Add pwru binary to retina-shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -412,7 +412,7 @@ manifests:
 	cd crd && make manifests && make generate
 
 # Fetch the latest tag from the GitHub
-LATEST_TAG := $(shell curl -s https://api.github.com/repos/microsoft/retina/releases | jq -r '.[0].name')
+LATEST_TAG := $(shell curl -s https://api.github.com/repos/microsoft/retina/releases/latest | jq -r '.name')
 
 HELM_IMAGE_TAG ?= $(LATEST_TAG)
 

--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -23,6 +23,28 @@ RUN tdnf install -y \
 	socat \
 	tcpdump \
 	wget \
+	tar \
+	file \
 	&& tdnf clean all
+
+# Re-use existing arg from Makefile target "container-docker"
+# https://github.com/microsoft/retina/blob/main/Makefile#L224
+ARG GOARCH=amd64
+ENV ARCH=${GOARCH}
+
+# Download and extract latest pwru release for the correct architecture (amd64 or arm64)
+RUN set -eux; \
+    case "$ARCH" in \
+        amd64|x86_64) PWRU_ARCH="amd64" ;; \
+        arm64|aarch64) PWRU_ARCH="arm64" ;; \
+        *) echo "Unsupported arch: $ARCH" && exit 1 ;; \
+    esac; \
+    PWRU_TAG=$(curl -s https://api.github.com/repos/cilium/pwru/releases/latest | jq -r '.tag_name'); \
+    PWRU_TAR="pwru-linux-${PWRU_ARCH}.tar.gz"; \
+    curl -fL -o /tmp/pwru.tar.gz "https://github.com/cilium/pwru/releases/download/${PWRU_TAG}/${PWRU_TAR}"; \
+    tar -xz -C /usr/local/bin -f /tmp/pwru.tar.gz pwru; \
+    chmod +x /usr/local/bin/pwru; \
+    rm /tmp/pwru.tar.gz; \
+    file /usr/local/bin/pwru | grep -q 'ELF'
 
 CMD ["/bin/bash", "-l"]

--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -31,6 +31,9 @@ RUN tdnf install -y \
 # https://github.com/microsoft/retina/blob/main/Makefile#L224
 ARG GOARCH=amd64
 ENV ARCH=${GOARCH}
+# https://github.com/cilium/pwru/releases
+ARG PWRU_TAG="v1.0.9"
+ENV PWRU_TAG=${PWRU_TAG}
 
 # Download and extract latest pwru release for the correct architecture (amd64 or arm64)
 RUN set -eux; \
@@ -39,7 +42,6 @@ RUN set -eux; \
         arm64|aarch64) PWRU_ARCH="arm64" ;; \
         *) echo "Unsupported arch: $ARCH" && exit 1 ;; \
     esac; \
-    PWRU_TAG=$(curl -s https://api.github.com/repos/cilium/pwru/releases/latest | jq -r '.tag_name'); \
     PWRU_TAR="pwru-linux-${PWRU_ARCH}.tar.gz"; \
     curl -fL -o /tmp/pwru.tar.gz "https://github.com/cilium/pwru/releases/download/${PWRU_TAG}/${PWRU_TAR}"; \
     tar -xz -C /usr/local/bin -f /tmp/pwru.tar.gz pwru; \

--- a/shell/README.md
+++ b/shell/README.md
@@ -4,11 +4,35 @@ Retina CLI provides a command to launch an interactive shell in a node or pod fo
 
 * The CLI command `kubectl retina shell` creates a pod with `HostNetwork=true` (for node debugging) or an ephemeral container in an existing pod (for pod debugging).
 * The container runs an image built from the Dockerfile in this directory. The image is based on Azure Linux and includes commonly-used networking tools.
+* The [pwru](https://github.com/cilium/pwru) tool is bundled in the image for advanced kernel packet tracing.
 
 For testing, you can override the image used by `retina shell` either with CLI arguments
 (`--retina-shell-image-repo` and `--retina-shell-image-version`) or environment variables
 (`RETINA_SHELL_IMAGE_REPO` and `RETINA_SHELL_IMAGE_VERSION`).
 
 Run `kubectl retina shell -h` for full documentation and examples.
+
+## Example: Running pwru
+
+To use `pwru` inside the retina shell, you must grant the following Linux capabilities to the container:
+
+* `NET_ADMIN` (required)
+* `SYS_ADMIN` (required)
+* `SYS_RESOURCE` (recommended for increasing memory lock limits)
+* `SYS_PTRACE` (only needed for some advanced tracing features)
+
+Capability requirements are based on common eBPF tool practices and not directly from the pwru documentation.
+
+Example command to launch a shell with the required capabilities:
+
+```sh
+kubectl retina shell --capabilities=NET_ADMIN,SYS_ADMIN,SYS_RESOURCE,SYS_PTRACE
+```
+
+Once inside the shell, you can run:
+
+```sh
+pwru --help
+```
 
 Currently only Linux is supported; Windows support will be added in the future.

--- a/shell/README.md
+++ b/shell/README.md
@@ -16,17 +16,16 @@ Run `kubectl retina shell -h` for full documentation and examples.
 
 To use `pwru` inside the retina shell, you must grant the following Linux capabilities to the container:
 
-* `NET_ADMIN` (required)
-* `SYS_ADMIN` (required)
-* `SYS_RESOURCE` (recommended for increasing memory lock limits)
-* `SYS_PTRACE` (only needed for some advanced tracing features)
+* `NET_ADMIN`
+* `SYS_ADMIN`
 
 Capability requirements are based on common eBPF tool practices and not directly from the pwru documentation.
 
 Example command to launch a shell with the required capabilities:
 
 ```sh
-kubectl retina shell --capabilities=NET_ADMIN,SYS_ADMIN,SYS_RESOURCE,SYS_PTRACE
+# Pod debugging
+kubectl retina shell -n kube-system pod/coredns-57d886c994-8m2ph --capabilities=NET_ADMIN,SYS_ADMIN
 ```
 
 Once inside the shell, you can run:


### PR DESCRIPTION
# Description

Add eBPF-based [pwru](https://github.com/cilium/pwru) executable binary to retina-shell for tracing network packets in the Linux kernel with advanced filtering capabilities

## Related Issue

#1662 

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

I have tested by building the image in isolation 

```sh
docker buildx build \
    --platform linux/amd64,linux/arm64 \
    --build-arg GOARCH=amd64 \
    -t ghcr.io/srodi/retina/retina-shell \
    --push .
```

And run on both linux/amd64 and linux/arm64

```sh
❯ docker run --rm -it ghcr.io/srodi/retina/retina-shell \
    pwru --version
Unable to find image 'ghcr.io/srodi/retina/retina-shell:latest' locally
latest: Pulling from srodi/retina/retina-shell
67f02795c36b: Pull complete 
879a565e8972: Pull complete 
b825e06ce1fe: Pull complete 
Digest: sha256:24877a745d4fa6f0ab5b5cb17399e13b8b764961658be53676e8749cb2f7525c
Status: Downloaded newer image for ghcr.io/srodi/retina/retina-shell:latest
pwru v1.0.9
```

test `pwru` run with no caps

```sh
❯ docker run --rm -it ghcr.io/srodi/retina/retina-shell pwru
2025/06/06 09:34:10 Failed to set temporary rlimit: failed to set memlock rlimit: operation not permitted
```

test with CAPS

```sh
❯ docker run --rm -it \
  --cap-add=NET_ADMIN \
  --cap-add=SYS_ADMIN \
  ghcr.io/srodi/retina/retina-shell pwru
2025/06/06 09:34:46 Attaching kprobes (via kprobe)...
917 / 1616 [-------------------------------------------------------------------------------------->_________________________________________________________________] 56.75% 483 p/s1102 / 1616 [------------------------------------------------------------------------------------------------------>________________________________________________] 68.19% 507 p/s
2025/06/06 09:34:48 Listening for events..
SKB                CPU PROCESS          NETNS      MARK/x        IFACE       PROTO  MTU   LEN   TUPLE FUNC
0xffff9d258a213ee8 0   <empty>:4017     4026532313 0               1         0x0800 65536 309   172.18.0.2:6443->172.18.0.2:39754(tcp) 0xffffffff8bdb2754
```

Test `node debugging` on AKS

![image](https://github.com/user-attachments/assets/26065ad2-6c3b-4380-b60e-059f26b0e077)

Test `pod debugging` on AKS

![image](https://github.com/user-attachments/assets/e15a966a-1fce-49fe-bcbe-0d1d1a05eadf)


## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
