### PR TITLE
chore(cli): refactor CLI to allow better testing interface + add tests

### DIFF
--- a/cli/cmd/capture/capture.go
+++ b/cli/cmd/capture/capture.go
@@ -4,28 +4,63 @@
 package capture
 
 import (
-	"github.com/microsoft/retina/cli/cmd"
+	"time"
+
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
 )
 
-var opts = struct {
+type Opts struct {
 	genericclioptions.ConfigFlags
-	Name *string
-}{
+	Name               *string
+	blobUpload         string
+	debug              bool
+	duration           time.Duration
+	excludeFilter      string
+	hostPath           string
+	includeFilter      string
+	includeMetadata    bool
+	interfaces         string
+	jobNumLimit        int
+	maxSize            int
+	namespaceSelectors string
+	nodeNames          string
+	nodeSelectors      string
+	nowait             bool
+	packetSize         int
+	podSelectors       string
+	pvc                string
+	s3AccessKeyID      string
+	s3Bucket           string
+	s3Endpoint         string
+	s3Path             string
+	s3Region           string
+	s3SecretAccessKey  string
+	tcpdumpFilter      string
+}
+
+var opts = Opts{
 	Name: new(string),
 }
 
 const defaultName = "retina-capture"
 
-var capture = &cobra.Command{
-	Use:   "capture",
-	Short: "Capture network traffic",
-}
+func NewCommand(kubeClient kubernetes.Interface) *cobra.Command {
+	capture := &cobra.Command{
+		Use:   "capture",
+		Short: "Capture network traffic",
+		Long:  "Capture network traffic from pods in a Kubernetes cluster.",
+	}
 
-func init() {
-	cmd.Retina.AddCommand(capture)
 	opts.ConfigFlags = *genericclioptions.NewConfigFlags(true)
 	opts.AddFlags(capture.PersistentFlags())
 	capture.PersistentFlags().StringVar(opts.Name, "name", defaultName, "The name of the Retina Capture")
+
+	capture.AddCommand(NewCreateSubCommand(kubeClient))
+	capture.AddCommand(NewDeleteSubCommand())
+	capture.AddCommand(NewDownloadSubCommand())
+	capture.AddCommand(NewListSubCommand())
+
+	return capture
 }

--- a/cli/cmd/capture/capture.go
+++ b/cli/cmd/capture/capture.go
@@ -58,7 +58,7 @@ func NewCommand(kubeClient kubernetes.Interface) *cobra.Command {
 	capture.PersistentFlags().StringVar(opts.Name, "name", defaultName, "The name of the Retina Capture")
 
 	capture.AddCommand(NewCreateSubCommand(kubeClient))
-	capture.AddCommand(NewDeleteSubCommand())
+	capture.AddCommand(NewDeleteSubCommand(kubeClient))
 	capture.AddCommand(NewDownloadSubCommand())
 	capture.AddCommand(NewListSubCommand())
 

--- a/cli/cmd/capture/capture.go
+++ b/cli/cmd/capture/capture.go
@@ -44,7 +44,7 @@ var opts = Opts{
 	Name: new(string),
 }
 
-const defaultName = "retina-capture"
+const DefaultName = "retina-capture"
 
 func NewCommand(kubeClient kubernetes.Interface) *cobra.Command {
 	capture := &cobra.Command{
@@ -55,7 +55,7 @@ func NewCommand(kubeClient kubernetes.Interface) *cobra.Command {
 
 	opts.ConfigFlags = *genericclioptions.NewConfigFlags(true)
 	opts.AddFlags(capture.PersistentFlags())
-	capture.PersistentFlags().StringVar(opts.Name, "name", defaultName, "The name of the Retina Capture")
+	capture.PersistentFlags().StringVar(opts.Name, "name", DefaultName, "The name of the Retina Capture")
 
 	capture.AddCommand(NewCreateSubCommand(kubeClient))
 	capture.AddCommand(NewDeleteSubCommand(kubeClient))

--- a/cli/cmd/capture/create.go
+++ b/cli/cmd/capture/create.go
@@ -33,34 +33,6 @@ import (
 	"github.com/microsoft/retina/pkg/config"
 )
 
-var (
-	blobUpload         string
-	debug              bool
-	duration           time.Duration
-	excludeFilter      string
-	hostPath           string
-	includeFilter      string
-	includeMetadata    bool
-	interfaces         string
-	jobNumLimit        int
-	maxSize            int
-	namespace          string
-	namespaceSelectors string
-	nodeNames          string
-	nodeSelectors      string
-	nowait             bool
-	packetSize         int
-	podSelectors       string
-	pvc                string
-	s3AccessKeyID      string
-	s3Bucket           string
-	s3Endpoint         string
-	s3Path             string
-	s3Region           string
-	s3SecretAccessKey  string
-	tcpdumpFilter      string
-)
-
 const (
 	DefaultDebug           bool          = false
 	DefaultDuration        time.Duration = 1 * time.Minute
@@ -110,99 +82,143 @@ var createExample = templates.Examples(i18n.T(`
 			--s3-secret-access-key "your-secret-access-key"
 		`))
 
-var createCapture = &cobra.Command{
-	Use:     "create",
-	Short:   "Create a Retina Capture",
-	Example: createExample,
-	RunE: func(*cobra.Command, []string) error {
-		kubeConfig, err := opts.ToRESTConfig()
-		if err != nil {
-			return errors.Wrap(err, "failed to compose k8s rest config")
+func create(kubeClient kubernetes.Interface) error {
+	// Set namespace. If --namespace is not set, use namespace on user's context
+	ns, _, err := opts.ConfigFlags.ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		return errors.Wrap(err, "failed to get namespace from kubeconfig")
+	}
+
+	if opts.Namespace == nil || *opts.Namespace == "" {
+		opts.Namespace = &ns
+	}
+
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM)
+	defer cancel()
+
+	capture, err := createCaptureF(ctx, kubeClient)
+	if err != nil {
+		return err
+	}
+
+	jobsCreated, err := createJobs(ctx, kubeClient, capture)
+	if err != nil {
+		retinacmd.Logger.Error("Failed to create job", zap.Error(err))
+		return err
+	}
+	if opts.nowait {
+		retinacmd.Logger.Info("Please manually delete all capture jobs")
+		if capture.Spec.OutputConfiguration.BlobUpload != nil {
+			retinacmd.Logger.Info("Please manually delete capture secret", zap.String("namespace", *opts.Namespace), zap.String("secret name", *capture.Spec.OutputConfiguration.BlobUpload))
+		}
+		if capture.Spec.OutputConfiguration.S3Upload != nil && capture.Spec.OutputConfiguration.S3Upload.SecretName != "" {
+			retinacmd.Logger.Info("Please manually delete capture secret", zap.String("namespace", *opts.Namespace), zap.String("secret name", capture.Spec.OutputConfiguration.S3Upload.SecretName))
+		}
+		printCaptureResult(jobsCreated)
+		return nil
+	}
+
+	// Wait until all jobs finish then delete the jobs before the timeout, otherwise print jobs created to
+	// let the customer recycle them.
+	retinacmd.Logger.Info("Waiting for capture jobs to finish")
+
+	allJobsCompleted := waitUntilJobsComplete(ctx, kubeClient, jobsCreated)
+
+	// Delete all jobs created only if they all completed, otherwise keep the jobs for debugging.
+	if allJobsCompleted {
+		retinacmd.Logger.Info("Deleting jobs as all jobs are completed")
+		jobsFailedToDelete := deleteJobs(ctx, kubeClient, jobsCreated)
+		if len(jobsFailedToDelete) != 0 {
+			retinacmd.Logger.Info("Please manually delete capture jobs failed to delete", zap.String("namespace", *opts.Namespace), zap.String("job list", strings.Join(jobsFailedToDelete, ",")))
 		}
 
-		kubeClient, err := kubernetes.NewForConfig(kubeConfig)
-		if err != nil {
-			return errors.Wrap(err, "failed to initialize kubernetes client")
-		}
-
-		// Set namespace. If --namespace is not set, use namespace on user's context
-		ns, _, err := opts.ConfigFlags.ToRawKubeConfigLoader().Namespace()
-		if err != nil {
-			return errors.Wrap(err, "failed to get namespace from kubeconfig")
-		}
-
-		if opts.Namespace == nil || *opts.Namespace == "" {
-			opts.Namespace = &ns
-		}
-
-		ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM)
-		defer cancel()
-
-		capture, err := createCaptureF(ctx, kubeClient)
-		if err != nil {
-			return err
-		}
-
-		jobsCreated, err := createJobs(ctx, kubeClient, capture)
-		if err != nil {
-			retinacmd.Logger.Error("Failed to create job", zap.Error(err))
-			return err
-		}
-		if nowait {
-			retinacmd.Logger.Info("Please manually delete all capture jobs")
-			if capture.Spec.OutputConfiguration.BlobUpload != nil {
-				retinacmd.Logger.Info("Please manually delete capture secret", zap.String("namespace", *opts.Namespace), zap.String("secret name", *capture.Spec.OutputConfiguration.BlobUpload))
+		if capture.Spec.OutputConfiguration.BlobUpload != nil {
+			err = deleteSecret(ctx, kubeClient, capture.Spec.OutputConfiguration.BlobUpload)
+			if err != nil {
+				retinacmd.Logger.Error("Failed to delete capture secret, please manually delete it",
+					zap.String("namespace", *opts.Namespace), zap.String("secret name", *capture.Spec.OutputConfiguration.BlobUpload), zap.Error(err))
 			}
-			if capture.Spec.OutputConfiguration.S3Upload != nil && capture.Spec.OutputConfiguration.S3Upload.SecretName != "" {
-				retinacmd.Logger.Info("Please manually delete capture secret", zap.String("namespace", *opts.Namespace), zap.String("secret name", capture.Spec.OutputConfiguration.S3Upload.SecretName))
-			}
-			printCaptureResult(jobsCreated)
-			return nil
 		}
 
-		// Wait until all jobs finish then delete the jobs before the timeout, otherwise print jobs created to
-		// let the customer recycle them.
-		retinacmd.Logger.Info("Waiting for capture jobs to finish")
-
-		allJobsCompleted := waitUntilJobsComplete(ctx, kubeClient, jobsCreated)
-
-		// Delete all jobs created only if they all completed, otherwise keep the jobs for debugging.
-		if allJobsCompleted {
-			retinacmd.Logger.Info("Deleting jobs as all jobs are completed")
-			jobsFailedToDelete := deleteJobs(ctx, kubeClient, jobsCreated)
-			if len(jobsFailedToDelete) != 0 {
-				retinacmd.Logger.Info("Please manually delete capture jobs failed to delete", zap.String("namespace", *opts.Namespace), zap.String("job list", strings.Join(jobsFailedToDelete, ",")))
+		if capture.Spec.OutputConfiguration.S3Upload != nil && capture.Spec.OutputConfiguration.S3Upload.SecretName != "" {
+			err = deleteSecret(ctx, kubeClient, &capture.Spec.OutputConfiguration.S3Upload.SecretName)
+			if err != nil {
+				retinacmd.Logger.Error("Failed to delete capture secret, please manually delete it",
+					zap.String("namespace", *opts.Namespace),
+					zap.String("secret name", capture.Spec.OutputConfiguration.S3Upload.SecretName),
+					zap.Error(err),
+				)
 			}
-
-			if capture.Spec.OutputConfiguration.BlobUpload != nil {
-				err = deleteSecret(ctx, kubeClient, capture.Spec.OutputConfiguration.BlobUpload)
-				if err != nil {
-					retinacmd.Logger.Error("Failed to delete capture secret, please manually delete it",
-						zap.String("namespace", *opts.Namespace), zap.String("secret name", *capture.Spec.OutputConfiguration.BlobUpload), zap.Error(err))
-				}
-			}
-
-			if capture.Spec.OutputConfiguration.S3Upload != nil && capture.Spec.OutputConfiguration.S3Upload.SecretName != "" {
-				err = deleteSecret(ctx, kubeClient, &capture.Spec.OutputConfiguration.S3Upload.SecretName)
-				if err != nil {
-					retinacmd.Logger.Error("Failed to delete capture secret, please manually delete it",
-						zap.String("namespace", *opts.Namespace),
-						zap.String("secret name", capture.Spec.OutputConfiguration.S3Upload.SecretName),
-						zap.Error(err),
-					)
-				}
-			}
-
-			if len(jobsFailedToDelete) == 0 && err == nil {
-				retinacmd.Logger.Info("Done for deleting jobs")
-			}
-			return nil
 		}
 
-		retinacmd.Logger.Info("Not all job are completed in the given time")
-		retinacmd.Logger.Info("Please manually delete the Capture")
-		return getCaptureAndPrintCaptureResult(ctx, kubeClient, capture.Name, *opts.Namespace)
-	},
+		if len(jobsFailedToDelete) == 0 && err == nil {
+			retinacmd.Logger.Info("Done for deleting jobs")
+		}
+		return nil
+	}
+
+	retinacmd.Logger.Info("Not all job are completed in the given time")
+	retinacmd.Logger.Info("Please manually delete the Capture")
+
+	return getCaptureAndPrintCaptureResult(ctx, kubeClient, capture.Name, *opts.Namespace)
+}
+
+func GetClientset() (*kubernetes.Clientset, error) {
+	kubeConfig, err := opts.ToRESTConfig()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to compose k8s rest config")
+	}
+
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to initialize kubernetes client")
+	}
+
+	return kubeClient, nil
+}
+
+func NewCreateSubCommand(kubeClient kubernetes.Interface) *cobra.Command {
+	createCapture := &cobra.Command{
+		Use:     "create",
+		Short:   "Create a Retina Capture",
+		Example: createExample,
+	}
+
+	createCapture.RunE = func(*cobra.Command, []string) error {
+		return create(kubeClient)
+	}
+
+	createCapture.Flags().DurationVar(&opts.duration, "duration", DefaultDuration, "Duration of capturing packets")
+	createCapture.Flags().IntVar(&opts.maxSize, "max-size", DefaultMaxSize, "Limit the capture file to MB in size which works only for Linux") //nolint:gomnd // default
+	createCapture.Flags().IntVar(&opts.packetSize, "packet-size", DefaultPacketSize, "Limits the each packet to bytes in size which works only for Linux")
+	createCapture.Flags().StringVar(&opts.nodeNames, "node-names", "", "A comma-separated list of node names to select nodes on which the network capture will be performed")
+	createCapture.Flags().StringVar(&opts.nodeSelectors, "node-selectors", DefaultNodeSelectors, "A comma-separated list of node labels to select nodes on which the network capture will be performed")
+	createCapture.Flags().StringVar(&opts.podSelectors, "pod-selectors", "",
+		"A comma-separated list of pod labels to select pods on which the network capture will be performed")
+	createCapture.Flags().StringVar(&opts.namespaceSelectors, "namespace-selectors", "",
+		"A comma-separated list of namespace labels to filter which namespaces will be targeted for packet capture (used with --pod-selectors)")
+	createCapture.Flags().StringVar(&opts.hostPath, "host-path", DefaultHostPath, "HostPath of the node to store the capture files")
+	createCapture.Flags().StringVar(&opts.pvc, "pvc", "", "PersistentVolumeClaim under the specified or default namespace to store capture files")
+	createCapture.Flags().StringVar(&opts.blobUpload, "blob-upload", "", "Blob SAS URL with write permission to upload capture files")
+	createCapture.Flags().StringVar(&opts.s3Region, "s3-region", "", "Region where the S3 compatible bucket is located")
+	createCapture.Flags().StringVar(&opts.s3Endpoint, "s3-endpoint", "",
+		"Endpoint for an S3 compatible storage service. Use this if you are using a custom or private S3 service that requires a specific endpoint")
+	createCapture.Flags().StringVar(&opts.s3Bucket, "s3-bucket", "", "Bucket in which to store capture files")
+	createCapture.Flags().StringVar(&opts.s3Path, "s3-path", DefaultS3Path, "Prefix path within the S3 bucket where captures will be stored")
+	createCapture.Flags().StringVar(&opts.s3AccessKeyID, "s3-access-key-id", "", "S3 access key id to upload capture files")
+	createCapture.Flags().StringVar(&opts.s3SecretAccessKey, "s3-secret-access-key", "", "S3 access secret key to upload capture files")
+	createCapture.Flags().StringVar(&opts.tcpdumpFilter, "tcpdump-filter", "", "Raw tcpdump flags which works only for Linux")
+	createCapture.Flags().StringVar(&opts.interfaces, "interfaces", "", "Comma-separated list of network interfaces to capture on (e.g., eth0,eth1)")
+	createCapture.Flags().StringVar(&opts.excludeFilter, "exclude-filter", "", "A comma-separated list of IP:Port pairs that are "+
+		"excluded from capturing network packets. Supported formats are IP:Port, IP, Port, *:Port, IP:*")
+	createCapture.Flags().StringVar(&opts.includeFilter, "include-filter", "", "A comma-separated list of IP:Port pairs that are "+
+		"used to filter capture network packets. Supported formats are IP:Port, IP, Port, *:Port, IP:*")
+	createCapture.Flags().BoolVar(&opts.includeMetadata, "include-metadata", DefaultIncludeMetadata, "If true, collect static network metadata into capture file")
+	createCapture.Flags().IntVar(&opts.jobNumLimit, "job-num-limit", DefaultJobNumLimit, "The maximum number of jobs can be created for each capture. 0 means no limit")
+	createCapture.Flags().BoolVar(&opts.nowait, "no-wait", DefaultNowait, "Do not wait for the long-running capture job to finish")
+	createCapture.Flags().BoolVar(&opts.debug, "debug", DefaultDebug, "When debug is true, a customized retina-agent image, determined by the environment variable RETINA_AGENT_IMAGE, is set")
+
+	return createCapture
 }
 
 func createSecretFromBlobUpload(ctx context.Context, kubeClient kubernetes.Interface, blobUpload, captureName string) (string, error) {
@@ -264,9 +280,9 @@ func createCaptureF(ctx context.Context, kubeClient kubernetes.Interface) (*reti
 		},
 		Spec: retinav1alpha1.CaptureSpec{
 			CaptureConfiguration: retinav1alpha1.CaptureConfiguration{
-				TcpdumpFilter:   &tcpdumpFilter,
+				TcpdumpFilter:   &opts.tcpdumpFilter,
 				CaptureTarget:   retinav1alpha1.CaptureTarget{},
-				IncludeMetadata: includeMetadata,
+				IncludeMetadata: opts.includeMetadata,
 				CaptureOption:   retinav1alpha1.CaptureOption{},
 			},
 		},
@@ -277,40 +293,40 @@ func createCaptureF(ctx context.Context, kubeClient kubernetes.Interface) (*reti
 
 	retinacmd.Logger.Info(fmt.Sprintf("Capture timestamp: %s", timestamp))
 
-	if duration != 0 {
-		retinacmd.Logger.Info(fmt.Sprintf("The capture duration is set to %s", duration))
-		capture.Spec.CaptureConfiguration.CaptureOption.Duration = &metav1.Duration{Duration: duration}
+	if opts.duration != 0 {
+		retinacmd.Logger.Info(fmt.Sprintf("The capture duration is set to %s", opts.duration))
+		capture.Spec.CaptureConfiguration.CaptureOption.Duration = &metav1.Duration{Duration: opts.duration}
 	}
 
-	if namespaceSelectors != "" || podSelectors != "" {
+	if opts.namespaceSelectors != "" || opts.podSelectors != "" {
 		// if node selector is using the default value (aka hasn't been set by user), set it to nil to prevent clash with namespace and pod selector
-		if nodeSelectors == DefaultNodeSelectors {
+		if opts.nodeSelectors == DefaultNodeSelectors {
 			retinacmd.Logger.Info("Overriding default node selectors value and setting it to nil. Using namespace and pod selectors. To use node selector, please remove namespace and pod selectors.")
-			nodeSelectors = ""
+			opts.nodeSelectors = ""
 		}
 	}
 
-	nodeSelectorLabelsMap, err := labels.ConvertSelectorToLabelsMap(nodeSelectors)
+	nodeSelectorLabelsMap, err := labels.ConvertSelectorToLabelsMap(opts.nodeSelectors)
 	if err != nil {
 		return nil, err
 	}
-	podSelectorLabelsMap, err := labels.ConvertSelectorToLabelsMap(podSelectors)
+	podSelectorLabelsMap, err := labels.ConvertSelectorToLabelsMap(opts.podSelectors)
 	if err != nil {
 		return nil, err
 	}
-	namespaceSelectorLabelsMap, err := labels.ConvertSelectorToLabelsMap(namespaceSelectors)
+	namespaceSelectorLabelsMap, err := labels.ConvertSelectorToLabelsMap(opts.namespaceSelectors)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(nodeSelectorLabelsMap) != 0 || len(nodeNames) != 0 {
+	if len(nodeSelectorLabelsMap) != 0 || opts.nodeNames != "" {
 		capture.Spec.CaptureConfiguration.CaptureTarget.NodeSelector = &metav1.LabelSelector{}
 	}
 	if len(nodeSelectorLabelsMap) != 0 {
 		capture.Spec.CaptureConfiguration.CaptureTarget.NodeSelector.MatchLabels = nodeSelectorLabelsMap
 	}
-	if len(nodeNames) != 0 {
-		nodeNameSlice := strings.Split(nodeNames, ",")
+	if opts.nodeNames != "" {
+		nodeNameSlice := strings.Split(opts.nodeNames, ",")
 		if len(nodeNameSlice) != 0 {
 			capture.Spec.CaptureConfiguration.CaptureTarget.NodeSelector.MatchExpressions = []metav1.LabelSelectorRequirement{{
 				Key:      corev1.LabelHostname,
@@ -320,29 +336,32 @@ func createCaptureF(ctx context.Context, kubeClient kubernetes.Interface) (*reti
 		}
 	}
 
+	// Add namespace selectors if provided, regardless of other selectors
 	if len(namespaceSelectorLabelsMap) != 0 {
 		capture.Spec.CaptureConfiguration.CaptureTarget.NamespaceSelector = &metav1.LabelSelector{
 			MatchLabels: namespaceSelectorLabelsMap,
 		}
 	}
+
+	// Add pod selectors if provided
 	if len(podSelectorLabelsMap) != 0 {
 		capture.Spec.CaptureConfiguration.CaptureTarget.PodSelector = &metav1.LabelSelector{
 			MatchLabels: podSelectorLabelsMap,
 		}
 	}
 
-	if maxSize != 0 {
-		retinacmd.Logger.Info(fmt.Sprintf("The capture file max size is set to %dMB", maxSize))
-		capture.Spec.CaptureConfiguration.CaptureOption.MaxCaptureSize = &maxSize
+	if opts.maxSize != 0 {
+		retinacmd.Logger.Info(fmt.Sprintf("The capture file max size is set to %dMB", opts.maxSize))
+		capture.Spec.CaptureConfiguration.CaptureOption.MaxCaptureSize = &opts.maxSize
 	}
 
-	if packetSize != 0 {
-		retinacmd.Logger.Info(fmt.Sprintf("The capture packet size is set to %d bytes", packetSize))
-		capture.Spec.CaptureConfiguration.CaptureOption.PacketSize = &packetSize
+	if opts.packetSize != 0 {
+		retinacmd.Logger.Info(fmt.Sprintf("The capture packet size is set to %d bytes", opts.packetSize))
+		capture.Spec.CaptureConfiguration.CaptureOption.PacketSize = &opts.packetSize
 	}
 
-	if interfaces != "" {
-		interfaceSlice := strings.Split(interfaces, ",")
+	if opts.interfaces != "" {
+		interfaceSlice := strings.Split(opts.interfaces, ",")
 		for i := range interfaceSlice {
 			interfaceSlice[i] = strings.TrimSpace(interfaceSlice[i])
 		}
@@ -350,49 +369,49 @@ func createCaptureF(ctx context.Context, kubeClient kubernetes.Interface) (*reti
 		capture.Spec.CaptureConfiguration.CaptureOption.Interfaces = interfaceSlice
 	}
 
-	if len(hostPath) != 0 {
-		capture.Spec.OutputConfiguration.HostPath = &hostPath
+	if opts.hostPath != "" {
+		capture.Spec.OutputConfiguration.HostPath = &opts.hostPath
 	}
-	if len(pvc) != 0 {
-		capture.Spec.OutputConfiguration.PersistentVolumeClaim = &pvc
+	if opts.pvc != "" {
+		capture.Spec.OutputConfiguration.PersistentVolumeClaim = &opts.pvc
 	}
 
-	if len(blobUpload) != 0 {
+	if opts.blobUpload != "" {
 		// Mount blob url as secret onto the capture pod for security concern if blob url is not empty.
-		secretName, err := createSecretFromBlobUpload(ctx, kubeClient, blobUpload, *opts.Name)
+		secretName, err := createSecretFromBlobUpload(ctx, kubeClient, opts.blobUpload, *opts.Name)
 		if err != nil {
 			return nil, err
 		}
 		capture.Spec.OutputConfiguration.BlobUpload = &secretName
 	}
 
-	if s3Bucket != "" {
-		secretName, err := createSecretFromS3Upload(ctx, kubeClient, s3AccessKeyID, s3SecretAccessKey, *opts.Name)
+	if opts.s3Bucket != "" {
+		secretName, err := createSecretFromS3Upload(ctx, kubeClient, opts.s3AccessKeyID, opts.s3SecretAccessKey, *opts.Name)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create s3 upload secret: %w", err)
 		}
 		capture.Spec.OutputConfiguration.S3Upload = &retinav1alpha1.S3Upload{
-			Endpoint:   s3Endpoint,
-			Bucket:     s3Bucket,
+			Endpoint:   opts.s3Endpoint,
+			Bucket:     opts.s3Bucket,
 			SecretName: secretName,
-			Region:     s3Region,
-			Path:       s3Path,
+			Region:     opts.s3Region,
+			Path:       opts.s3Path,
 		}
 	}
 
-	if len(excludeFilter) != 0 {
+	if opts.excludeFilter != "" {
 		if capture.Spec.CaptureConfiguration.Filters == nil {
 			capture.Spec.CaptureConfiguration.Filters = &retinav1alpha1.CaptureConfigurationFilters{}
 		}
-		excludeFilterSlice := strings.Split(excludeFilter, ",")
+		excludeFilterSlice := strings.Split(opts.excludeFilter, ",")
 		capture.Spec.CaptureConfiguration.Filters.Exclude = excludeFilterSlice
 	}
 
-	if len(includeFilter) != 0 {
+	if opts.includeFilter != "" {
 		if capture.Spec.CaptureConfiguration.Filters == nil {
 			capture.Spec.CaptureConfiguration.Filters = &retinav1alpha1.CaptureConfigurationFilters{}
 		}
-		includeFilterSlice := strings.Split(includeFilter, ",")
+		includeFilterSlice := strings.Split(opts.includeFilter, ",")
 		capture.Spec.CaptureConfiguration.Filters.Include = includeFilterSlice
 	}
 	return capture, nil
@@ -401,9 +420,9 @@ func createCaptureF(ctx context.Context, kubeClient kubernetes.Interface) (*reti
 func getCLICaptureConfig() config.CaptureConfig {
 	return config.CaptureConfig{
 		CaptureImageVersion:       buildinfo.Version,
-		CaptureDebug:              debug,
+		CaptureDebug:              opts.debug,
 		CaptureImageVersionSource: captureUtils.VersionSourceCLIVersion,
-		CaptureJobNumLimit:        jobNumLimit,
+		CaptureJobNumLimit:        opts.jobNumLimit,
 	}
 }
 
@@ -430,15 +449,15 @@ func waitUntilJobsComplete(ctx context.Context, kubeClient kubernetes.Interface,
 	allJobsCompleted := false
 
 	// TODO: let's make the timeout and period to wait for all job to finish configurable.
-	var deadline time.Duration = DefaultWaitTimeout
-	if duration != 0 {
-		deadline = duration * 2
+	deadline := DefaultWaitTimeout
+	if opts.duration != 0 {
+		deadline = opts.duration * 2
 	}
 
-	var period time.Duration = DefaultWaitPeriod
+	period := DefaultWaitPeriod
 	// To print less noisy messages, we rely on duration to decide the wait period.
-	if period < duration/10 {
-		period = duration / 10
+	if period < opts.duration/10 {
+		period = opts.duration / 10
 	}
 	retinacmd.Logger.Info(fmt.Sprintf("Waiting timeout is set to %s", deadline))
 
@@ -494,37 +513,4 @@ func deleteJobs(ctx context.Context, kubeClient kubernetes.Interface, jobs []bat
 		}
 	}
 	return jobsFailedtoDelete
-}
-
-func init() {
-	capture.AddCommand(createCapture)
-	createCapture.Flags().DurationVar(&duration, "duration", DefaultDuration, "Duration of capturing packets")
-	createCapture.Flags().IntVar(&maxSize, "max-size", DefaultMaxSize, "Limit the capture file to MB in size which works only for Linux") //nolint:gomnd // default
-	createCapture.Flags().IntVar(&packetSize, "packet-size", DefaultPacketSize, "Limits the each packet to bytes in size which works only for Linux")
-	createCapture.Flags().StringVar(&nodeNames, "node-names", "", "A comma-separated list of node names to select nodes on which the network capture will be performed")
-	createCapture.Flags().StringVar(&nodeSelectors, "node-selectors", DefaultNodeSelectors, "A comma-separated list of node labels to select nodes on which the network capture will be performed")
-	createCapture.Flags().StringVar(&podSelectors, "pod-selectors", "",
-		"A comma-separated list of pod labels to select pods on which the network capture will be performed")
-	createCapture.Flags().StringVar(&namespaceSelectors, "namespace-selectors", "",
-		"A comma-separated list of namespace labels in which to apply the pod-selectors. By default, the pod namespace is specified by the flag namespace")
-	createCapture.Flags().StringVar(&hostPath, "host-path", DefaultHostPath, "HostPath of the node to store the capture files")
-	createCapture.Flags().StringVar(&pvc, "pvc", "", "PersistentVolumeClaim under the specified or default namespace to store capture files")
-	createCapture.Flags().StringVar(&blobUpload, "blob-upload", "", "Blob SAS URL with write permission to upload capture files")
-	createCapture.Flags().StringVar(&s3Region, "s3-region", "", "Region where the S3 compatible bucket is located")
-	createCapture.Flags().StringVar(&s3Endpoint, "s3-endpoint", "",
-		"Endpoint for an S3 compatible storage service. Use this if you are using a custom or private S3 service that requires a specific endpoint")
-	createCapture.Flags().StringVar(&s3Bucket, "s3-bucket", "", "Bucket in which to store capture files")
-	createCapture.Flags().StringVar(&s3Path, "s3-path", DefaultS3Path, "Prefix path within the S3 bucket where captures will be stored")
-	createCapture.Flags().StringVar(&s3AccessKeyID, "s3-access-key-id", "", "S3 access key id to upload capture files")
-	createCapture.Flags().StringVar(&s3SecretAccessKey, "s3-secret-access-key", "", "S3 access secret key to upload capture files")
-	createCapture.Flags().StringVar(&tcpdumpFilter, "tcpdump-filter", "", "Raw tcpdump flags which works only for Linux")
-	createCapture.Flags().StringVar(&interfaces, "interfaces", "", "Comma-separated list of network interfaces to capture on (e.g., eth0,eth1)")
-	createCapture.Flags().StringVar(&excludeFilter, "exclude-filter", "", "A comma-separated list of IP:Port pairs that are "+
-		"excluded from capturing network packets. Supported formats are IP:Port, IP, Port, *:Port, IP:*")
-	createCapture.Flags().StringVar(&includeFilter, "include-filter", "", "A comma-separated list of IP:Port pairs that are "+
-		"used to filter capture network packets. Supported formats are IP:Port, IP, Port, *:Port, IP:*")
-	createCapture.Flags().BoolVar(&includeMetadata, "include-metadata", DefaultIncludeMetadata, "If true, collect static network metadata into capture file")
-	createCapture.Flags().IntVar(&jobNumLimit, "job-num-limit", DefaultJobNumLimit, "The maximum number of jobs can be created for each capture. 0 means no limit")
-	createCapture.Flags().BoolVar(&nowait, "no-wait", DefaultNowait, "Do not wait for the long-running capture job to finish")
-	createCapture.Flags().BoolVar(&debug, "debug", DefaultDebug, "When debug is true, a customized retina-agent image, determined by the environment variable RETINA_AGENT_IMAGE, is set")
 }

--- a/cli/cmd/capture/create_test.go
+++ b/cli/cmd/capture/create_test.go
@@ -33,7 +33,7 @@ type testcase struct {
 }
 
 func randomString(length int) string {
-	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
 	result := make([]byte, length)
 	for i := range result {
 		result[i] = charset[rand.Intn(len(charset))] //nolint:gosec // this random number generator is fine
@@ -163,7 +163,7 @@ func TestCreateJobsWithNamespace(t *testing.T) {
 		{
 			name:             "create --namespace=workload --podSelector=service=A --namespace-selectors=name=workload",
 			inputName:        "",
-			wantName:         "retina-capture", // Default name for capture job
+			wantName:         DefaultName,
 			inputNamespace:   "workload",
 			wantNamespace:    "workload",
 			inputPodSelector: "service=A",
@@ -172,9 +172,31 @@ func TestCreateJobsWithNamespace(t *testing.T) {
 			wantErr:          false,
 		},
 		{
+			name:             "create --namespace=workload --podSelector=service=A",
+			inputName:        "",
+			wantName:         DefaultName,
+			inputNamespace:   "workload",
+			wantNamespace:    "workload",
+			inputPodSelector: "service=A",
+			inputNsSelector:  "",
+			wantNodes:        []string{},
+			wantErr:          true,
+		},
+		{
+			name:             "create --namespace=workload --namespace-selectors=name=workload",
+			inputName:        "",
+			wantName:         DefaultName,
+			inputNamespace:   "workload",
+			wantNamespace:    "workload",
+			inputPodSelector: "",
+			inputNsSelector:  "name=workload",
+			wantNodes:        []string{},
+			wantErr:          true,
+		},
+		{
 			name:             "create --namespace=workload --podSelector=service=B --namespace-selectors=name=workload",
 			inputName:        "",
-			wantName:         "retina-capture", // Default name for capture job
+			wantName:         DefaultName,
 			inputNamespace:   "workload",
 			wantNamespace:    "workload",
 			inputPodSelector: "service=B",
@@ -185,7 +207,7 @@ func TestCreateJobsWithNamespace(t *testing.T) {
 		{
 			name:              "create --namespace=workload --node-selectors=kubernetes.io/hostname=B1",
 			inputName:         "",
-			wantName:          "retina-capture", // Default name for capture job
+			wantName:          DefaultName,
 			inputNamespace:    "workload",
 			wantNamespace:     "workload",
 			inputNodeSelector: "kubernetes.io/hostname=B1",
@@ -195,7 +217,7 @@ func TestCreateJobsWithNamespace(t *testing.T) {
 		{
 			name:              "create --namespace=workload --podSelector=service=B --namespace-selectors=name=workload --node-selectors=kubernetes.io/hostname=B1",
 			inputName:         "",
-			wantName:          "retina-capture", // Default name for capture job
+			wantName:          DefaultName,
 			inputNamespace:    "workload",
 			wantNamespace:     "workload",
 			inputPodSelector:  "service=B",

--- a/cli/cmd/capture/create_test.go
+++ b/cli/cmd/capture/create_test.go
@@ -1,0 +1,313 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package capture
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/microsoft/retina/pkg/label"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+type testcase struct {
+	name              string
+	inputName         string
+	wantName          string
+	inputNamespace    string
+	wantNamespace     string
+	inputPodSelector  string
+	inputNsSelector   string
+	inputNodeSelector string
+	wantNodes         []string
+	wantErr           bool
+}
+
+func randomString(length int) string {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	result := make([]byte, length)
+	for i := range result {
+		result[i] = charset[rand.Intn(len(charset))] //nolint:gosec // this random number generator is fine
+	}
+	return string(result)
+}
+
+func argsFromTestCase(tc testcase) []string {
+	args := []string{"create", "--pod-selectors", tc.inputPodSelector}
+	if tc.inputNsSelector != "" {
+		args = append(args, "--namespace-selectors="+tc.inputNsSelector)
+	}
+	if tc.inputNamespace != "" {
+		args = append(args, "--namespace", tc.inputNamespace)
+	}
+	if tc.inputName != "" {
+		args = append(args, "--name", tc.inputName)
+	}
+	if tc.inputNodeSelector != "" {
+		args = append(args, "--node-selectors="+tc.inputNodeSelector)
+	}
+	return args
+}
+
+func NewNode(name string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"kubernetes.io/hostname": name,
+			},
+		},
+	}
+}
+
+func NewNamespace(name string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"name": name,
+			},
+		},
+	}
+}
+
+func NewClientServerPods(service, namespace string) []*corev1.Pod {
+	return []*corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "client" + service,
+				Namespace: namespace,
+				Labels: map[string]string{
+					"service": service,
+				},
+			},
+			Spec: corev1.PodSpec{
+				NodeName: service + "1",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "server" + service,
+				Namespace: namespace,
+				Labels: map[string]string{
+					"service": service,
+				},
+			},
+			Spec: corev1.PodSpec{
+				NodeName: service + "2",
+			},
+		},
+	}
+}
+
+func TestCreateJobsWithNamespace(t *testing.T) {
+	// Create a fake Kubernetes client with workload and capture namespaces
+	newKubeclient := func() *fake.Clientset {
+		objects := []runtime.Object{
+			NewNode("A1"),
+			NewNode("A2"),
+			NewNode("B1"),
+			NewNode("B2"),
+			NewNamespace("workload"),
+			NewNamespace("capture"),
+		}
+		for _, pod := range NewClientServerPods("A", "workload") {
+			objects = append(objects, pod)
+		}
+		for _, pod := range NewClientServerPods("B", "workload") {
+			objects = append(objects, pod)
+		}
+
+		kubeClient := fake.NewClientset(objects...)
+
+		// Handle job creation to set job name if not provided, which is done automatically in a real k8s cluster
+		kubeClient.PrependReactor("create", "jobs", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+			createAction, ok := action.(clienttesting.CreateAction)
+			if !ok {
+				return false, nil, fmt.Errorf("expected CreateAction, got %T", action) //nolint:err113 // test code
+			}
+			job := createAction.GetObject().(*batchv1.Job)
+
+			// Set job name if unset
+			if job.Name == "" {
+				job.Name = job.GenerateName + randomString(5)
+			}
+			return false, job, nil
+		})
+
+		return kubeClient
+	}
+
+	// Setup test cases
+	testCases := []testcase{
+		{
+			name:             "create --name=test --podSelector=service=A --namespace-selectors=name=workload",
+			inputName:        "test",
+			wantName:         "test",
+			inputNamespace:   "",
+			wantNamespace:    "default",
+			inputPodSelector: "service=A",
+			inputNsSelector:  "name=workload",
+			wantNodes:        []string{"A1", "A2"},
+			wantErr:          false,
+		},
+		{
+			name:             "create --namespace=workload --podSelector=service=A --namespace-selectors=name=workload",
+			inputName:        "",
+			wantName:         "retina-capture", // Default name for capture job
+			inputNamespace:   "workload",
+			wantNamespace:    "workload",
+			inputPodSelector: "service=A",
+			inputNsSelector:  "name=workload",
+			wantNodes:        []string{"A1", "A2"},
+			wantErr:          false,
+		},
+		{
+			name:             "create --namespace=workload --podSelector=service=B --namespace-selectors=name=workload",
+			inputName:        "",
+			wantName:         "retina-capture", // Default name for capture job
+			inputNamespace:   "workload",
+			wantNamespace:    "workload",
+			inputPodSelector: "service=B",
+			inputNsSelector:  "name=workload",
+			wantNodes:        []string{"B1", "B2"},
+			wantErr:          false,
+		},
+		{
+			name:              "create --namespace=workload --node-selectors=kubernetes.io/hostname=B1",
+			inputName:         "",
+			wantName:          "retina-capture", // Default name for capture job
+			inputNamespace:    "workload",
+			wantNamespace:     "workload",
+			inputNodeSelector: "kubernetes.io/hostname=B1",
+			wantNodes:         []string{"B1"},
+			wantErr:           false,
+		},
+		{
+			name:              "create --namespace=workload --podSelector=service=B --namespace-selectors=name=workload --node-selectors=kubernetes.io/hostname=B1",
+			inputName:         "",
+			wantName:          "retina-capture", // Default name for capture job
+			inputNamespace:    "workload",
+			wantNamespace:     "workload",
+			inputPodSelector:  "service=B",
+			inputNsSelector:   "name=workload",
+			inputNodeSelector: "kubernetes.io/hostname=B1",
+			wantNodes:         []string{"B1"},
+			wantErr:           true,
+		},
+	}
+	for _, tc := range testCases {
+		fmt.Println("\n### Running test case:", tc.name)
+		// Given
+		kubeClient := newKubeclient()
+		cmd := NewCommand(kubeClient)
+		cmd.SetArgs(argsFromTestCase(tc))
+		buf := new(bytes.Buffer)
+		cmd.SetOut(buf)
+
+		t.Run(tc.name, func(t *testing.T) {
+			// When
+			err := cmd.Execute()
+
+			// Then
+
+			// Check the command execution
+			AssertError(t, err, tc)
+
+			// Validate that jobs are created correctly
+			JobsCreatedCorrectly(t, kubeClient, tc)
+		})
+	}
+}
+
+// AssertError checks if the error matches the expected outcome based on the testcase
+func AssertError(t *testing.T, err error, tc testcase) {
+	t.Helper()
+	if tc.wantErr {
+		if err == nil {
+			t.Fatalf("Expected error for test case %s, but got none", tc.name)
+		}
+		t.Skip("Successfully got expected error")
+	}
+	if err != nil {
+		t.Fatalf("Failed to execute command: %v", err)
+	}
+}
+
+// JobsCreatedCorrectly validates that Kubernetes jobs were created correctly based on the namespace and pod selector flags
+// provided to the command. It verifies that jobs are created in the right namespace and with the correct node affinity.
+func JobsCreatedCorrectly(t *testing.T, kubeClient *fake.Clientset, tc testcase) {
+	t.Helper()
+	// Get created jobs
+	jobs, err := kubeClient.BatchV1().Jobs(tc.wantNamespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", label.CaptureNameLabel, tc.wantName),
+	})
+	// Execution should not return an error
+	if err != nil {
+		t.Fatalf("Failed to list jobs in namespace %s: %v", tc.wantNamespace, err)
+	}
+
+	// Jobs should not be nil or empty
+	if jobs == nil || len(jobs.Items) == 0 {
+		t.Fatalf("No jobs found for capture %s in namespace %s", tc.wantName, tc.wantNamespace)
+	}
+
+	// Number of jobs should match expected number of nodes
+	if len(jobs.Items) != len(tc.wantNodes) {
+		t.Fatalf("Expected %d jobs, but found %d", len(tc.wantNodes), len(jobs.Items))
+	}
+
+	// Create a map of expected nodes for easier comparison
+	expectedNodes := make(map[string]bool)
+	for _, node := range tc.wantNodes {
+		expectedNodes[node] = true
+	}
+	matchCount := 0
+
+	// Validate node affinity for each job
+	for idx := range jobs.Items {
+		job := jobs.Items[idx]
+
+		// Validate node affinity based on pod selector and namespace selector
+		if len(tc.wantNodes) > 0 {
+			if job.Spec.Template.Spec.Affinity == nil || job.Spec.Template.Spec.Affinity.NodeAffinity == nil {
+				t.Fatalf("Expected job to have node affinity, but none found")
+			}
+
+			nodeAffinity := job.Spec.Template.Spec.Affinity.NodeAffinity
+			if nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+				t.Fatalf("Expected job to have required node affinity, but none found")
+			}
+
+			// Look for hostname match expression
+			for _, nodeSelectorTerm := range nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
+				for _, expression := range nodeSelectorTerm.MatchExpressions {
+					if expression.Key == "kubernetes.io/hostname" {
+						// Check if all values are in expected nodes and count matches
+						for _, value := range expression.Values {
+							if expectedNodes[value] {
+								matchCount++
+							} else {
+								t.Errorf("Unexpected node %s in job %s, expected nodes: %v", value, job.Name, tc.wantNodes)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Check if all expected nodes are present
+	if matchCount != len(tc.wantNodes) {
+		t.Errorf("Job's node affinity doesn't match expected nodes. Expected: %v", tc.wantNodes)
+	}
+}

--- a/cli/cmd/capture/delete.go
+++ b/cli/cmd/capture/delete.go
@@ -27,76 +27,66 @@ var deleteExample = templates.Examples(i18n.T(`
 		kubectl retina capture delete --name retina-capture-8v6wd --namespace capture
 		`))
 
-var deleteCapture = &cobra.Command{
-	Use:     "delete",
-	Short:   "Delete a Retina capture",
-	Example: deleteExample,
-	RunE: func(*cobra.Command, []string) error {
-		kubeConfig, err := opts.ToRESTConfig()
-		if err != nil {
-			return errors.Wrap(err, "")
-		}
+func NewDeleteSubCommand(kubeClient kubernetes.Interface) *cobra.Command {
+	deleteCapture := &cobra.Command{
+		Use:     "delete",
+		Short:   "Delete a Retina capture",
+		Example: deleteExample,
+		RunE: func(*cobra.Command, []string) error {
+			ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM)
+			defer cancel()
 
-		kubeClient, err := kubernetes.NewForConfig(kubeConfig)
-		if err != nil {
-			return errors.Wrap(err, "")
-		}
-
-		// Set namespace. If --namespace is not set, use namespace on user's context
-		ns, _, err := opts.ConfigFlags.ToRawKubeConfigLoader().Namespace()
-		if err != nil {
-			return errors.Wrap(err, "failed to get namespace from kubeconfig")
-		}
-
-		if opts.Namespace == nil || *opts.Namespace == "" {
-			opts.Namespace = &ns
-		}
-
-		ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM)
-		defer cancel()
-
-		captureJobSelector := &metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				label.CaptureNameLabel: *opts.Name,
-				label.AppLabel:         captureConstants.CaptureAppname,
-			},
-		}
-		labelSelector, _ := labels.Parse(metav1.FormatLabelSelector(captureJobSelector))
-		jobListOpt := metav1.ListOptions{
-			LabelSelector: labelSelector.String(),
-		}
-
-		jobList, err := kubeClient.BatchV1().Jobs(*opts.Namespace).List(ctx, jobListOpt)
-		if err != nil {
-			return errors.Wrap(err, "failed to list capture jobs")
-		}
-		if len(jobList.Items) == 0 {
-			return errors.Errorf("capture %s in namespace %s was not found", *opts.Name, *opts.Namespace)
-		}
-
-		for _, job := range jobList.Items {
-			deletePropagationBackground := metav1.DeletePropagationBackground
-			if err := kubeClient.BatchV1().Jobs(job.Namespace).Delete(ctx, job.Name, metav1.DeleteOptions{
-				PropagationPolicy: &deletePropagationBackground,
-			}); err != nil {
-				retinacmd.Logger.Info("Failed to delete job", zap.String("job name", job.Name), zap.Error(err))
+			// Set namespace. If --namespace is not set, use namespace on user's context
+			ns, _, err := opts.ConfigFlags.ToRawKubeConfigLoader().Namespace()
+			if err != nil {
+				return errors.Wrap(err, "failed to get namespace from kubeconfig")
 			}
-		}
 
-		for _, volume := range jobList.Items[0].Spec.Template.Spec.Volumes {
-			if volume.Secret != nil {
-				if err := kubeClient.CoreV1().Secrets(*opts.Namespace).Delete(ctx, volume.Secret.SecretName, metav1.DeleteOptions{}); err != nil {
-					return errors.Wrap(err, "failed to delete capture secret")
+			if opts.Namespace == nil || *opts.Namespace == "" {
+				opts.Namespace = &ns
+			}
+
+			captureJobSelector := &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					label.CaptureNameLabel: *opts.Name,
+					label.AppLabel:         captureConstants.CaptureAppname,
+				},
+			}
+			labelSelector, _ := labels.Parse(metav1.FormatLabelSelector(captureJobSelector))
+			jobListOpt := metav1.ListOptions{
+				LabelSelector: labelSelector.String(),
+			}
+
+			jobList, err := kubeClient.BatchV1().Jobs(*opts.Namespace).List(ctx, jobListOpt)
+			if err != nil {
+				return errors.Wrap(err, "failed to list capture jobs")
+			}
+			if len(jobList.Items) == 0 {
+				return errors.Errorf("capture %s in namespace %s was not found", *opts.Name, *opts.Namespace)
+			}
+
+			for idx := range jobList.Items {
+				deletePropagationBackground := metav1.DeletePropagationBackground
+				if err := kubeClient.BatchV1().Jobs(jobList.Items[idx].Namespace).Delete(ctx, jobList.Items[idx].Name, metav1.DeleteOptions{
+					PropagationPolicy: &deletePropagationBackground,
+				}); err != nil {
+					retinacmd.Logger.Info("Failed to delete job", zap.String("job name", jobList.Items[idx].Name), zap.Error(err))
 				}
-				break
 			}
-		}
-		retinacmd.Logger.Info(fmt.Sprintf("Retina Capture %q delete", *opts.Name))
 
-		return nil
-	},
-}
+			for idx := range jobList.Items[0].Spec.Template.Spec.Volumes {
+				if jobList.Items[0].Spec.Template.Spec.Volumes[idx].Secret != nil {
+					if err := kubeClient.CoreV1().Secrets(*opts.Namespace).Delete(ctx, jobList.Items[0].Spec.Template.Spec.Volumes[idx].Secret.SecretName, metav1.DeleteOptions{}); err != nil {
+						return errors.Wrap(err, "failed to delete capture secret")
+					}
+					break
+				}
+			}
+			retinacmd.Logger.Info(fmt.Sprintf("Retina Capture %q delete", *opts.Name))
 
-func NewDeleteSubCommand() *cobra.Command {
+			return nil
+		},
+	}
+
 	return deleteCapture
 }

--- a/cli/cmd/capture/delete.go
+++ b/cli/cmd/capture/delete.go
@@ -97,6 +97,6 @@ var deleteCapture = &cobra.Command{
 	},
 }
 
-func init() {
-	capture.AddCommand(deleteCapture)
+func NewDeleteSubCommand() *cobra.Command {
+	return deleteCapture
 }

--- a/cli/cmd/capture/delete_test.go
+++ b/cli/cmd/capture/delete_test.go
@@ -1,0 +1,192 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package capture
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/microsoft/retina/pkg/label"
+	batchv1 "k8s.io/api/batch/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+const (
+	// Constants for creating test capture jobs
+	defaultCaptureJobName      = "retina-capture-test"
+	defaultCaptureJobNamespace = "workload"
+)
+
+type deleteTestCase struct {
+	name            string
+	inputName       string // name flag for delete
+	inputNamespace  string // namespace flag for delete
+	jobNamespace    string // namespace where the job is expected to be found
+	jobPodSelectors string // pod selectors for the job
+}
+
+// newKubeclient creates a consistent fake Kubernetes client for all tests
+func newKubeclient() *fake.Clientset {
+	objects := []runtime.Object{
+		NewNode("A1"),
+		NewNode("A2"),
+		NewNode("B1"),
+		NewNode("B2"),
+		NewNamespace("default"),
+		NewNamespace("workload"),
+	}
+
+	// Add pods to the client
+	for _, pod := range NewClientServerPods("A", "default") {
+		objects = append(objects, pod)
+	}
+	for _, pod := range NewClientServerPods("B", "workload") {
+		objects = append(objects, pod)
+	}
+
+	kubeClient := fake.NewClientset(objects...)
+
+	// Handle job creation to set job name if not provided, which is done automatically in a real k8s cluster
+	kubeClient.PrependReactor("create", "jobs", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+		createAction, ok := action.(clienttesting.CreateAction)
+		if !ok {
+			return false, nil, fmt.Errorf("expected CreateAction, got %T", action) //nolint:err113 // test code
+		}
+		job := createAction.GetObject().(*batchv1.Job)
+
+		// Set job name if unset
+		if job.Name == "" {
+			job.Name = job.GenerateName + randomString(5)
+		}
+		return false, job, nil
+	})
+
+	return kubeClient
+}
+
+func deleteArgs(tc deleteTestCase) []string {
+	args := []string{"delete"}
+	if tc.inputNamespace != "" {
+		args = append(args, "--namespace", tc.inputNamespace)
+	}
+	if tc.inputName != "" {
+		args = append(args, "--name", tc.inputName)
+	}
+	return args
+}
+
+func createArgs(name, namespace, podSelectors string) []string {
+	// Create a default set of arguments for the create command
+	return []string{
+		"create",
+		"--name=" + name,
+		"--namespace=" + namespace,
+		"--pod-selectors=" + podSelectors,
+		"--namespace-selectors=name=" + namespace,
+	}
+}
+
+func createCapture(t *testing.T, kubeClient kubernetes.Interface, name, namespace, podSelectors string) {
+	createCmd := NewCommand(kubeClient)
+
+	createCmd.SetArgs(createArgs(name, namespace, podSelectors))
+
+	buf := new(bytes.Buffer)
+	createCmd.SetOut(buf)
+
+	err := createCmd.Execute()
+	if err != nil {
+		t.Fatalf("Failed to create capture jobs: %v", err)
+	}
+}
+
+// setupDeleteTest prepares the test environment and creates jobs if needed
+func setupDeleteTest(t *testing.T, tc deleteTestCase) *fake.Clientset {
+	// Create a Kubernetes client with test resources
+	kubeClient := newKubeclient()
+
+	createCapture(t, kubeClient, tc.inputName, tc.jobNamespace, tc.jobPodSelectors)
+	createCapture(t, kubeClient, "do-not-delete", tc.jobNamespace, tc.jobPodSelectors)
+
+	return kubeClient
+}
+
+func jobExists(t *testing.T, kubeClient kubernetes.Interface, name, namespace string) bool {
+	jobs, err := kubeClient.BatchV1().Jobs(namespace).List(
+		context.TODO(),
+		metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("%s=%s", label.CaptureNameLabel, name),
+		},
+	)
+	if err != nil {
+		t.Fatalf("Failed to list jobs in namespace %s: %v", namespace, err)
+	}
+
+	return len(jobs.Items) > 0
+}
+
+// jobDeletedCorrectly validates that Kubernetes jobs were deleted correctly
+func jobDeletedCorrectly(t *testing.T, kubeClient *fake.Clientset, tc deleteTestCase) {
+	t.Helper()
+
+	// Check if the job was deleted as expected
+	if jobExists(t, kubeClient, tc.inputName, tc.inputNamespace) {
+		t.Errorf("Expected job %s to be deleted from namespace %s, but it still exists",
+			tc.inputName, tc.inputNamespace)
+	}
+
+	// Check if the other job in namespace is still present
+	if !jobExists(t, kubeClient, "do-not-delete", tc.inputNamespace) {
+		t.Errorf("Expected job do-not-delete in namespace %s, but it was deleted",
+			tc.inputNamespace)
+	}
+}
+
+func TestDeleteCaptureJobs(t *testing.T) {
+	testCases := []deleteTestCase{
+		{
+			name:            "delete providing name only",
+			inputName:       defaultCaptureJobName,
+			inputNamespace:  "",
+			jobNamespace:    "default",
+			jobPodSelectors: "service=A",
+		},
+		{
+			name:            "delete providing name and namespace",
+			inputName:       defaultCaptureJobName,
+			inputNamespace:  defaultCaptureJobNamespace,
+			jobNamespace:    defaultCaptureJobNamespace,
+			jobPodSelectors: "service=B",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			kubeClient := setupDeleteTest(t, tc)
+
+			// Create a delete command
+			deleteCmd := NewCommand(kubeClient)
+
+			// Set command args
+			deleteCmd.SetArgs(deleteArgs(tc))
+			buf := new(bytes.Buffer)
+			deleteCmd.SetOut(buf)
+
+			// Execute the delete command
+			err := deleteCmd.Execute()
+			if err != nil {
+				t.Fatalf("Failed to delete capture job: %v", err)
+			}
+
+			// Validate job is deleted correctly
+			jobDeletedCorrectly(t, kubeClient, tc)
+		})
+	}
+}

--- a/cli/cmd/capture/list.go
+++ b/cli/cmd/capture/list.go
@@ -25,35 +25,35 @@ var listExample = templates.Examples(i18n.T(`
 		kubectl retina capture list --all-namespaces
 	`))
 
-var listCaptures = &cobra.Command{
-	Use:     "list",
-	Short:   "List Retina Captures",
-	Example: listExample,
-	RunE: func(*cobra.Command, []string) error {
-		kubeConfig, err := opts.ToRESTConfig()
-		if err != nil {
-			return errors.Wrap(err, "failed to compose k8s rest config")
-		}
+func NewListSubCommand() *cobra.Command {
+	listCaptures := &cobra.Command{
+		Use:     "list",
+		Short:   "List Retina Captures",
+		Example: listExample,
+		RunE: func(*cobra.Command, []string) error {
+			kubeConfig, err := opts.ToRESTConfig()
+			if err != nil {
+				return errors.Wrap(err, "failed to compose k8s rest config")
+			}
 
-		kubeClient, err := kubernetes.NewForConfig(kubeConfig)
-		if err != nil {
-			return errors.Wrap(err, "failed to initialize kubernetes client")
-		}
+			kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+			if err != nil {
+				return errors.Wrap(err, "failed to initialize kubernetes client")
+			}
 
-		// Create a context that is canceled when a termination signal is received
-		ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM)
-		defer cancel()
+			// Create a context that is canceled when a termination signal is received
+			ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM)
+			defer cancel()
 
-		captureNamespace := *opts.Namespace
-		if allNamespaces {
-			captureNamespace = ""
-		}
-		return listCapturesInNamespaceAndPrintCaptureResults(ctx, kubeClient, captureNamespace)
-	},
-}
+			captureNamespace := *opts.Namespace
+			if allNamespaces {
+				captureNamespace = ""
+			}
+			return listCapturesInNamespaceAndPrintCaptureResults(ctx, kubeClient, captureNamespace)
+		},
+	}
 
-func init() {
-	capture.AddCommand(listCaptures)
 	listCaptures.Flags().BoolVarP(&allNamespaces, "all-namespaces", "A", allNamespaces,
 		"If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
+	return listCaptures
 }

--- a/cli/cmd/capture/table_util.go
+++ b/cli/cmd/capture/table_util.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-func getCaptureAndPrintCaptureResult(ctx context.Context, kubeClient *kubernetes.Clientset, name, namespace string) error {
+func getCaptureAndPrintCaptureResult(ctx context.Context, kubeClient kubernetes.Interface, name, namespace string) error {
 	return listCapturesAndPrintCaptureResults(ctx, kubeClient, name, namespace)
 }
 
@@ -30,7 +30,7 @@ func listCapturesInNamespaceAndPrintCaptureResults(ctx context.Context, kubeClie
 }
 
 // listCapturesAndPrintCaptureResults list captures and print the running jobs into properly aligned text.
-func listCapturesAndPrintCaptureResults(ctx context.Context, kubeClient *kubernetes.Clientset, name, namespace string) error {
+func listCapturesAndPrintCaptureResults(ctx context.Context, kubeClient kubernetes.Interface, name, namespace string) error {
 	jobListOpt := metav1.ListOptions{}
 	if len(name) != 0 {
 		captureJobSelector := &metav1.LabelSelector{
@@ -87,7 +87,10 @@ func printCaptureResult(captureJobs []batchv1.Job) {
 
 		for i := range jobs {
 			job := &jobs[i]
-			completions := fmt.Sprintf("%d/%d", job.Status.Succeeded, *job.Spec.Completions)
+			var completions string
+			if job.Spec.Completions != nil {
+				completions = fmt.Sprintf("%d/%d", job.Status.Succeeded, *job.Spec.Completions)
+			}
 			age := durationUtil.HumanDuration(time.Since(job.CreationTimestamp.Time))
 			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", captureNamespace, captureName, job.Name, completions, age)
 		}

--- a/cli/main.go
+++ b/cli/main.go
@@ -7,10 +7,16 @@ import (
 	"os"
 
 	"github.com/microsoft/retina/cli/cmd"
-	_ "github.com/microsoft/retina/cli/cmd/capture"
+	"github.com/microsoft/retina/cli/cmd/capture"
 )
 
 func main() {
+	kubeClient, err := capture.GetClientset()
+	if err != nil {
+		fmt.Printf("Failed to get Kubernetes client: %v\n", err)
+		os.Exit(1)
+	}
+	cmd.Retina.AddCommand(capture.NewCommand(kubeClient))
 	if err := cmd.Retina.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
# Description

kubectl-retina CLI does not have e2e tests to validate its behavior. For that, some refactoring is needed.

This PR:
* refactors CLI code to allow injection of fake kubeclient for testing purposes. This allows the creation of tests that can validate that kubernetes resources are created as expected.
* Add some tests for `capture create` and `capture delete` commands to confirm that main arguments are behaving as expected.

Other tests will be added in the future and this code will be a reference for that.

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
