### PR TITLE
chore(cli): add inspektor gadget to retina shell

### DIFF
--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -26,7 +26,25 @@ RUN tdnf install -y \
 	tar \
 	file \
 	bpftool \
+	ig \
 	&& tdnf clean all
+
+# Create the entrypoint script to mount debugfs
+SHELL ["/bin/bash", "-c"]
+
+RUN echo $'#!/bin/bash\n\
+if ! mountpoint -q /sys/kernel/debug; then\n\
+mount -t debugfs none /sys/kernel/debug\n\
+fi\n\
+exec "$@"' > /usr/local/bin/entrypoint.sh;
+
+# Set the host root directory for IG
+ENV HOST_ROOT=/host
+
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Set the entrypoint
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
 # Re-use existing arg from Makefile target "container-docker"
 # https://github.com/microsoft/retina/blob/main/Makefile#L224

--- a/shell/README.md
+++ b/shell/README.md
@@ -6,6 +6,7 @@ Retina CLI provides a command to launch an interactive shell in a node or pod fo
 * The container runs an image built from the Dockerfile in this directory. The image is based on Azure Linux and includes commonly-used networking tools.
 * The [pwru](https://github.com/cilium/pwru) tool is bundled in the image for advanced kernel packet tracing.
 * bpftool is also included for eBPF debugging.
+* [Inspektor Gadget (ig)](https://inspektor-gadget.io/) is included for additional debugging capabilities.
 
 For testing, you can override the image used by `retina shell` either with CLI arguments
 (`--retina-shell-image-repo` and `--retina-shell-image-version`) or environment variables
@@ -34,6 +35,28 @@ Once inside the shell, you can run:
 ```sh
 pwru --help
 bpftool --help
+```
+
+To use `ig`, you need to add the `--mount-host-filesystem`,  `--apparmor-unconfined` and `--seccomp-unconfined` flags, along with the following capabilities:
+
+* `NET_ADMIN`
+* `SYS_ADMIN`
+* `SYS_RESOURCE`
+* `SYSLOG`
+* `IPC_LOCK`
+* `SYS_PTRACE`
+* `NET_RAW`
+
+```sh
+# Node debugging
+kubectl retina shell aks-nodepool1-42816995-vmss000001 --capabilities=NET_ADMIN,SYS_ADMIN,SYS_RESOURCE,SYSLOG,IPC_LOCK,SYS_PTRACE,NET_RAW  --mount-host-filesystem --apparmor-unconfined --seccomp-unconfined
+```
+
+Once inside the shell, you can run:
+
+```sh
+ig -h
+ig run trace_dns:latest
 ```
 
 Currently only Linux is supported; Windows support will be added in the future.

--- a/shell/manifests.go
+++ b/shell/manifests.go
@@ -54,19 +54,35 @@ func hostNetworkPodForNodeDebug(config Config, debugPodNamespace, nodeName strin
 	}
 
 	if config.MountHostFilesystem || config.AllowHostFilesystemWrite {
-		pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
-			Name: "host-filesystem",
-			VolumeSource: v1.VolumeSource{
-				HostPath: &v1.HostPathVolumeSource{
-					Path: "/",
+		pod.Spec.Volumes = append(pod.Spec.Volumes,
+			v1.Volume{
+				Name: "host-filesystem",
+				VolumeSource: v1.VolumeSource{
+					HostPath: &v1.HostPathVolumeSource{
+						Path: "/",
+					},
 				},
 			},
-		})
-		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, v1.VolumeMount{
-			Name:      "host-filesystem",
-			MountPath: "/host",
-			ReadOnly:  !config.AllowHostFilesystemWrite,
-		})
+			v1.Volume{
+				Name: "run",
+				VolumeSource: v1.VolumeSource{
+					HostPath: &v1.HostPathVolumeSource{
+						Path: "/run",
+					},
+				},
+			},
+		)
+		pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts,
+			v1.VolumeMount{
+				Name:      "host-filesystem",
+				MountPath: "/host",
+				ReadOnly:  !config.AllowHostFilesystemWrite,
+			},
+			v1.VolumeMount{
+				Name:      "run",
+				MountPath: "/run",
+			},
+		)
 	}
 
 	if config.AppArmorUnconfined {

--- a/shell/manifests_test.go
+++ b/shell/manifests_test.go
@@ -68,12 +68,15 @@ func TestHostNetworkPodForNodeDebugWithMountHostFilesystem(t *testing.T) {
 		MountHostFilesystem: true,
 	}
 	pod := hostNetworkPodForNodeDebug(config, "kube-system", "node0001")
-	assert.Len(t, pod.Spec.Volumes, 1)
+	assert.Len(t, pod.Spec.Volumes, 2)
 	assert.Equal(t, "host-filesystem", pod.Spec.Volumes[0].Name)
-	assert.Len(t, pod.Spec.Containers[0].VolumeMounts, 1)
+	assert.Len(t, pod.Spec.Containers[0].VolumeMounts, 2)
 	assert.Equal(t, "host-filesystem", pod.Spec.Containers[0].VolumeMounts[0].Name)
 	assert.Equal(t, "/host", pod.Spec.Containers[0].VolumeMounts[0].MountPath)
+	assert.Equal(t, "run", pod.Spec.Containers[0].VolumeMounts[1].Name)
+	assert.Equal(t, "/run", pod.Spec.Containers[0].VolumeMounts[1].MountPath)
 	assert.True(t, pod.Spec.Containers[0].VolumeMounts[0].ReadOnly)
+	assert.False(t, pod.Spec.Containers[0].VolumeMounts[1].ReadOnly)
 }
 
 func TestHostNetworkPodForNodeDebugWithMountHostFilesystemWithWriteAccess(t *testing.T) {
@@ -82,10 +85,13 @@ func TestHostNetworkPodForNodeDebugWithMountHostFilesystemWithWriteAccess(t *tes
 		AllowHostFilesystemWrite: true,
 	}
 	pod := hostNetworkPodForNodeDebug(config, "kube-system", "node0001")
-	assert.Len(t, pod.Spec.Volumes, 1)
+	assert.Len(t, pod.Spec.Volumes, 2)
 	assert.Equal(t, "host-filesystem", pod.Spec.Volumes[0].Name)
-	assert.Len(t, pod.Spec.Containers[0].VolumeMounts, 1)
+	assert.Len(t, pod.Spec.Containers[0].VolumeMounts, 2)
 	assert.Equal(t, "host-filesystem", pod.Spec.Containers[0].VolumeMounts[0].Name)
 	assert.Equal(t, "/host", pod.Spec.Containers[0].VolumeMounts[0].MountPath)
+	assert.Equal(t, "run", pod.Spec.Containers[0].VolumeMounts[1].Name)
+	assert.Equal(t, "/run", pod.Spec.Containers[0].VolumeMounts[1].MountPath)
 	assert.False(t, pod.Spec.Containers[0].VolumeMounts[0].ReadOnly)
+	assert.False(t, pod.Spec.Containers[0].VolumeMounts[1].ReadOnly)
 }


