### PR TITLE
refactor: add dockerfile for windows build and make build-binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -346,12 +346,9 @@ all-gen: ## generate all code
 	$(MAKE) proto-gen
 	$(MAKE) go-gen
 
-build-binaries:
-	go build -v -o /go/bin/retina/captureworkload -ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version=$(TAG) -X github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID=$(APP_INSIGHTS_ID)" captureworkload/main.go
-	go build -x -v -o /go/bin/retina/controller -ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version=$(TAG) -X github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID=$(APP_INSIGHTS_ID)" controller/main.go 
-	if [ "$(GOOS)" != "linux" ]; then \
-		go build -v -o /go/bin/retina/initretina -ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version=$(TAG) -X github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID=$(APP_INSIGHTS_ID)" init/retina/main_linux.go; \
-	fi;
+build-windows-binaries:
+	GOOS=windows GOARCH=$(GOARCH) go build -v -o /go/bin/retina/captureworkload -ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version=$(TAG) -X github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID=$(APP_INSIGHTS_ID)" captureworkload/main.go
+	GOOS=windows GOARCH=$(GOARCH) go build -x -v -o /go/bin/retina/controller -ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version=$(TAG) -X github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID=$(APP_INSIGHTS_ID)" controller/main.go
 
 ##@ Multiplatform
 

--- a/Makefile
+++ b/Makefile
@@ -346,6 +346,13 @@ all-gen: ## generate all code
 	$(MAKE) proto-gen
 	$(MAKE) go-gen
 
+build-binaries:
+	go build -v -o /go/bin/retina/captureworkload -ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version=$(TAG) -X github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID=$(APP_INSIGHTS_ID)" captureworkload/main.go
+	go build -x -v -o /go/bin/retina/controller -ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version=$(TAG) -X github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID=$(APP_INSIGHTS_ID)" controller/main.go 
+	if [ "$(GOOS)" != "linux" ]; then \
+		go build -v -o /go/bin/retina/initretina -ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version=$(TAG) -X github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID=$(APP_INSIGHTS_ID)" init/retina/main_linux.go; \
+	fi;
+
 ##@ Multiplatform
 
 manifest-retina-image: ## create a multiplatform manifest for the retina image

--- a/controller/Dockerfile.windows-retina-oss-build
+++ b/controller/Dockerfile.windows-retina-oss-build
@@ -12,12 +12,16 @@ FROM ${OS_VERSION} AS agent-win
 ARG GOARCH=amd64 # default to amd64
 ARG GOOS=windows # default to windows
 ARG OS_VERSION=ltsc2022
+ARG REPO_PATH
+ARG BINARIES_PATH
 ENV GOARCH=${GOARCH}
 ENV GOOS=${GOOS}
 ENV OS_VERSION=${OS_VERSION}
-COPY drop_build_prepare/retina/windows/kubeconfigtemplate.yaml kubeconfigtemplate.yaml
-COPY drop_build_prepare/retina/windows/setkubeconfigpath.ps1 setkubeconfigpath.ps1
-COPY drop_build_agent_win_${GOOS}_${GOARCH}_BinaryBuild/captureworkload.exe captureworkload.exe
-COPY drop_build_agent_win_${GOOS}_${GOARCH}_BinaryBuild/controller.exe controller.exe
+ENV BINARIES_PATH=${BINARIES_PATH}
+ENV REPO_PATH=${REPO_PATH}
+COPY ${REPO_PATH}/retina/windows/kubeconfigtemplate.yaml kubeconfigtemplate.yaml
+COPY ${REPO_PATH}/retina/windows/setkubeconfigpath.ps1 setkubeconfigpath.ps1
+COPY ${BINARIES_PATH}/captureworkload.exe captureworkload.exe
+COPY ${BINARIES_PATH}/controller.exe controller.exe
 ADD https://github.com/microsoft/etl2pcapng/releases/download/v1.10.0/etl2pcapng.exe /etl2pcapng.exe
 CMD ["controller.exe", "start", "--kubeconfig=.\\kubeconfig"]

--- a/controller/Dockerfile.windows-retina-oss-build
+++ b/controller/Dockerfile.windows-retina-oss-build
@@ -1,0 +1,23 @@
+# Only applicable for windows images
+ARG OS_VERSION=ltsc2022
+# pinned base images
+
+# mcr.microsoft.com/windows/servercore:ltsc2019 
+FROM mcr.microsoft.com/windows/servercore@sha256:6fdf140282a2f809dae9b13fe441635867f0a27c33a438771673b8da8f3348a4 AS ltsc2019
+
+# mcr.microsoft.com/windows/servercore:ltsc2022
+FROM mcr.microsoft.com/windows/servercore@sha256:45952938708fbde6ec0b5b94de68bcdec3f8c838be018536b1e9e5bd95e6b943 AS ltsc2022
+
+FROM ${OS_VERSION} AS agent-win
+ARG GOARCH=amd64 # default to amd64
+ARG GOOS=windows # default to windows
+ARG OS_VERSION=ltsc2022
+ENV GOARCH=${GOARCH}
+ENV GOOS=${GOOS}
+ENV OS_VERSION=${OS_VERSION}
+COPY drop_build_prepare/retina/windows/kubeconfigtemplate.yaml kubeconfigtemplate.yaml
+COPY drop_build_prepare/retina/windows/setkubeconfigpath.ps1 setkubeconfigpath.ps1
+COPY drop_build_agent_win_${GOOS}_${GOARCH}_BinaryBuild/captureworkload.exe captureworkload.exe
+COPY drop_build_agent_win_${GOOS}_${GOARCH}_BinaryBuild/controller.exe controller.exe
+ADD https://github.com/microsoft/etl2pcapng/releases/download/v1.10.0/etl2pcapng.exe /etl2pcapng.exe
+CMD ["controller.exe", "start", "--kubeconfig=.\\kubeconfig"]


### PR DESCRIPTION
# Description
We want to separate the windows build into 2 steps
1. Build the binaries needed for the final image
2. Build the final image including the binaries built in step 1

For step 1, add a build-binaries task to the Makefile that builds the binaries needed for the final image.
For step 2, add a Dockerfile for the windows build that builds the final image including the binaries built in step 1

## Related Issue


## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
