### PR TITLE
chore(ci): add build kubectl-retina-mcr

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -27,6 +27,28 @@ jobs:
           distribution: goreleaser
           version: latest
           args: build --snapshot --clean
+  build-mcr:
+    name: Build kubectl-retina-mcr
+    if: github.ref_type == 'branch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+      - name: Run GoReleaser build
+        uses: goreleaser/goreleaser-action@v6
+        env:
+          AGENT_IMAGE_NAME: mcr.microsoft.com/containernetworking/retina-agent
+          SUFFIX: -mcr
+        with:
+          distribution: goreleaser
+          version: latest
+          args: build --snapshot --clean
   release:
     name: Release kubectl-retina
     runs-on: ubuntu-latest
@@ -51,3 +73,25 @@ jobs:
       - name: Update new version in krew-index
         if: github.repository_owner == 'microsoft'
         uses: rajatjindal/krew-release-bot@v0.0.47
+    name: Release kubectl-retina-mcr
+    runs-on: ubuntu-latest
+    if: github.ref_type == 'tag'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+      - name: Run GoReleaser release
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          AGENT_IMAGE_NAME: mcr.microsoft.com/containernetworking/retina-agent
+          SUFFIX: -mcr

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,7 +9,7 @@ before:
     - go mod tidy
 
 builds:
-  - binary: kubectl-retina-{{ .Os }}-{{ .Arch }}
+  - binary: kubectl-retina{{.Env.SUFFIX}}-{{ .Os }}-{{ .Arch }}
     env:
       - CGO_ENABLED=0
     goarch:
@@ -23,6 +23,10 @@ builds:
       - darwin
     ldflags:
       - -X github.com/microsoft/retina/internal/buildinfo.Version=v{{.Version}}
+      - >-
+        {{- if index .Env "AGENT_IMAGE_NAME" }}
+          -X github.com/microsoft/retina/internal/buildinfo.RetinaAgentImageName={{.Env.AGENT_IMAGE_NAME}}
+        {{- end }}
     main: cli/main.go
 
 archives:
@@ -30,7 +34,7 @@ archives:
     wrap_in_directory: false
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [ 'zip' ]
 
 changelog:
   sort: asc


### PR DESCRIPTION
# Description

This PR adds to the `goreleaser.yaml` file the necessary steps to build and release the `kubectl-retina-mcr` binary.
This binary references the `mcr.microsoft.com/containernetworking/retina-agent` image.
This PR also updates a deprecated option:
`format: [zip'` -> `formats: [ 'zip' ]`
ref: https://goreleaser.com/deprecations/#archivesformat

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

I tested manually run goreleaser with same environment variables as it should run in pipeline to validate that binary is built and it works as expected:

```bash
# current execution of goreleaser
$ goreleaser build --snapshot --verbose --clean
# ...

$ ./dist/retina_linux_amd64_v1/kubectl-retina-linux-amd64 capture create --host-path ~/ --node-names "aks-nodepool1-17156767-vmss000000" --duration 5s -n default
# ...

$ k get po retina-capture-jtxgw-27l8l -o yaml | grep image:
    image: ghcr.io/microsoft/retina/retina-agent:v0.0.34-SNAPSHOT-91af0fd

# added execution of goreleaser with `AGENT_IMAGE_NAME` and `SUFFIX` env vars:
$ AGENT_IMAGE_NAME=mcr.microsoft.com/containernetworking/retina-agent SUFFIX=-mcr goreleaser build --snapshot --verbose --clean
# ...

$ ./dist/retina_linux_amd64_v1/kubectl-retina-mcr-linux-amd64 capture create --host-path ~/ --node-names "aks-nodepool1-17156767-vmss000000" --duration 5s -n default
# ...

$ k get po retina-capture-mksfb-szsdk -o yaml | grep image:
    image: mcr.microsoft.com/containernetworking/retina-agent:v0.0.34-SNAPSHOT-91af0fd
```

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
