### PR TITLE
fix(cli): use namespace from user context when --namespace is not set

### DIFF
--- a/cli/cmd/capture/create.go
+++ b/cli/cmd/capture/create.go
@@ -121,6 +121,16 @@ var createCapture = &cobra.Command{
 			return errors.Wrap(err, "failed to initialize kubernetes client")
 		}
 
+		// Set namespace. If --namespace is not set, use namespace on user's context
+		ns, _, err := opts.ConfigFlags.ToRawKubeConfigLoader().Namespace()
+		if err != nil {
+			return errors.Wrap(err, "failed to get namespace from kubeconfig")
+		}
+
+		if opts.Namespace == nil || *opts.Namespace == "" {
+			opts.Namespace = &ns
+		}
+
 		ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM)
 		defer cancel()
 

--- a/cli/cmd/capture/delete.go
+++ b/cli/cmd/capture/delete.go
@@ -42,6 +42,16 @@ var deleteCapture = &cobra.Command{
 			return errors.Wrap(err, "")
 		}
 
+		// Set namespace. If --namespace is not set, use namespace on user's context
+		ns, _, err := opts.ConfigFlags.ToRawKubeConfigLoader().Namespace()
+		if err != nil {
+			return errors.Wrap(err, "failed to get namespace from kubeconfig")
+		}
+
+		if opts.Namespace == nil || *opts.Namespace == "" {
+			opts.Namespace = &ns
+		}
+
 		ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM)
 		defer cancel()
 


### PR DESCRIPTION
# Description

Currently when trying to create a capture and `--namespace` is not set, retina-kubectl does not work as expected which would be to create a capture in the namespace set in user's kubectl context.

This PR fixes this issue by setting namespace based on user's kubectl context.

## Related Issue

Fixes #1579

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Test:
```bash
./artifacts/kubectl-retina capture create --node-names "aks-nodepool1-17156767-vmss000000" --duration 5s --name test
ts=2025-06-18T09:20:02.268+0100 level=info caller=capture/create.go:274 msg="Capture timestamp: 2025-06-18 08:20:02 +0000 UTC"
ts=2025-06-18T09:20:02.269+0100 level=info caller=capture/create.go:277 msg="The capture duration is set to 5s"
ts=2025-06-18T09:20:02.269+0100 level=info caller=capture/create.go:331 msg="The capture file max size is set to 100MB"
ts=2025-06-18T09:20:02.269+0100 level=info caller=utils/capture_image.go:57 msg="Using capture workload image ghcr.io/microsoft/retina/retina-agent:v0.0.34-10-g8e41f1b with version determined by CLI version"
ts=2025-06-18T09:20:02.276+0100 level=info caller=capture/crd_to_job.go:203 msg="HostPath is not empty" HostPath=/mnt/retina/captures
ts=2025-06-18T09:20:03.218+0100 level=info caller=capture/crd_to_job.go:902 msg="The Parsed tcpdump filter is \"\""
#########################
Expected Capture Files
#########################
test-aks-nodepool1-17156767-vmss000000-20250618082002UTC.tar.gz

Note: The file(s) may not be created if the capture job(s) fail prematurely.
#########################
ts=2025-06-18T09:20:03.397+0100 level=info caller=capture/create.go:411 msg="Packet capture job is created" namespace=default capture job=test-n55p4
ts=2025-06-18T09:20:03.397+0100 level=info caller=capture/create.go:148 msg="Please manually delete all capture jobs"
NAMESPACE   CAPTURE NAME   JOB          COMPLETIONS   AGE
default     test           test-n55p4   0/1           0s

./artifacts/kubectl-retina capture delete --name test
ts=2025-06-18T09:20:54.962+0100 level=info caller=capture/delete.go:94 msg="Retina Capture \"test\" delete"
```

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
