### PR TITLE
fix(ci): goreleaser workflow

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -24,29 +24,7 @@ jobs:
       - name: Run GoReleaser build
         uses: goreleaser/goreleaser-action@v6
         env:
-          SUFFIX: ''
-        with:
-          distribution: goreleaser
-          version: latest
-          args: build --snapshot --clean
-  build-mcr:
-    name: Build kubectl-retina-mcr
-    if: github.ref_type == 'branch'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-      - name: Set up Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          go-version-file: go.mod
-      - name: Run GoReleaser build
-        uses: goreleaser/goreleaser-action@v6
-        env:
-          AGENT_IMAGE_NAME: mcr.microsoft.com/containernetworking/retina-agent
-          SUFFIX: -mcr
+          MCR_AGENT_IMAGE_NAME: mcr.microsoft.com/containernetworking/retina-agent
         with:
           distribution: goreleaser
           version: latest
@@ -72,30 +50,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SUFFIX: ''
+          MCR_AGENT_IMAGE_NAME: mcr.microsoft.com/containernetworking/retina-agent
       - name: Update new version in krew-index
         if: github.repository_owner == 'microsoft'
         uses: rajatjindal/krew-release-bot@v0.0.47
-  release-mcr:
-    name: Release kubectl-retina-mcr
-    runs-on: ubuntu-latest
-    if: github.ref_type == 'tag'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0
-      - name: Set up Go
-        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          go-version-file: go.mod
-      - name: Run GoReleaser release
-        uses: goreleaser/goreleaser-action@v6
-        with:
-          distribution: goreleaser
-          version: latest
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          AGENT_IMAGE_NAME: mcr.microsoft.com/containernetworking/retina-agent
-          SUFFIX: -mcr

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,7 +9,8 @@ before:
     - go mod tidy
 
 builds:
-  - binary: kubectl-retina{{.Env.SUFFIX}}-{{ .Os }}-{{ .Arch }}
+  - binary: kubectl-retina-{{ .Os }}-{{ .Arch }}
+    id: retina
     env:
       - CGO_ENABLED=0
     goarch:
@@ -23,14 +24,38 @@ builds:
       - darwin
     ldflags:
       - -X github.com/microsoft/retina/internal/buildinfo.Version=v{{.Version}}
-      - >-
-        {{- if index .Env "AGENT_IMAGE_NAME" }}
-          -X github.com/microsoft/retina/internal/buildinfo.RetinaAgentImageName={{.Env.AGENT_IMAGE_NAME}}
-        {{- end }}
+    main: cli/main.go
+  - binary: kubectl-retina-mcr-{{ .Os }}-{{ .Arch }}
+    id: retina-mcr
+    env:
+      - CGO_ENABLED=0
+    goarch:
+      - amd64
+      - arm64
+    gcflags:
+      - -dwarflocationlists=true
+    goos:
+      - linux
+      - windows
+      - darwin
+    ldflags:
+      - -X github.com/microsoft/retina/internal/buildinfo.Version=v{{.Version}}
+      - -X github.com/microsoft/retina/internal/buildinfo.RetinaAgentImageName={{.Env.MCR_AGENT_IMAGE_NAME}}
     main: cli/main.go
 
 archives:
   - name_template: "{{ .Binary }}-v{{ .Version }}"
+    id: retina-kubectl
+    ids:
+    - retina
+    wrap_in_directory: false
+    format_overrides:
+      - goos: windows
+        formats: [ 'zip' ]
+  - name_template: "{{ .Binary }}-v{{ .Version }}"
+    id: retina-kubectl-mcr
+    ids:
+    - retina-mcr
     wrap_in_directory: false
     format_overrides:
       - goos: windows


### PR DESCRIPTION
# Description

This PR fixes goreleaser workflow problem introduced at #1695.

`.goreleaser.yaml` 
* declares 2 builds: kubectl-retina (referring to retina image in  ghcr) and kubectl-retina-mcr (referring to retina image in mcr).
* declares 2 archives: one with ghcr binary and another with mcr binary.

goreleaser workflow, runs `goreleaser` to build and release as declared.

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

-

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
