### PR TITLE
fix(ci): run markdownlint and commit message checks on merge_group

### DIFF
--- a/.github/workflows/commit-message.yaml
+++ b/.github/workflows/commit-message.yaml
@@ -1,6 +1,7 @@
 name: commit-message
 on:
   merge_group:
+    types: [checks_requested]
   pull_request:
     branches: [main]
     types:
@@ -10,7 +11,6 @@ on:
       - reopened
 jobs:
   commit-message:
-    if: ${{ github.event_name != 'merge_group' }}
     runs-on: ubuntu-24.04
     steps:
       - name: verify_commit_message

--- a/.github/workflows/markdownlint.yaml
+++ b/.github/workflows/markdownlint.yaml
@@ -1,11 +1,11 @@
 name: Markdown Lint
 on:
   merge_group:
+    types: [checks_requested]
   pull_request:
     branches: [main]
 jobs:
   markdownlint:
-    if: ${{ github.event_name != 'merge_group' }}
     name: markdownlint
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Description

markdownlint and commit-messages are required checks in merge queue but they are skipped. 

![image](https://github.com/user-attachments/assets/0c54131c-c494-412b-a783-c3916717813c)

This commit enables them to run.

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
