### PR TITLE
chore(shell): add bpftrace to shell image

### DIFF
--- a/docs/06-Troubleshooting/shell.md
+++ b/docs/06-Troubleshooting/shell.md
@@ -4,7 +4,7 @@
 
 The `retina shell` command allows you to start an interactive shell on a Kubernetes node or pod for adhoc debugging.
 
-This runs a container image built from the Dockerfile in the `/shell` directory, with many common networking tools installed (`ping`, `curl`, etc.), as well as specialized tools such as [bpftool](#bpftool), [pwru](#pwru) or [Inspektor Gadget](#inspektor-gadget-ig).
+This runs a container image built from the Dockerfile in the `/shell` directory, with many common networking tools installed (`ping`, `curl`, etc.), as well as specialized tools such as [bpftool](#bpftool), [bpftrace](#bpftrace) [pwru](#pwru) or [Inspektor Gadget](#inspektor-gadget-ig).
 
 Currently the Retina Shell only works in Linux environments. Windows support will be added in the future.
 
@@ -233,6 +233,32 @@ You can then run for example:
 bpftool -h
 bpftool prog show
 bpftool map dump id <map_id>
+```
+
+## [bpftrace](https://bpftrace.org/)
+
+bpftrace is a high-level tracing language for Linux and provides a quick and easy way for people to write observability-based eBPF programs.
+
+Requires the the flags `--mount-host-filesystem`,  `--apparmor-unconfined`, `--seccomp-unconfined`, and the following capabilities:
+
+* `NET_ADMIN`
+* `SYS_ADMIN`
+* `SYS_RESOURCE`
+* `BPF`
+* `MKNOD`
+* `SYS_CHROOT`
+
+```sh
+# e.g. pod debugging
+kubectl retina shell -n kube-system pod/<pod-name> --capabilities=NET_ADMIN,SYS_ADMIN,SYS_RESOURCE,BPF,MKNOD,SYS_CHROOT --mount-host-filesystem --apparmor-unconfined --seccomp-unconfined
+```
+
+You can then run for example:
+
+```shell
+bpftrace --help
+bpftrace -e 'kprobe:tcp_v4_rcv { printf("tcp packet received\n"); }'
+bpftrace -e 'tracepoint:syscalls:sys_enter_connect { printf("connect\n"); }'
 ```
 
 ## [Inspektor Gadget (ig)](https://inspektor-gadget.io/)

--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -28,15 +28,19 @@ RUN tdnf install -y \
 	tar \
 	file \
 	bpftool \
+	bpftrace \
 	ig \
 	&& tdnf clean all
 
-# Create the entrypoint script to mount debugfs
+# Create the entrypoint script to mount debugfs and tracefs
 SHELL ["/bin/bash", "-c"]
 
 RUN echo $'#!/bin/bash\n\
 if ! mountpoint -q /sys/kernel/debug; then\n\
 mount -t debugfs none /sys/kernel/debug\n\
+fi\n\
+if ! mountpoint -q /sys/kernel/tracing; then\n\
+mount -t tracefs tracefs /sys/kernel/tracing\n\
 fi\n\
 exec "$@"' > /usr/local/bin/entrypoint.sh;
 


### PR DESCRIPTION
# Description

Add `bpftrace` to retina shell.

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Tests executed:
```bash
# 1. Build binary with: make retina-shell-image
# 2. Push image to registry

# 3. Run kubectl retina shell:
$ ./artifacts/kubectl-retina shell aks-nodepool1-42816995-vmss000000 --capabilities=NET_ADMIN,SYS_ADMIN,SYS_RESOURCE,BPF,MKNOD,SYS_CHROOT --retina-shell-image-version=v0.0.36-3006-5 --retina-shell-image-repo=ghcr.io/alexcastilio/retina/retina-shell --apparmor-unconfined --seccomp-unconfined --mount-host-filesystem

# 4. bpftrace commands executed:
root@aks-nodepool1-42816995-vmss000000 [ / ]# bpftrace -e 'kprobe:tcp_v4_rcv { printf("tcp packet received\n"); }'
Attaching 1 probe...
tcp packet received
tcp packet received
tcp packet received
tcp packet received
tcp packet received
^C

root@aks-nodepool1-42816995-vmss000000 [ / ]# bpftrace -e 'tracepoint:syscalls:sys_enter_connect { printf("connect\n"); }'
Attaching 1 probe...
connect
connect
connect
connect
connect
connect
connect
connect
connect
^C

# for this test, open another terminal and run some commands that make dns calls (e.g. curl, wget)
root@aks-nodepool1-42816995-vmss000000 [ / ]# bpftrace -e 'uprobe:/usr/lib/libc.so.6:getaddrinfo { @start[tid] = nsecs; } uretprobe:/usr/lib/libc.so.6:getaddrinfo { @latency = hist((nsecs - @start[tid]) / 1000); delete(@start[tid]); }'
Attaching 2 probes...
^C
root@aks-nodepool1-42816995-vmss000000 [ / ]#

@latency:
[2K, 4K)               1 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
[4K, 8K)               1 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
[8K, 16K)              0 |                                                    |
[16K, 32K)             1 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|

```

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
