### PR TITLE
chore(cli): set retina agent image registry at build time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,14 @@ KIND_CLUSTER = retina-cluster
 WINVER2022   ?= "10.0.20348.1906"
 WINVER2019   ?= "10.0.17763.4737"
 APP_INSIGHTS_ID ?= ""
+AGENT_IMAGE_NAME ?= ""
 GENERATE_TARGET_DIRS = \
 	./pkg/plugin/linuxutil
+
+# Set agent registry to get image from when using retina-kubectl
+ifneq ($(AGENT_IMAGE_NAME), "")
+	EXTRA_BUILD_ARGS := "--build-arg AGENT_IMAGE_NAME=$(AGENT_IMAGE_NAME)"
+endif
 
 # Default platform is linux/amd64
 GOOS			?= linux
@@ -306,7 +312,8 @@ kubectl-retina-image:
 			IMAGE=$(KUBECTL_RETINA_IMAGE) \
 			VERSION=$(TAG) \
 			TAG=$(RETINA_PLATFORM_TAG) \
-			CONTEXT_DIR=$(REPO_ROOT)
+			CONTEXT_DIR=$(REPO_ROOT) \
+			EXTRA_BUILD_ARGS=$(EXTRA_BUILD_ARGS)
 
 kapinger-image: 
 	docker buildx build --builder retina --platform windows/amd64 --target windows-amd64 -t $(IMAGE_REGISTRY)/$(KAPINGER_IMAGE):$(TAG)-windows-amd64  ./hack/tools/kapinger/ --push

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -3,6 +3,7 @@ FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:
 
 ARG VERSION
 ARG APP_INSIGHTS_ID
+ARG AGENT_IMAGE_NAME="ghcr.io/microsoft/retina/retina-agent"
 
 WORKDIR /workspace
 COPY . .
@@ -17,7 +18,8 @@ ENV GOARCH=${GOARCH}
 RUN --mount=type=cache,target="/root/.cache/go-build" \
     CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
     -ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version="$VERSION" \
-    -X "github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID"="$APP_INSIGHTS_ID"" \
+    -X "github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID"="$APP_INSIGHTS_ID" \
+    -X "github.com/microsoft/retina/internal/buildinfo.RetinaAgentImageName"="$AGENT_IMAGE_NAME"" \
     -a -o kubectl-retina cli/main.go
 
 # mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -9,4 +9,5 @@ var (
 	// If it is set, the application will send telemetry to the corresponding Application Insights resource.
 	ApplicationInsightsID string
 	Version               string
+	RetinaAgentImageName  = "ghcr.io/microsoft/retina/retina-agent"
 )

--- a/pkg/capture/constants/job_specification.go
+++ b/pkg/capture/constants/job_specification.go
@@ -3,6 +3,10 @@
 
 package constants
 
+import (
+	"github.com/microsoft/retina/internal/buildinfo"
+)
+
 // Capture job specification
 const (
 	CaptureHostPathVolumeName string = "hostpath"
@@ -35,9 +39,9 @@ const (
 	// CaptureOutputLocationS3UploadSecretAccessKey is the key of the secret that stores the s3 secret access key.
 	CaptureOutputLocationS3UploadSecretAccessKey string = "s3-secret-access-key"
 
-	// CaptureWorkloadImageName defines the official capture workload image repo and image name
-	CaptureWorkloadImageName string = "ghcr.io/microsoft/retina/retina-agent"
-
 	// DebugCaptureWorkloadImageName defines the capture workload image for testing and debugging
 	DebugCaptureWorkloadImageName string = "ghcr.io/microsoft/retina/retina-agent"
 )
+
+// CaptureWorkloadImageName defines the official capture workload image repo and image name
+var CaptureWorkloadImageName string = buildinfo.RetinaAgentImageName


### PR DESCRIPTION
# Description

When a retina capture is created by retina-kubectl CLI, it uses `ghcr.io/microsoft` as registry to pull retina agent image from. This change allows setting at build time what image name should CLI use when creating retina capture jobs.

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Logs of tests executed:
```bash
# default behavior: use ghcr.io/microsoft as before
$ make kubectl-retina-image
echo "Building for linux/amd64"
Building for linux/amd64
set -e ; \
make container-docker \
                PLATFORM=linux/amd64 \
                DOCKERFILE=cli/Dockerfile \
                REGISTRY=ghcr.io \
                IMAGE=microsoft/retina/kubectl-retina \
                VERSION=v0.0.34-16-gf04641c \
                TAG=v0.0.34-16-gf04641c-linux-amd64 \
                CONTEXT_DIR=/home/lx/projects/retina/repositories/official-retina \
                EXTRA_BUILD_ARGS=
make[1]: Entering directory '/home/lx/projects/retina/repositories/official-retina'
# ...

$ ./artifacts/kubectl-retina capture create --host-path ~/ --node-names "aks-nodepool1-17156767-vmss000000" --duration 5s -n default
# ...

$ $ k get po retina-capture-tgq9s-w84q6 -o yaml | grep image:
    image: ghcr.io/microsoft/retina/retina-agent:v0.0.34-16-gf04641c

# new behavior: set image name to be used at build time
$ AGENT_IMAGE_NAME=mcr.microsoft.com/containernetworking/retina-agent make kubectl-retina-image
echo "Building for linux/amd64"
Building for linux/amd64
set -e ; \
make container-docker \
                PLATFORM=linux/amd64 \
                DOCKERFILE=cli/Dockerfile \
                REGISTRY=ghcr.io \
                IMAGE=microsoft/retina/kubectl-retina \
                VERSION=v0.0.34-16-gf04641c \
                TAG=v0.0.34-16-gf04641c-linux-amd64 \
                CONTEXT_DIR=/home/lx/projects/retina/repositories/official-retina \
                EXTRA_BUILD_ARGS="--build-arg AGENT_IMAGE_NAME=mcr.microsoft.com/containernetworking/retina-agent"

# ...

$ ./artifacts/kubectl-retina capture create --host-path ~/ --node-names "aks-nodepool1-17156767-vmss000000" --duration 5s -n default
# ...

$ k get po retina-capture-xqj84-8wlph -o yaml | grep image:
    image: mcr.microsoft.com/containernetworking/retina-agent:v0.0.34-16-gf04641c

```

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
