### PR TITLE
chore(shell): add option to Unconfined AppArmor and SecComp profiles

### DIFF
--- a/cli/cmd/shell.go
+++ b/cli/cmd/shell.go
@@ -24,6 +24,8 @@ var (
 	retinaShellImageVersion  string
 	mountHostFilesystem      bool
 	allowHostFilesystemWrite bool
+	appArmorUnconfined       bool
+	seccompUnconfined        bool
 	hostPID                  bool
 	capabilities             []string
 	timeout                  time.Duration
@@ -113,6 +115,8 @@ var shellCmd = &cobra.Command{
 			AllowHostFilesystemWrite: allowHostFilesystemWrite,
 			HostPID:                  hostPID,
 			Capabilities:             capabilities,
+			AppArmorUnconfined:       appArmorUnconfined,
+			SeccompUnconfined:        seccompUnconfined,
 			Timeout:                  timeout,
 		}
 
@@ -163,6 +167,8 @@ func init() {
 	shellCmd.Flags().BoolVar(&hostPID, "host-pid", false, "Set HostPID on the shell container. Applies only to nodes, not pods.")
 	shellCmd.Flags().StringSliceVarP(&capabilities, "capabilities", "c", []string{}, "Add capabilities to the shell container")
 	shellCmd.Flags().DurationVar(&timeout, "timeout", defaultTimeout, "The maximum time to wait for the shell container to start")
+	shellCmd.Flags().BoolVar(&appArmorUnconfined, "apparmor-unconfined", false, "Set AppArmor profile type to unconfined. Applies only to nodes, not pods.")
+	shellCmd.Flags().BoolVar(&seccompUnconfined, "seccomp-unconfined", false, "Set Seccomp profile type to unconfined. Applies only to nodes, not pods.")
 
 	// configFlags and matchVersion flags are used to load kubeconfig.
 	// This uses the same mechanism as `kubectl debug` to connect to apiserver and attach to containers.

--- a/shell/manifests.go
+++ b/shell/manifests.go
@@ -69,6 +69,18 @@ func hostNetworkPodForNodeDebug(config Config, debugPodNamespace, nodeName strin
 		})
 	}
 
+	if config.AppArmorUnconfined {
+		pod.Spec.Containers[0].SecurityContext.AppArmorProfile = &v1.AppArmorProfile{
+			Type: v1.AppArmorProfileTypeUnconfined,
+		}
+	}
+
+	if config.SeccompUnconfined {
+		pod.Spec.Containers[0].SecurityContext.SeccompProfile = &v1.SeccompProfile{
+			Type: v1.SeccompProfileTypeUnconfined,
+		}
+	}
+
 	return pod
 }
 

--- a/shell/shell.go
+++ b/shell/shell.go
@@ -22,6 +22,9 @@ type Config struct {
 	// Host filesystem access applies only to nodes, not pods.
 	MountHostFilesystem      bool
 	AllowHostFilesystemWrite bool
+
+	AppArmorUnconfined bool
+	SeccompUnconfined  bool
 }
 
 // RunInPod starts an interactive shell in a pod by creating and attaching to an ephemeral container.


### PR DESCRIPTION
# Description

Creation option to create retina shell pod with Unconfined [AppArmor](https://kubernetes.io/docs/tutorials/security/apparmor/) and [SecComp](https://kubernetes.io/docs/tutorials/security/seccomp/) Profiles.

Both AppArmor and SecComp are security features that restrict privilege and resource access. By enabling options to create a pod with unconfined profiles, tools that require more privileges can be used in troubleshooting scenarios.

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Manual test:
![image](https://github.com/user-attachments/assets/17808891-6578-414d-b721-109dc0abc759)
![image](https://github.com/user-attachments/assets/740e132a-1e8b-4bfe-b3bb-315649fff674)


## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
