### PR TITLE
test: fix e2e test for retina capture

### DIFF
--- a/test/e2e/scenarios/capture/validate-capture.go
+++ b/test/e2e/scenarios/capture/validate-capture.go
@@ -48,6 +48,9 @@ func (v *validateCapture) Run() error {
 	imageNamespace := os.Getenv(generic.DefaultImageNamespace)
 	imageTag := os.Getenv(generic.DefaultTagEnv)
 
+	os.Setenv("KUBECONFIG", v.KubeConfigPath)
+	log.Printf("KUBECONFIG: %s\n", os.Getenv("KUBECONFIG"))
+
 	cmd := exec.CommandContext(ctx, "kubectl", "retina", "capture", "create", "--namespace", v.CaptureNamespace, "--name", v.CaptureName, "--duration", v.Duration, "--debug") //#nosec
 	cmd.Env = append(os.Environ(), "RETINA_AGENT_IMAGE="+filepath.Join(imageRegistry, imageNamespace, "retina-agent:"+imageTag))
 


### PR DESCRIPTION
# Description

PR https://github.com/microsoft/retina/pull/1564 was merged with e2e failed execution for retina capture. This PR fixes the e2e test for retina capture by adding the `KUBECONFIG` environment variable to run the `kubectl` command correctly.

Commits:
* improve output of e2e test for retina capture create in case of error
* Add `KUBECONFIG` env variable to run `kubectl` command correctly

Link to successful e2e test execution for retina capture (only e2e for retina capture was tested in the following run): 
https://github.com/microsoft/retina/actions/runs/15539842820/job/43748366816

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