### PR DESCRIPTION
# Description

Add inspektor gadget to retina shell.

Changes:
* Add script to run before bash at creation of pod to mount `debugfs`
* Install IG + configure `HOST_ROOT` environment variable
* Mount Volume `/run` from host for IG to access runtime data

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

```bash
# Run Retina Shell
..

# test 1:
root@aks-nodepool1-42816995-vmss000001 [ / ]# ig run top_tcp:latest | head
RUNTIME.CONTAINERNAME                       PID              TID SRC                                      DST                                      COMM                   SENT   RECEIVED
RUNTIME.CONTAINERNAME                       PID              TID SRC                                      DST                                      COMM                   SENT   RECEIVED
fortio                                  1744204          1829243 10.244.2.74:41792                        10.0.37.29:8080                          fortio                  0 B       75 B
fortio                                  1744204          1744223 10.244.2.74:42912                        10.0.37.29:8080                          fortio                 92 B        0 B
fortio                                  1744111          1744138 10.244.2.154:8080                        10.244.2.74:43864                        fortio                 75 B       92 B
fortio                                  1744204          1744223 10.244.2.74:55912                        10.0.37.29:8080                          fortio                 92 B        0 B
fortio                                  1744204          1829243 10.244.2.74:37872                        10.0.37.29:8080                          fortio                 92 B        0 B
fortio                                  1744204          3662728 10.244.2.74:36794                        10.0.37.29:8080                          fortio                 92 B        0 B
fortio                                  1744111          1744138 10.244.2.154:8080                        10.244.2.74:57910                        fortio                 75 B       92 B
fortio                                  1744111          1745004 10.244.2.154:8080                        10.244.2.74:43806                        fortio                 75 B       92 B

# test2:
root@aks-nodepool1-42816995-vmss000001 [ / ]# ig run trace_dns:latest
RUNTIME.CONTAINΓÇª SRC                    DST                    NAMESERVΓÇª COMM          PID      TID QR QTYPE    NAME            RCODE    ADDRESSΓÇª LATENCY_NS
grafana-sc-datas 10.244.2.183:55535     10.0.0.10:53           10.0.0.10 python    1754576  1754576 Q  A        lx-retina--lx-ΓÇª                          0ns
coredns          10.244.2.183:55535     10.244.2.103:53        10.244.2ΓÇª coredns   4067854  4067854 Q  A        lx-retina--lx-ΓÇª                          0ns
grafana-sc-datas 10.244.2.183:55535     10.0.0.10:53           10.0.0.10 python    1754576  1754576 Q  AAAA     lx-retina--lx-ΓÇª                          0ns
coredns          10.244.2.183:55535     10.244.2.103:53        10.244.2ΓÇª coredns   4067854  4067854 Q  AAAA     lx-retina--lx-ΓÇª                          0ns
coredns          10.244.2.103:53        10.244.2.183:55535     10.244.2ΓÇª coredns   4067854  4067854 R  A        lx-retina--lx-ΓÇª NameErrΓÇª                 0ns
grafana-sc-datas 10.0.0.10:53           10.244.2.183:55535     10.0.0.10 python    1754576  1754576 R  A        lx-retina--lx-ΓÇª NameErrΓÇª            610.10┬╡s
coredns          10.244.2.103:53        10.244.2.183:55535     10.244.2ΓÇª coredns   4067854  4067854 R  AAAA     lx-retina--lx-ΓÇª NameErrΓÇª                 0ns
grafana-sc-datas 10.0.0.10:53           10.244.2.183:55535     10.0.0.10 python    1754576  1754576 R  AAAA     lx-retina--lx-ΓÇª NameErrΓÇª            602.50┬╡s
grafana-sc-datas 10.244.2.183:45814     10.0.0.10:53           10.0.0.10 python    1754576  1754576 Q  A        lx-retina--lx-ΓÇª                          0ns
grafana-sc-datas 10.244.2.183:45814     10.0.0.10:53           10.0.0.10 python    1754576  1754576 Q  AAAA     lx-retina--lx-ΓÇª                          0ns
grafana-sc-datas 10.0.0.10:53           10.244.2.183:45814     10.0.0.10 python    1754576  1754576 R  A        lx-retina--lx-ΓÇª NameErrΓÇª              1.58ms
grafana-sc-datas 10.0.0.10:53           10.244.2.183:45814     10.0.0.10 python    1754576  1754576 R  AAAA     lx-retina--lx-ΓÇª NameErrΓÇª              1.53ms
grafana-sc-datas 10.244.2.183:43535     10.0.0.10:53           10.0.0.10 python    1754576  1754576 Q  A        lx-retina--lx-ΓÇª                          0ns
coredns          10.244.2.183:43535     10.244.2.103:53        10.244.2ΓÇª coredns   4067854  4067854 Q  A        lx-retina--lx-ΓÇª                          0ns
grafana-sc-datas 10.244.2.183:43535     10.0.0.10:53           10.0.0.10 python    1754576  1754576 Q  AAAA     lx-retina--lx-ΓÇª                          0ns
coredns          10.244.2.183:43535     10.244.2.103:53        10.244.2ΓÇª coredns   4067854  4067854 Q  AAAA     lx-retina--lx-ΓÇª                          0ns
coredns          10.244.2.103:53        10.244.2.183:43535     10.244.2ΓÇª coredns   4067854  4067854 R  A        lx-retina--lx-ΓÇª NameErrΓÇª                 0ns
grafana-sc-datas 10.0.0.10:53           10.244.2.183:43535     10.0.0.10 python    1754576  1754576 R  A        lx-retina--lx-ΓÇª NameErrΓÇª            494.40┬╡s
coredns          10.244.2.103:53        10.244.2.183:43535     10.244.2ΓÇª coredns   4067854  4067854 R  AAAA     lx-retina--lx-ΓÇª NameErrΓÇª                 0ns
grafana-sc-datas 10.0.0.10:53           10.244.2.183:43535     10.0.0.10 python    1754576  1754576 R  AAAA     lx-retina--lx-ΓÇª NameErrΓÇª            661.40┬╡s
grafana-sc-datas 10.244.2.183:47847     10.0.0.10:53           10.0.0.10 python    1754576  1754576 Q  A        lx-retina--lx-ΓÇª                          0ns
coredns          10.244.2.183:47847     10.244.2.103:53        10.244.2ΓÇª coredns   4067854  4067854 Q  A        lx-retina--lx-ΓÇª                          0ns
grafana-sc-datas 10.244.2.183:47847     10.0.0.10:53           10.0.0.10 python    1754576  1754576 Q  AAAA     lx-retina--lx-ΓÇª                          0ns
coredns          10.244.2.183:47847     10.244.2.103:53        10.244.2ΓÇª coredns   4067854  4067854 Q  AAAA     lx-retina--lx-ΓÇª                          0ns
coredns          10.244.2.103:53        10.244.2.183:47847     10.244.2ΓÇª coredns   4067854  4067854 R  AAAA     lx-retina--lx-ΓÇª NameErrΓÇª                 0ns
grafana-sc-datas 10.0.0.10:53           10.244.2.183:47847     10.0.0.10 python    1754576  1754576 R  AAAA     lx-retina--lx-ΓÇª NameErrΓÇª            640.60┬╡s
grafana-sc-datas 10.244.2.183:60938     10.0.0.10:53           10.0.0.10 python    1754576  1754576 Q  A        lx-retina--lx-ΓÇª                          0ns
coredns          10.244.2.183:60938     10.244.2.103:53        10.244.2ΓÇª coredns   4067854  4067854 Q  A        lx-retina--lx-ΓÇª                          0ns
grafana-sc-datas 10.244.2.183:60938     10.0.0.10:53           10.0.0.10 python    1754576  1754576 Q  AAAA     lx-retina--lx-ΓÇª                          0ns
coredns          10.244.2.183:60938     10.244.2.103:53        10.244.2ΓÇª coredns   4067854  4067854 Q  AAAA     lx-retina--lx-ΓÇª                          0ns
coredns          10.244.2.103:53        10.244.2.183:47847     10.244.2ΓÇª coredns   4067854  4067854 R  A        lx-retina--lx-ΓÇª NameErrΓÇª                 0ns
grafana-sc-datas 10.0.0.10:53           10.244.2.183:47847     10.0.0.10 python    1754576  1754576 R  A        lx-retina--lx-ΓÇª NameErrΓÇª              1.81ms
coredns          10.244.2.103:45118     168.63.129.16:53       168.63.1ΓÇª coredns   4067854  4078662 Q  AAAA     lx-retina--lx-ΓÇª                          0ns
coredns          10.244.2.103:41727     168.63.129.16:53       168.63.1ΓÇª coredns   4067854  4078662 Q  A        lx-retina--lx-ΓÇª                          0ns
coredns          168.63.129.16:53       10.244.2.103:45118     168.63.1ΓÇª coredns   4067854  4078662 R  AAAA     lx-retina--lx-ΓÇª Success               3.03ms
coredns          10.244.2.103:53        10.244.2.183:60938     10.244.2ΓÇª coredns   4067854  4067854 R  AAAA     lx-retina--lx-ΓÇª Success                  0ns
grafana-sc-datas 10.0.0.10:53           10.244.2.183:60938     10.0.0.10 python    1754576  1754576 R  AAAA     lx-retina--lx-ΓÇª Success               4.30ms
coredns          10.244.2.103:53        10.244.2.183:60938     10.244.2ΓÇª coredns   4067854  4067854 R  A        lx-retina--lx-ΓÇª Success  172.179ΓÇª        0ns
grafana-sc-datas 10.0.0.10:53           10.244.2.183:60938     10.0.0.10 python    1754576  1754576 R  A        lx-retina--lx-ΓÇª Success  172.179ΓÇª     4.66ms
coredns          168.63.129.16:53       10.244.2.103:41727     168.63.1ΓÇª coredns   4067854  4078662 R  A        lx-retina--lx-ΓÇª Success  172.179ΓÇª     3.21ms

# test 3:
root@aks-nodepool1-42816995-vmss000001 [ / ]# ig run top_process:latest
RUNTIME.CONTAINERNAME            PID COMM          CPUUSAGE CPUUSAGERELAΓÇª     MEMORYRSS MEMORYVIRTUAL MEMORYRELATΓÇª THREADCOUNT STATE        UID STARTTIMESTR
RUNTIME.CONTAINERNAME            PID COMM          CPUUSAGE CPUUSAGERELAΓÇª     MEMORYRSS MEMORYVIRTUAL MEMORYRELATΓÇª THREADCOUNT STATE        UID STARTTIMESTR
                                   1 systemd            0.0           0.0      14483456     172789760          0.1           1 S              0 ΓÇª0T10:07:15Z
                                  10 mm_percpu_wq       0.0           0.0             0             0          0.0           1 I              0 ΓÇª0T10:07:16Z
                                 100 watchdogd          0.0           0.0             0             0          0.0           1 S              0 ΓÇª0T10:07:16Z
                               10174 node-problem-      0.0           0.0       3604480       8085504          0.0           1 S              0 ΓÇª0T10:11:45Z
                                 103 kworker/0:1H-      0.0           0.0             0             0          0.0           1 I              0 ΓÇª0T10:07:16Z
                                 105 kswapd0            0.0           0.0             0             0          0.0           1 S              0 ΓÇª0T10:07:16Z
                               10589 node-exporter      0.0           0.0        974848       2961408          0.0           1 S              0 ΓÇª0T10:11:47Z
                               10224 node-problem-      0.0           0.0      82599936    3172532224          0.5          15 S              0 ΓÇª0T10:11:45Z
                                 108 kthrotld           0.0           0.0             0             0          0.0           1 I              0 ΓÇª0T10:07:16Z
                                 106 ecryptfs-kthr      0.0           0.0             0             0          0.0           1 S              0 ΓÇª0T10:07:16Z
                                 109 nfit               0.0           0.0             0             0          0.0           1 I              0 ΓÇª0T10:07:16Z
                                  11 rcu_tasks_rud      0.0           0.0             0             0          0.0           1 S              0 ΓÇª0T10:07:16Z
                                 111 scsi_eh_0          0.0           0.0             0             0          0.0           1 S              0 ΓÇª0T10:07:17Z
                                 114 scsi_eh_1          0.0           0.0             0             0          0.0           1 S              0 ΓÇª0T10:07:17Z
                                 112 nvme-wq            0.0           0.0             0             0          0.0           1 I              0 ΓÇª0T10:07:17Z
                                 115 scsi_tmf_0         0.0           0.0             0             0          0.0           1 I              0 ΓÇª0T10:07:17Z
                                 118 scsi_tmf_1         0.0           0.0             0             0          0.0           1 I              0 ΓÇª0T10:07:17Z
                                 117 scsi_eh_2          0.0           0.0             0             0          0.0           1 S              0 ΓÇª0T10:07:17Z
                                 119 nvme-reset-wq      0.0           0.0             0             0          0.0           1 I              0 ΓÇª0T10:07:17Z
                                  12 rcu_tasks_tra      0.0           0.0             0             0          0.0           1 S              0 ΓÇª0T10:07:16Z
                                 120 scsi_eh_3          0.0           0.0             0             0          0.0           1 S              0 ΓÇª0T10:07:17Z
                                 121 scsi_tmf_2         0.0           0.0             0             0          0.0           1 I              0 ΓÇª0T10:07:17Z
                                 122 nvme-delete-w      0.0           0.0             0             0          0.0           1 I              0 ΓÇª0T10:07:17Z
                                 123 scsi_tmf_3         0.0           0.0             0             0          0.0           1 I              0 ΓÇª0T10:07:17Z
                                 124 scsi_eh_4          0.0           0.0             0             0          0.0           1 S              0 ΓÇª0T10:07:17Z
                                 125 scsi_tmf_4         0.0           0.0             0             0          0.0           1 I              0 ΓÇª0T10:07:17Z
                                 126 scsi_eh_5          0.0           0.0             0             0          0.0           1 S              0 ΓÇª0T10:07:17Z
                                 127 scsi_tmf_5         0.0           0.0             0             0          0.0           1 I              0 ΓÇª0T10:07:17Z
                                 128 kworker/1:1H-      0.0           0.0             0             0          0.0           1 I              0 ΓÇª0T10:07:17Z
                                 129 vfio-irqfd-cl      0.0           0.0             0             0          0.0           1 I              0 ΓÇª0T10:07:17Z
                                  13 ksoftirqd/0        0.0           0.0             0             0          0.0           1 S              0 ΓÇª0T10:07:16Z
                                 133 hv_balloon         0.0           0.0             0             0          0.0           1 S              0 ΓÇª0T10:07:17Z
                                 134 mld                0.0           0.0             0             0          0.0           1 I              0 ΓÇª0T10:07:17Z
                                 135 kworker/3:1H-      0.0           0.0             0             0          0.0           1 I              0 ΓÇª0T10:07:17Z
                                 136 ipv6_addrconf      0.0           0.0             0             0          0.0           1 I              0 ΓÇª0T10:07:17Z
                                  14 rcu_sched          0.0           0.0             0             0          0.0           1 I              0 ΓÇª0T10:07:16Z
                                 145 kstrp              0.0           0.0             0             0          0.0           1 I              0 ΓÇª0T10:07:17Z
                                  15 migration/0        0.0           0.0             0             0          0.0           1 S              0 ΓÇª0T10:07:16Z
                                 148 zswap-shrink       0.0           0.0             0             0          0.0           1 I              0 ΓÇª0T10:07:17Z
                                 149 kworker/u9:0       0.0           0.0             0             0          0.0           1 I              0 ΓÇª0T10:07:17Z
                                 154 jbd2/sda1-8        0.0           0.0             0             0          0.0           1 S              0 ΓÇª0T10:07:18Z
                             1541728 kworker/u8:3-      0.0           0.0             0             0          0.0           1 I              0 ΓÇª3T13:06:10Z
                                 155 ext4-rsv-conv      0.0           0.0             0             0          0.0           1 I              0 ΓÇª0T10:07:18Z
                             1618879 sleep              0.0           0.0       1044480       6340608          0.0           1 S              0 ΓÇª3T14:08:09Z
                             1656992 kworker/1:1-e      0.0           0.0             0             0          0.0           1 I              0 ΓÇª3T14:38:28Z
                             1653373 kworker/0:2-c      0.0           0.0             0             0          0.0           1 I              0 ΓÇª3T14:35:03Z
                             1662165 kworker/2:3-e      0.0           0.0             0             0          0.0           1 I              0 ΓÇª3T14:42:00Z
                             1662837 kworker/3:2-e      0.0           0.0             0             0          0.0           1 I              0 ΓÇª3T14:42:39Z
                             1662164 kworker/2:1-e      0.0           0.0             0             0          0.0           1 I              0 ΓÇª3T14:42:00Z
                             1671525 kworker/3:0-e      0.0           0.0             0             0          0.0           1 I              0 ΓÇª3T14:50:01Z
                             1671326 kworker/1:3-e      0.0           0.0             0             0          0.0           1 I              0 ΓÇª3T14:50:00Z
                             1675970 kworker/u8:1-      0.0           0.0             0             0          0.0           1 I              0 ΓÇª3T14:53:28Z
                             1675971 kworker/u8:5-      0.0           0.0             0             0          0.0           1 I              0 ΓÇª3T14:53:28Z
                             1675972 kworker/u8:6-      0.0           0.0             0             0          0.0           1 I              0 ΓÇª3T14:53:28Z
                             1679482 containerd-sh      0.0           0.0      15396864    1267671040          0.1          13 S              0 ΓÇª3T14:56:09Z
retina-shell                 1679552 bash               0.0           0.0       5128192       6201344          0.0           1 S              0 ΓÇª3T14:56:10Z
                             1679504 pause              0.0           0.0          4096        995328          0.0           1 S          65535 ΓÇª3T14:56:10Z
                             1679931 kworker/1:0-e      0.0           0.0             0             0          0.0           1 I              0 ΓÇª3T14:56:32Z
                             1680124 kworker/1:2-e      0.0           0.0             0             0          0.0           1 I              0 ΓÇª3T14:56:45Z
                             1680813 kworker/1:4-e      0.0           0.0             0             0          0.0           1 I              0 ΓÇª3T14:57:10Z
                             1685035 kworker/u8:0-      0.0           0.0             0             0          0.0           1 I              0 ΓÇª3T15:00:24Z
                             1681613 kworker/0:3-a      0.0           0.0             0             0          0.0           1 I              0 ΓÇª3T14:57:55Z
                             1680814 kworker/1:5-e      0.0           0.0             0             0          0.0           1 I              0 ΓÇª3T14:57:10Z

# test4: 
root@aks-nodepool1-42816995-vmss000001 [ / ]# ig run profile_cpu:latest --map-fetch-interval 0
^CWARN[0009] stack with ID 4294967282 is lost: lookup: key does not exist
WARN[0009] stack with ID 4294967282 is lost: lookup: key does not exist
WARN[0009] stack with ID 4294967282 is lost: lookup: key does not exist
WARN[0009] stack with ID 4294967282 is lost: lookup: key does not exist
WARN[0009] stack with ID 4294967282 is lost: lookup: key does not exist
WARN[0009] stack with ID 4294967282 is lost: lookup: key does not exist
WARN[0009] stack with ID 4294967282 is lost: lookup: key does not exist
WARN[0009] stack with ID 4294967282 is lost: lookup: key does not exist
WARN[0009] stack with ID 4294967282 is lost: lookup: key does not exist
WARN[0009] stack with ID 4294967282 is lost: lookup: key does not exist
WARN[0009] stack with ID 4294967282 is lost: lookup: key does not exist
WARN[0009] stack with ID 4294967282 is lost: lookup: key does not exist
WARN[0009] stack with ID 4294967282 is lost: lookup: key does not exist
WARN[0009] stack with ID 4294967282 is lost: lookup: key does not exist
WARN[0009] stack with ID 4294967282 is lost: lookup: key does not exist
WARN[0009] stack with ID 4294967282 is lost: lookup: key does not exist
WARN[0009] stack with ID 4294967282 is lost: lookup: key does not exist
WARN[0009] stack with ID 4294967282 is lost: lookup: key does not exist
WARN[0009] stack with ID 4294967282 is lost: lookup: key does not exist
RUNTIME.CONTAINERNAME                             KERNEL_IP            COMM                    PID        TID SAMPLES              KERN_STACK
fortio                                            18446744072009756834 fortio              1744204    1744218 8                    [0]finish_task_switch.isΓÇª
fortio                                            18446744072022862826 fortio              1744111    1744139 2                    [0]__lock_text_start; [1ΓÇª
fortio                                            18446744072009756834 fortio              1744204    1744218 1                    [0]finish_task_switch.isΓÇª
fortio                                            18446744072008772157 fortio              1744204    1829243 1                    [0]x64_sys_call; [1]entrΓÇª
konnectivity-agent                                18446744072647485403 proxy-agent           20071      20614 1                    [0]bpf_prog_c692d192a4d1ΓÇª
fortio                                            18446744072022862826 fortio              1744111    1744137 1                    [0]__lock_text_start; [1ΓÇª
fortio                                            0                    fortio              1744111    1744225 11
fortio                                            18446744072022862826 fortio              1744204    3662728 3                    [0]__lock_text_start; [1ΓÇª
fortio                                            18446744072010367488 fortio              1744111    1965298 1                    [0]futex_wait_queue_me; ΓÇª
fortio                                            18446744072020699733 fortio              1744204    1744226 1                    [0]ip_finish_output2; [1ΓÇª
fortio                                            18446744072019852461 fortio              1744111    1744139 1                    [0]skb_release_data; [1]ΓÇª
fortio                                            0                    fortio              1744111    1744575 6
fortio                                            18446744072010235760 fortio              1744204    1829243 1                    [0]syscall_trace_enter.cΓÇª
fortio                                            18446744072022805100 fortio              1744111    1744137 1                    [0]syscall_enter_from_usΓÇª
fortio                                            0                    fortio              1744111    1744651 9
fortio                                            18446744072020699544 fortio              1744111    1744225 1                    [0]ip_finish_output2; [1ΓÇª
fortio                                            18446744072010270080 fortio              1744111    1744575 1                    [0]hrtimer_try_to_cancelΓÇª
fortio                                            18446744072012664714 fortio              1744111    1744651 1                    [0]__fget_light; [1]do_eΓÇª
fortio                                            18446744072649004944 fortio              1744111    1744225 1                    [0]bpf_prog_c692d192a4d1ΓÇª
fortio                                            18446744072009756834 fortio              1744111    1744651 1                    [0]finish_task_switch.isΓÇª
fortio                                            18446744072021103375 fortio              1744204    1744223 1                    [0]fib_table_lookup; [1]ΓÇª
fortio                                            18446744072020847664 fortio              1744111    1744225 1                    [0]tcp_small_queue_checkΓÇª
fortio                                            18446744072647501157 fortio              1744111    1744651 1                    [0]bpf_prog_c692d192a4d1ΓÇª
fortio                                            18446744072019978352 fortio              1744111    1744651 1                    [0]dev_queue_xmit; [1]ipΓÇª
fortio                                            18446744072020844671 fortio              1744204    1744226 1                    [0]tcp_event_new_data_seΓÇª
fortio                                            18446744072022862826 fortio              1744204    1744223 2                    [0]__lock_text_start; [1ΓÇª
coredns                                           18446744072019784970 coredns             4067854    4067908 1                    [0]sock_recvmsg; [1]sockΓÇª
fortio                                            18446744072010604336 fortio              1744111    1744225 1                    [0]audit_filter_syscall;ΓÇª
fortio                                            18446744072020129911 fortio              1744204    1829243 1                    [0]sk_filter_trim_cap; [ΓÇª
fortio                                            18446744072012405713 fortio              1744204    1744223 1                    [0]mem_cgroup_charge_skmΓÇª
fortio                                            18446744072015392176 fortio              1744111    1965298 1                    [0]_copy_from_user; [1]_ΓÇª
fortio                                            18446744072020896941 fortio              1744111    1744575 1                    [0]tcp_v4_do_rcv; [1]tcpΓÇª
konnectivity-agent                                0                    proxy-agent           20071      20071 1
fortio                                            18446744072014241172 fortio              1744204    3662728 1                    [0]security_sock_rcv_skbΓÇª
node-driver-registrar                             0                    runc:[2:INIT]       1689249    1689249 1
fortio                                            18446744072010236990 fortio              1744111    1744137 1                    [0]syscall_exit_work; [1ΓÇª
fortio                                            0                    fortio              1744204    1744223 3
fortio                                            0                    fortio              1744111    1965298 14

```

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
