### PR TITLE
Added handling for CiliumOnWindows Registry Values in Hns and EbpfWin…

### DIFF
--- a/pkg/plugin/common/common_windows.go
+++ b/pkg/plugin/common/common_windows.go
@@ -8,13 +8,19 @@ import (
 	"golang.org/x/sys/windows/registry"
 )
 
+const (
+	// KeyPath is the registry key path where the CiliumOnWindows value is stored.
+	// This key is used to determine if Cilium is enabled on Windows.
+	KeyPath = `SYSTEM\CurrentControlSet\Services\hns\State`
+	// CiliumOnWindows is the registry value name that indicates if Cilium is enabled on Windows.
+	// If this value is set to 1, Cilium is enabled on Windows. If this value is not set or set to 0, Cilium is not enabled.
+	ValueName = "CiliumOnWindows"
+)
+
 // IsCiliumOnWindowsEnabled checks if the CiliumOnWindows registry value is set to 1.
 // Returns (true, nil) if set to 1, (false, nil) if not set or not exist, (false, err) for other errors.
 func IsCiliumOnWindowsEnabled() (bool, error) {
-	keyPath := `SYSTEM\CurrentControlSet\Services\hns\State`
-	valueName := "CiliumOnWindows"
-
-	k, err := registry.OpenKey(registry.LOCAL_MACHINE, keyPath, registry.QUERY_VALUE)
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, KeyPath, registry.QUERY_VALUE)
 	if err != nil {
 		if err == registry.ErrNotExist {
 			return false, nil
@@ -23,7 +29,7 @@ func IsCiliumOnWindowsEnabled() (bool, error) {
 	}
 	defer k.Close()
 
-	val, _, err := k.GetIntegerValue(valueName)
+	val, _, err := k.GetIntegerValue(ValueName)
 	if err != nil {
 		if err == registry.ErrNotExist {
 			return false, nil

--- a/pkg/plugin/common/common_windows.go
+++ b/pkg/plugin/common/common_windows.go
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// package common contains common functions and types used by all Retina Windows plugins.
+package common
+
+import (
+	"golang.org/x/sys/windows/registry"
+)
+
+// IsCiliumOnWindowsEnabled checks if the CiliumOnWindows registry value is set to 1.
+// Returns (true, nil) if set to 1, (false, nil) if not set or not exist, (false, err) for other errors.
+func IsCiliumOnWindowsEnabled() (bool, error) {
+	keyPath := `SYSTEM\CurrentControlSet\Services\hns\State`
+	valueName := "CiliumOnWindows"
+
+	k, err := registry.OpenKey(registry.LOCAL_MACHINE, keyPath, registry.QUERY_VALUE)
+	if err != nil {
+		if err == registry.ErrNotExist {
+			return false, nil
+		}
+		return false, err
+	}
+	defer k.Close()
+
+	val, _, err := k.GetIntegerValue(valueName)
+	if err != nil {
+		if err == registry.ErrNotExist {
+			return false, nil
+		}
+		return false, err
+	}
+	return val == 1, nil
+}

--- a/pkg/plugin/ebpfwindows/ebpf_windows.go
+++ b/pkg/plugin/ebpfwindows/ebpf_windows.go
@@ -85,24 +85,20 @@ func (p *Plugin) Start(ctx context.Context) error {
 
 	ciliumEnabled, err := plugincommon.IsCiliumOnWindowsEnabled()
 
-	if ciliumEnabled {
-		p.l.Info("Cilium is enabled on Windows, proceeding with ebpfWindows plugin initialization")
-		p.pullMetricsAndEvents(ctx)
-		p.l.Info("Complete ebpfWindows plugin...")
-		return nil
-	}
-
 	if err != nil {
 		p.l.Error("Error while checking if Cilium is enabled on Windows", zap.Error(err))
+		return fmt.Errorf("Failed to check if Cilium is enabled on Windows: %w", err)
 	}
 
-	// Wait for either context cancellation
-	select {
-	case <-ctx.Done():
-		p.l.Info("Context cancelled, exiting Start loop")
+	if !ciliumEnabled {
+		p.l.Warn("Cilium is not enabled on Windows, skipping ebpfWindows plugin initialization")
 		return nil
 	}
 
+	p.l.Info("Cilium is enabled on Windows, proceeding with ebpfWindows plugin initialization")
+	p.pullMetricsAndEvents(ctx)
+	p.l.Info("Complete ebpfWindows plugin...")
+	return nil
 }
 
 // metricsMapIterateCallback is the callback function that is called for each key-value pair in the metrics map.

--- a/pkg/plugin/include_windows.go
+++ b/pkg/plugin/include_windows.go
@@ -3,6 +3,7 @@ package plugin
 
 // Plugins self-register via their init() funcs as long as they are imported.
 import (
+	_ "github.com/microsoft/retina/pkg/plugin/ebpfwindows"
 	_ "github.com/microsoft/retina/pkg/plugin/hnsstats"
 	_ "github.com/microsoft/retina/pkg/plugin/pktmon"
 )


### PR DESCRIPTION
# Description
Added registry check for CiliumOnWindows in Hns and EbpfWindows plugins  to support CoExistence in Mixed Mode clusters

Please provide a brief description of the changes made in this pull request.
Added a common function to check for the Registry value.

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
I have manually deployed the image on AKS cluster  with   --set enabledPlugin_win="[ebpfwindows\,hnsstats\]" `
and verified through logs either ebpfwindows or hnsttats are running based on CiliumOnWindows Registry value
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes



---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
