### PR TITLE
fix: exclude aznfs package from installed packages list

### DIFF
--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -23,6 +23,7 @@ RUN tdnf install -y \
 	socat \
 	tcpdump \
 	wget \
+	--exclude=aznfs \
 	&& tdnf clean all
 
 CMD ["/bin/bash", "-l"]


### PR DESCRIPTION
# Description

Retina Shell Image Build is failing due to failure to install `aznfs` package which is a new dependency of `conntrack` package added recently for some reason. Previous successful pipeline execution did not show that in the list of packages being installed: https://github.com/microsoft/retina/actions/runs/15496126524/job/43634783255
First failed pipeline execution with the problem: https://github.com/microsoft/retina/actions/runs/15530534142/job/43721335257

This PR adds `--exclude=aznfs` to the `tdnf install` command in the `shell/Dockerfile` to exclude the `aznfs` package from the list of installed packages as a workaround.

There's an issue created about it in azurelinux repository: https://github.com/microsoft/azurelinux/issues/13971

References below:

![image](https://github.com/user-attachments/assets/a720ee9e-37fb-4706-8d73-42799a5a1427)
![image](https://github.com/user-attachments/assets/c29fac43-e5ff-4100-b300-b955091087a3)


## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
