### PR TITLE
fix: revert: exclude aznfs package from installed packages list

### DIFF
--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -23,7 +23,6 @@ RUN tdnf install -y \
 	socat \
 	tcpdump \
 	wget \
-	--exclude=aznfs \
 	&& tdnf clean all
 
 CMD ["/bin/bash", "-l"]


### PR DESCRIPTION
Reverts microsoft/retina#1667
It was a workaround for an issue that was fixed: https://github.com/microsoft/azurelinux/issues/13971#issuecomment-2956384627