### PR TITLE
feat(hubble): Add `trafficDistribution` field support for Kubernetes 1.31+

### DIFF
--- a/deploy/hubble/manifests/controller/helm/retina/templates/hubble-relay/service.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/hubble-relay/service.yaml
@@ -14,6 +14,9 @@ metadata:
     app.kubernetes.io/part-of: retina
 spec:
   type: {{ .Values.hubble.relay.service.type | quote }}
+  {{- if and .Values.hubble.relay.service.trafficDistribution (semverCompare ">=1.31-0" .Capabilities.KubeVersion.GitVersion) }}
+  trafficDistribution: {{ .Values.hubble.relay.service.trafficDistribution }}
+  {{- end }}
   selector:
     k8s-app: hubble-relay
   ports:

--- a/deploy/hubble/manifests/controller/helm/retina/templates/hubble-ui/service.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/hubble-ui/service.yaml
@@ -19,6 +19,9 @@ metadata:
     app.kubernetes.io/part-of: cilium
 spec:
   type: {{ .Values.hubble.ui.service.type | quote }}
+  {{- if and .Values.hubble.ui.service.trafficDistribution (semverCompare ">=1.31-0" .Capabilities.KubeVersion.GitVersion) }}
+  trafficDistribution: {{ .Values.hubble.ui.service.trafficDistribution }}
+  {{- end }}
   selector:
     k8s-app: hubble-ui
   ports:

--- a/deploy/hubble/manifests/controller/helm/retina/values.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/values.yaml
@@ -504,6 +504,12 @@ hubble:
       type: ClusterIP
       # --- The port to use when the service type is set to NodePort.
       nodePort: 31234
+      # --- trafficDistribution field for service load balancing behavior.
+      # Valid values: PreferClose
+      # Provides better performance and reliability than annotation-based topologyAwareRouting
+      # by being built into the Service API and offering more predictable routing behavior.
+      # See https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution
+      trafficDistribution: ""
 
     # -- Host to listen to. Specify an empty string to bind to all the interfaces.
     listenHost: ""
@@ -779,6 +785,12 @@ hubble:
       type: ClusterIP
       # --- The port to use when the service type is set to NodePort.
       nodePort: 31235
+      # --- trafficDistribution field for service load balancing behavior.
+      # Valid values: PreferClose
+      # Provides better performance and reliability than annotation-based topologyAwareRouting
+      # by being built into the Service API and offering more predictable routing behavior.
+      # See https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution
+      trafficDistribution: ""
 
     # -- Defines base url prefix for all hubble-ui http requests.
     # It needs to be changed in case if ingress for hubble-ui is configured under some sub-path.


### PR DESCRIPTION
# Description

Add [trafficDistribution](https://kubernetes.io/docs/concepts/services-networking/service/#traffic-distribution) field support to Hubble services (excluding DaemonSet-connected services) with Kubernetes version compatibility check (≥1.31). This provides better performance and reliability than annotation-based [topologyAwareRouting](https://kubernetes.io/docs/concepts/services-networking/topology-aware-routing/) by being natively integrated into the Service API.



### Changes:

- Added trafficDistribution configuration to Hubble Relay and UI services in values.yaml
- Updated service templates with conditional rendering based on Kubernetes version
- Excluded DaemonSet-connected services (agent, peer) as they use hostNetwork

### Usage

Retina administrators can now set hubble.relay.service.trafficDistribution: PreferClose or hubble.ui.service.trafficDistribution: PreferClose in their values to enable topology-aware routing with improved performance characteristics.

## Related Issue

- [Comparison with service.kubernetes.io/topology-mode: Auto](https://kubernetes.io/docs/reference/networking/virtual-ips/#comparison-with-service-kubernetes-io-topology-mode-auto): Kubernetes official doc

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ x I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

### Why trafficDistribution over topologyAwareRouting?
The trafficDistribution field is **recommended** over [topologyAwareRouting](https://kubernetes.io/docs/concepts/services-networking/topology-aware-routing/) annotations as it provides native Kubernetes Service API integration with better performance and reliability characteristics. This field is available in Kubernetes 1.31+ and offers more granular control over traffic routing behavior compared to the annotation-based approach.

```mermaid
---
title: topologyAwareRouting vs trafficDistribution
---
graph LR
    A[K8s < 1.31] --> B["`**topologyAwareRouting**
    Annotation (Legacy)`"]
    C[K8s ≥ 1.31] --> D["`**trafficDistribution**
    PreferClose`"]
    
    B --Migration--> D 
    B --> F["`Inter AZ DTO Cost
    Reduction`"]
    D --> F

    style D fill:darkorange, color:white
    style B stroke:red, color:white

    note["As of Kubernetes 1.31, the trafficDistribution feature has been moved to beta."]

    style note fill:transparent, stroke:transparent, color:lightgray
```

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
