### PR TITLE
Consume latest RetinaEbpfApi; Add lost events API; Update struct processing due to latest RetinaEbpfApi changes

### DIFF
--- a/.github/workflows/e2e-test-event-writer.yml
+++ b/.github/workflows/e2e-test-event-writer.yml
@@ -52,9 +52,19 @@ jobs:
         run: |
           echo "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
-      - name: Set standalone LLVM path
+      - name: Install LLVM 18.1.8
+        shell: pwsh
         run: |
-          echo "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          # Install LLVM 18.1.8 to ensure consistent version across runners
+          try {
+            choco install llvm --version=18.1.8 --allow-downgrade -y --force
+            # Add installed LLVM to PATH first so it takes precedence
+            echo "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+            Write-Host "Successfully installed LLVM 18.1.8"
+          } catch {
+            Write-Warning "Failed to install LLVM 18.1.8 via chocolatey: $($_.Exception.Message)"
+            Write-Host "Continuing with pre-installed LLVM version"
+          }
 
       - name: Nuget Restore
         shell: cmd

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -48,7 +48,7 @@ RUN if [ "$GOOS" = "linux" ] ; then \
 FROM golang AS eBPFRetinaStage
 WORKDIR /tmp
 RUN tdnf install -y unzip && \
-    curl -L -o eBPFRetina.zip https://www.nuget.org/api/v2/package/Microsoft.Wcn.Observability.eBPF.Retina.x64/0.1.0-prerelease.9 && \
+    curl -L -o eBPFRetina.zip https://www.nuget.org/api/v2/package/Microsoft.Wcn.Observability.eBPF.Retina.x64/0.1.0-prerelease.11 && \
     unzip -d eBPFRetina eBPFRetina.zip || exit 0 && \
     if [ ! -d "eBPFRetina" ]; then echo "eBPFRetina directory not found after unzip!" && exit 1; fi
 

--- a/controller/Dockerfile.windows-native
+++ b/controller/Dockerfile.windows-native
@@ -27,7 +27,7 @@ FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:
 FROM golang AS eBPFRetinaStage
 WORKDIR /tmp
 RUN tdnf install -y unzip && \
-    curl -L -o eBPFRetina.zip https://www.nuget.org/api/v2/package/Microsoft.Wcn.Observability.eBPF.Retina.x64/0.1.0-prerelease.9 && \
+    curl -L -o eBPFRetina.zip https://www.nuget.org/api/v2/package/Microsoft.Wcn.Observability.eBPF.Retina.x64/0.1.0-prerelease.11 && \
     unzip -d eBPFRetina eBPFRetina.zip || exit 0 && \
     if [ ! -d "eBPFRetina" ]; then echo "eBPFRetina directory not found after unzip!" && exit 1; fi
 

--- a/pkg/plugin/ebpfwindows/ebpf_windows.go
+++ b/pkg/plugin/ebpfwindows/ebpf_windows.go
@@ -119,6 +119,8 @@ func (p *Plugin) metricsMapIterateCallback(key *MetricsKey, value *MetricsValue)
 		} else if key.IsIngress() {
 			metrics.DropBytesGauge.WithLabelValues(key.DropForwardReason(), ingressLabel).Set(float64(value.Bytes))
 			metrics.DropPacketsGauge.WithLabelValues(key.DropForwardReason(), ingressLabel).Set(float64(value.Count))
+		} else {
+			p.l.Error("MetricsMapIterateCallback drop key is neither ingress nor egress", zap.String("key", key.String()))
 		}
 	} else {
 		p.l.Debug("MetricsMapIterateCallback Forward", zap.String("key", key.String()))
@@ -128,6 +130,8 @@ func (p *Plugin) metricsMapIterateCallback(key *MetricsKey, value *MetricsValue)
 		} else if key.IsIngress() {
 			metrics.ForwardPacketsGauge.WithLabelValues(ingressLabel).Set(float64(value.Count))
 			metrics.ForwardBytesGauge.WithLabelValues(ingressLabel).Set(float64(value.Bytes))
+		} else {
+			p.l.Error("MetricsMapIterateCallback forward key is neither ingress nor egress", zap.String("key", key.String()))
 		}
 	}
 }

--- a/pkg/plugin/ebpfwindows/ebpf_windows_test.go
+++ b/pkg/plugin/ebpfwindows/ebpf_windows_test.go
@@ -371,13 +371,12 @@ func TestMetricsMapIterateCallback_DropEgress(t *testing.T) {
 		l: log.Logger().Named("test-ebpf"),
 	}
 	keyDrop := &MetricsKey{
-		Reason:   2,
-		Dir:      dirEgress,
-		Line:     0,
-		File:     0,
-		Reserved: [3]uint8{0, 0, 0},
+		Version:        1,
+		Reason:         2,
+		Direction:      dirEgress,
+		ExtendedReason: 0, // Extended reason is not used in this test
 	}
-	val := &MetricsValues{{Count: 1, Bytes: pktSizeBytes}}
+	val := &MetricsValue{Count: 1, Bytes: pktSizeBytes}
 	p.metricsMapIterateCallback(keyDrop, val)
 	_, err := metrics.DropBytesGauge.GetMetricWithLabelValues("Reason_InvalidPacket", "egress")
 	if err != nil {
@@ -401,13 +400,12 @@ func TestMetricsMapIterateCallback_DropIngress(t *testing.T) {
 		l: log.Logger().Named("test-ebpf"),
 	}
 	keyDrop := &MetricsKey{
-		Reason:   2,
-		Dir:      dirIngress,
-		Line:     0,
-		File:     0,
-		Reserved: [3]uint8{0, 0, 0},
+		Version:        1,
+		Reason:         2,
+		Direction:      dirIngress,
+		ExtendedReason: 0, // Extended reason is not used in this test
 	}
-	val := &MetricsValues{{Count: 1, Bytes: pktSizeBytes}}
+	val := &MetricsValue{Count: 1, Bytes: pktSizeBytes}
 	p.metricsMapIterateCallback(keyDrop, val)
 	_, err := metrics.DropBytesGauge.GetMetricWithLabelValues("Reason_InvalidPacket", "ingress")
 	if err != nil {
@@ -431,13 +429,12 @@ func TestMetricsMapIterateCallback_ForwardEgress(t *testing.T) {
 		l: log.Logger().Named("test-ebpf"),
 	}
 	keyFwd := &MetricsKey{
-		Reason:   0,
-		Dir:      dirEgress,
-		Line:     0,
-		File:     0,
-		Reserved: [3]uint8{0, 0, 0},
+		Version:        1,
+		Reason:         0,
+		Direction:      dirEgress,
+		ExtendedReason: 0, // Extended reason is not used in this test
 	}
-	val := &MetricsValues{{Count: 1, Bytes: pktSizeBytes}}
+	val := &MetricsValue{Count: 1, Bytes: pktSizeBytes}
 	p.metricsMapIterateCallback(keyFwd, val)
 	_, err := metrics.ForwardBytesGauge.GetMetricWithLabelValues("egress")
 	if err != nil {
@@ -461,13 +458,12 @@ func TestMetricsMapIterateCallback_ForwardIngress(t *testing.T) {
 		l: log.Logger().Named("test-ebpf"),
 	}
 	keyFwd := &MetricsKey{
-		Reason:   0,
-		Dir:      dirIngress,
-		Line:     0,
-		File:     0,
-		Reserved: [3]uint8{0, 0, 0},
+		Version:        1,
+		Reason:         0,
+		Direction:      dirIngress,
+		ExtendedReason: 0, // Extended reason is not used in this test
 	}
-	val := &MetricsValues{{Count: 1, Bytes: pktSizeBytes}}
+	val := &MetricsValue{Count: 1, Bytes: pktSizeBytes}
 	p.metricsMapIterateCallback(keyFwd, val)
 	_, err := metrics.ForwardBytesGauge.GetMetricWithLabelValues("ingress")
 	if err != nil {
@@ -497,7 +493,7 @@ func TestMetricsMapIterateCallback_NilKey(t *testing.T) {
 		},
 		l: log.Logger().Named("test-ebpf"),
 	}
-	fakeValues := &MetricsValues{{}}
+	fakeValues := &MetricsValue{}
 	p.metricsMapIterateCallback(nil, fakeValues)
 }
 
@@ -537,7 +533,7 @@ func TestIterateWithCallback_Error_NilMetricsValue(t *testing.T) {
 	logger := log.Logger().Named("test-ebpf")
 
 	called := false
-	err := m.IterateWithCallback(logger, func(_ *MetricsKey, _ *MetricsValues) {
+	err := m.IterateWithCallback(logger, func(_ *MetricsKey, _ *MetricsValue) {
 		called = true
 	})
 	if err != nil {
@@ -545,36 +541,7 @@ func TestIterateWithCallback_Error_NilMetricsValue(t *testing.T) {
 	}
 
 	fakeKey := &MetricsKey{}
-	enumCallBack(unsafe.Pointer(fakeKey), nil, 0)
-	if called {
-		t.Errorf("expected callback not to be called")
-	}
-}
-
-// TestIterateWithCallback_Error_ZeroMetricsValueSize tests the behavior of the IterateWithCallback function
-// when retinaEBPFAPI invokes enumCallBack with zero value size.
-func TestIterateWithCallback_Error_ZeroMetricsValueSize(t *testing.T) {
-	// Mock the function variable to simulate a successful Windows API call
-	orig := callEnumMetricsMap
-	callEnumMetricsMap = func(_ uintptr) (uintptr, uintptr, error) {
-		return 0, 0, nil
-	}
-	defer func() { callEnumMetricsMap = orig }()
-
-	m := NewMetricsMap()
-	logger := log.Logger().Named("test-ebpf")
-
-	called := false
-	err := m.IterateWithCallback(logger, func(_ *MetricsKey, _ *MetricsValues) {
-		called = true
-	})
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-
-	fakeKey := &MetricsKey{}
-	fakeValues := &MetricsValues{{}}
-	enumCallBack(unsafe.Pointer(fakeKey), unsafe.Pointer(&(*fakeValues)[0]), 0)
+	enumCallBack(unsafe.Pointer(fakeKey), nil)
 	if called {
 		t.Errorf("expected callback not to be called")
 	}
@@ -594,15 +561,15 @@ func TestIterateWithCallback_Error_NilMetricsKey(t *testing.T) {
 	logger := log.Logger().Named("test-ebpf")
 
 	called := false
-	err := m.IterateWithCallback(logger, func(_ *MetricsKey, _ *MetricsValues) {
+	err := m.IterateWithCallback(logger, func(_ *MetricsKey, _ *MetricsValue) {
 		called = true
 	})
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	fakeValues := &MetricsValues{{}}
-	enumCallBack(unsafe.Pointer(nil), unsafe.Pointer(&(*fakeValues)[0]), len(*fakeValues))
+	fakeValues := &MetricsValue{}
+	enumCallBack(unsafe.Pointer(nil), unsafe.Pointer(fakeValues))
 	if called {
 		t.Errorf("expected callback not to be called")
 	}
@@ -622,7 +589,7 @@ func TestIterateWithCallback_Error_NilMetricValue(t *testing.T) {
 	logger := log.Logger().Named("test-ebpf")
 
 	called := false
-	err := m.IterateWithCallback(logger, func(_ *MetricsKey, _ *MetricsValues) {
+	err := m.IterateWithCallback(logger, func(_ *MetricsKey, _ *MetricsValue) {
 		called = true
 	})
 	if err != nil {
@@ -630,7 +597,7 @@ func TestIterateWithCallback_Error_NilMetricValue(t *testing.T) {
 	}
 
 	fakeKey := &MetricsKey{}
-	enumCallBack(unsafe.Pointer(fakeKey), unsafe.Pointer(nil), 0)
+	enumCallBack(unsafe.Pointer(fakeKey), unsafe.Pointer(nil))
 	if called {
 		t.Errorf("expected callback not to be called")
 	}
@@ -650,7 +617,7 @@ func TestIterateWithCallback_Success(t *testing.T) {
 	logger := log.Logger().Named("test-ebpf")
 
 	called := false
-	err := m.IterateWithCallback(logger, func(_ *MetricsKey, _ *MetricsValues) {
+	err := m.IterateWithCallback(logger, func(_ *MetricsKey, _ *MetricsValue) {
 		called = true
 	})
 	if err != nil {
@@ -658,8 +625,8 @@ func TestIterateWithCallback_Success(t *testing.T) {
 	}
 
 	fakeKey := &MetricsKey{}
-	fakeValues := &MetricsValues{{}}
-	enumCallBack(unsafe.Pointer(fakeKey), unsafe.Pointer(&(*fakeValues)[0]), len(*fakeValues))
+	fakeValues := &MetricsValue{}
+	enumCallBack(unsafe.Pointer(fakeKey), unsafe.Pointer(fakeValues))
 	if !called {
 		t.Errorf("expected callback to be called")
 	}

--- a/test/e2e/scenarios/windows/validate-winbpf-metrics.go
+++ b/test/e2e/scenarios/windows/validate-winbpf-metrics.go
@@ -456,6 +456,18 @@ func (v *ValidateWinBpfMetric) Run() error {
 
 	slog.Info("Prometheus metrics output", "output", promOutput)
 
+	// Dump retina pod logs for debugging
+	slog.Info("Dumping Retina pod logs for debugging")
+	logDumper := &kubernetes.GetPodLogs{
+		KubeConfigFilePath: v.KubeConfigFilePath,
+		Namespace:          v.RetinaDaemonSetNamespace,
+		LabelSelector:      "k8s-app=retina",
+	}
+	logErr := logDumper.Run()
+	if logErr != nil {
+		slog.Warn("Failed to dump retina pod logs", "error", logErr)
+	}
+
 	err = v.verifyBasicMetrics(promOutput)
 	if err != nil {
 

--- a/test/e2e/scenarios/windows/validate-winbpf-metrics.go
+++ b/test/e2e/scenarios/windows/validate-winbpf-metrics.go
@@ -468,18 +468,6 @@ func (v *ValidateWinBpfMetric) Run() error {
 		slog.Warn("Failed to dump retina pod logs", "error", logErr)
 	}
 
-	// Dump network observability logs
-	slog.Info("Dumping Network Observability pod logs for debugging")
-	logDumper = &kubernetes.GetPodLogs{
-		KubeConfigFilePath: v.KubeConfigFilePath,
-		Namespace:          v.RetinaDaemonSetNamespace,
-		LabelSelector:      "k8s-app=networkobservability",
-	}
-	logErr = logDumper.Run()
-	if logErr != nil {
-		slog.Warn("Failed to dump network observability pod logs", "error", logErr)
-	}
-
 	err = v.verifyBasicMetrics(promOutput)
 	if err != nil {
 

--- a/test/e2e/scenarios/windows/validate-winbpf-metrics.go
+++ b/test/e2e/scenarios/windows/validate-winbpf-metrics.go
@@ -489,6 +489,7 @@ func (v *ValidateWinBpfMetric) Run() error {
 	}
 
 	slog.Info("Prometheus metrics output", "output", promOutput)
+
 	err = v.verifyBasicMetrics(promOutput)
 	if err != nil {
 

--- a/test/e2e/scenarios/windows/validate-winbpf-metrics.go
+++ b/test/e2e/scenarios/windows/validate-winbpf-metrics.go
@@ -468,6 +468,18 @@ func (v *ValidateWinBpfMetric) Run() error {
 		slog.Warn("Failed to dump retina pod logs", "error", logErr)
 	}
 
+	// Dump network observability logs
+	slog.Info("Dumping Network Observability pod logs for debugging")
+	logDumper = &kubernetes.GetPodLogs{
+		KubeConfigFilePath: v.KubeConfigFilePath,
+		Namespace:          v.RetinaDaemonSetNamespace,
+		LabelSelector:      "k8s-app=networkobservability",
+	}
+	logErr := logDumper.Run()
+	if logErr != nil {
+		slog.Warn("Failed to dump network observability pod logs", "error", logErr)
+	}
+
 	err = v.verifyBasicMetrics(promOutput)
 	if err != nil {
 

--- a/test/e2e/scenarios/windows/validate-winbpf-metrics.go
+++ b/test/e2e/scenarios/windows/validate-winbpf-metrics.go
@@ -2,6 +2,7 @@ package windows
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -9,6 +10,21 @@ import (
 
 	kubernetes "github.com/microsoft/retina/test/e2e/framework/kubernetes"
 	prom "github.com/microsoft/retina/test/e2e/framework/prometheus"
+)
+
+var (
+	// ErrForwardBytesZero indicates forward bytes metric is zero
+	ErrForwardBytesZero = errors.New("forward bytes metric is zero, expected non-zero value")
+	// ErrForwardCountZero indicates forward count metric is zero
+	ErrForwardCountZero = errors.New("forward count metric is zero, expected non-zero value")
+	// ErrDropBytesZero indicates drop bytes metric is zero
+	ErrDropBytesZero = errors.New("drop bytes metric is zero, expected non-zero value")
+	// ErrDropCountZero indicates drop count metric is zero
+	ErrDropCountZero = errors.New("drop count metric is zero, expected non-zero value")
+	// ErrWindowsDropBytesZero indicates windows drop bytes metric is zero
+	ErrWindowsDropBytesZero = errors.New("windows drop bytes metric is zero, expected non-zero value")
+	// ErrWindowsDropCountZero indicates windows drop count metric is zero
+	ErrWindowsDropCountZero = errors.New("windows drop count metric is zero, expected non-zero value")
 )
 
 const (
@@ -246,7 +262,7 @@ func (v *ValidateWinBpfMetric) verifyBasicMetrics(promOutput string) error {
 		}
 		slog.Info("networkobservability_forward_bytes value", "value", fwdBytes, "labels", fwdLabels)
 		if fwdBytes == 0 {
-			return fmt.Errorf("forward bytes metric is zero, expected non-zero value")
+			return ErrForwardBytesZero
 		}
 
 		fwdCount, err = prom.GetMetricGuageValueFromBuffer([]byte(promOutput), "networkobservability_forward_count", fwdLabels)
@@ -255,7 +271,7 @@ func (v *ValidateWinBpfMetric) verifyBasicMetrics(promOutput string) error {
 		}
 		slog.Info("networkobservability_forward_count value", "value", fwdCount, "labels", fwdLabels)
 		if fwdCount == 0 {
-			return fmt.Errorf("forward count metric is zero, expected non-zero value")
+			return ErrForwardCountZero
 		}
 
 		// Drop event
@@ -265,7 +281,7 @@ func (v *ValidateWinBpfMetric) verifyBasicMetrics(promOutput string) error {
 		}
 		slog.Info("networkobservability_drop_bytes value", "value", drpBytes, "labels", drpLabels)
 		if drpBytes == 0 {
-			return fmt.Errorf("drop bytes metric is zero, expected non-zero value")
+			return ErrDropBytesZero
 		}
 
 		drpCount, err = prom.GetMetricGuageValueFromBuffer([]byte(promOutput), "networkobservability_drop_count", drpLabels)
@@ -274,7 +290,7 @@ func (v *ValidateWinBpfMetric) verifyBasicMetrics(promOutput string) error {
 		}
 		slog.Info("networkobservability_drop_count value", "value", drpCount, "labels", drpLabels)
 		if drpCount == 0 {
-			return fmt.Errorf("drop count metric is zero, expected non-zero value")
+			return ErrDropCountZero
 		}
 
 		// Windows drop event
@@ -284,7 +300,7 @@ func (v *ValidateWinBpfMetric) verifyBasicMetrics(promOutput string) error {
 		}
 		slog.Info("networkobservability_drop_bytes (windows) value", "value", windowsDrpBytes, "labels", windowsDrpLabels)
 		if windowsDrpBytes == 0 {
-			return fmt.Errorf("windows drop bytes metric is zero, expected non-zero value")
+			return ErrWindowsDropBytesZero
 		}
 
 		windowsDrpCount, err = prom.GetMetricGuageValueFromBuffer([]byte(promOutput), "networkobservability_drop_count", windowsDrpLabels)
@@ -293,7 +309,7 @@ func (v *ValidateWinBpfMetric) verifyBasicMetrics(promOutput string) error {
 		}
 		slog.Info("networkobservability_drop_count (windows) value", "value", windowsDrpCount, "labels", windowsDrpLabels)
 		if windowsDrpCount == 0 {
-			return fmt.Errorf("windows drop count metric is zero, expected non-zero value")
+			return ErrWindowsDropCountZero
 		}
 	}
 

--- a/test/e2e/scenarios/windows/validate-winbpf-metrics.go
+++ b/test/e2e/scenarios/windows/validate-winbpf-metrics.go
@@ -475,7 +475,7 @@ func (v *ValidateWinBpfMetric) Run() error {
 		Namespace:          v.RetinaDaemonSetNamespace,
 		LabelSelector:      "k8s-app=networkobservability",
 	}
-	logErr := logDumper.Run()
+	logErr = logDumper.Run()
 	if logErr != nil {
 		slog.Warn("Failed to dump network observability pod logs", "error", logErr)
 	}

--- a/test/e2e/scenarios/windows/validate-winbpf-metrics.go
+++ b/test/e2e/scenarios/windows/validate-winbpf-metrics.go
@@ -228,7 +228,7 @@ func (v *ValidateWinBpfMetric) verifyBasicMetrics(promOutput string) error {
 
 	windowsDrpLabels := map[string]string{
 		"direction": "ingress",
-		"reason":    "220, 607",
+		"reason":    "DropReason_PacketMonitor, Drop_FL_InterfaceNotReady",
 	}
 
 	if promOutput == "" {
@@ -241,42 +241,60 @@ func (v *ValidateWinBpfMetric) verifyBasicMetrics(promOutput string) error {
 		}
 
 		fwdBytes, err = prom.GetMetricGuageValueFromBuffer([]byte(promOutput), "networkobservability_forward_bytes", fwdLabels)
-		if err != nil && strings.Contains(err.Error(), "failed to parse prometheus metrics (networkobservability_forward_bytes)") {
+		if err != nil {
 			return fmt.Errorf("failed to get forward bytes metric: %w", err)
 		}
 		slog.Info("networkobservability_forward_bytes value", "value", fwdBytes, "labels", fwdLabels)
+		if fwdBytes == 0 {
+			return fmt.Errorf("forward bytes metric is zero, expected non-zero value")
+		}
 
 		fwdCount, err = prom.GetMetricGuageValueFromBuffer([]byte(promOutput), "networkobservability_forward_count", fwdLabels)
-		if err != nil && strings.Contains(err.Error(), "failed to parse prometheus metrics (networkobservability_forward_count)") {
+		if err != nil {
 			return fmt.Errorf("failed to get forward count metric: %w", err)
 		}
 		slog.Info("networkobservability_forward_count value", "value", fwdCount, "labels", fwdLabels)
+		if fwdCount == 0 {
+			return fmt.Errorf("forward count metric is zero, expected non-zero value")
+		}
 
 		// Drop event
 		drpBytes, err = prom.GetMetricGuageValueFromBuffer([]byte(promOutput), "networkobservability_drop_bytes", drpLabels)
-		if err != nil && strings.Contains(err.Error(), "failed to parse prometheus metrics (networkobservability_drop_bytes)") {
+		if err != nil {
 			return fmt.Errorf("failed to get drop bytes metric: %w", err)
 		}
 		slog.Info("networkobservability_drop_bytes value", "value", drpBytes, "labels", drpLabels)
+		if drpBytes == 0 {
+			return fmt.Errorf("drop bytes metric is zero, expected non-zero value")
+		}
 
 		drpCount, err = prom.GetMetricGuageValueFromBuffer([]byte(promOutput), "networkobservability_drop_count", drpLabels)
-		if err != nil && strings.Contains(err.Error(), "failed to parse prometheus metrics (networkobservability_drop_count)") {
+		if err != nil {
 			return fmt.Errorf("failed to get drop count metric: %w", err)
 		}
 		slog.Info("networkobservability_drop_count value", "value", drpCount, "labels", drpLabels)
+		if drpCount == 0 {
+			return fmt.Errorf("drop count metric is zero, expected non-zero value")
+		}
 
 		// Windows drop event
 		windowsDrpBytes, err = prom.GetMetricGuageValueFromBuffer([]byte(promOutput), "networkobservability_drop_bytes", windowsDrpLabels)
-		if err != nil && strings.Contains(err.Error(), "failed to parse prometheus metrics (windows networkobservability_drop_bytes)") {
+		if err != nil {
 			return fmt.Errorf("failed to get windows drop bytes metric: %w", err)
 		}
 		slog.Info("networkobservability_drop_bytes (windows) value", "value", windowsDrpBytes, "labels", windowsDrpLabels)
+		if windowsDrpBytes == 0 {
+			return fmt.Errorf("windows drop bytes metric is zero, expected non-zero value")
+		}
 
 		windowsDrpCount, err = prom.GetMetricGuageValueFromBuffer([]byte(promOutput), "networkobservability_drop_count", windowsDrpLabels)
-		if err != nil && strings.Contains(err.Error(), "failed to parse prometheus metrics (windows networkobservability_drop_count)") {
+		if err != nil {
 			return fmt.Errorf("failed to get windows drop count metric: %w", err)
 		}
 		slog.Info("networkobservability_drop_count (windows) value", "value", windowsDrpCount, "labels", windowsDrpLabels)
+		if windowsDrpCount == 0 {
+			return fmt.Errorf("windows drop count metric is zero, expected non-zero value")
+		}
 	}
 
 	return nil
@@ -455,19 +473,6 @@ func (v *ValidateWinBpfMetric) Run() error {
 	}
 
 	slog.Info("Prometheus metrics output", "output", promOutput)
-
-	// Dump retina pod logs for debugging
-	slog.Info("Dumping Retina pod logs for debugging")
-	logDumper := &kubernetes.GetPodLogs{
-		KubeConfigFilePath: v.KubeConfigFilePath,
-		Namespace:          v.RetinaDaemonSetNamespace,
-		LabelSelector:      "k8s-app=retina",
-	}
-	logErr := logDumper.Run()
-	if logErr != nil {
-		slog.Warn("Failed to dump retina pod logs", "error", logErr)
-	}
-
 	err = v.verifyBasicMetrics(promOutput)
 	if err != nil {
 

--- a/test/e2e/tools/event-writer/event_writer.h
+++ b/test/e2e/tools/event-writer/event_writer.h
@@ -20,6 +20,9 @@
 #define EVENT_WRITER_PIN_PATH \
     "/ebpf/global/event_writer"
 
+#define DROP_PKTMON -220
+#define Drop_FL_InterfaceNotReady 607
+
 enum {
 	CILIUM_NOTIFY_UNSPEC = 0,
 	CILIUM_NOTIFY_DROP,
@@ -166,6 +169,15 @@ struct metrics_key {
 	uint16_t	line;		/* __MAGIC_LINE__ */
 	uint8_t	    file;		/* __MAGIC_FILE__, needs to fit __source_file_name_to_id */
 	uint8_t	    reserved[3];	/* reserved for future extension */
+};
+
+struct windows_metrics_key {
+    uint8_t  type;
+    uint16_t reason; /* 0: forwarded, >0 dropped */
+    uint8_t  dir : 2, /* 1: ingress 2: egress */
+             pad : 6;
+    uint16_t line; /* __MAGIC_LINE__ */
+    uint8_t  file;  /* __MAGIC_FILE__, needs to fit __source_file_name_to_id */
 };
 
 struct metrics_value {

--- a/test/e2e/tools/event-writer/event_writer.h
+++ b/test/e2e/tools/event-writer/event_writer.h
@@ -11,6 +11,9 @@
 #define METRICS_MAP_PIN_PATH \
     "/ebpf/global/cilium_metrics"
 
+#define WINDOWS_METRICS_MAP_PIN_PATH \
+    "/ebpf/global/windows_metrics"
+
 #define FILTER_MAP_PIN_PATH \
     "/ebpf/global/filter_map"
 

--- a/test/e2e/yaml/windows/install-ebpf-xdp.yaml
+++ b/test/e2e/yaml/windows/install-ebpf-xdp.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: install-ebpf-xdp-container
-        image: ghcr.io/kumarvin123/retina/test/e2e-test-event-writer:latest
+        image: ghcr.io/matthewige/retina/test/e2e-test-event-writer:latest
         imagePullPolicy: Always
         command:
           - powershell.exe

--- a/test/e2e/yaml/windows/install-ebpf-xdp.yaml
+++ b/test/e2e/yaml/windows/install-ebpf-xdp.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: install-ebpf-xdp-container
-        image: ghcr.io/matthewige/retina/test/e2e-test-event-writer:latest
+        image: ghcr.io/microsoft/retina/test/e2e-test-event-writer:latest
         imagePullPolicy: Always
         command:
           - powershell.exe

--- a/test/e2e/yaml/windows/non-hpc-pod.yaml
+++ b/test/e2e/yaml/windows/non-hpc-pod.yaml
@@ -9,7 +9,7 @@ spec:
     "kubernetes.io/os": windows
   containers:
   - name: non-hpc-container
-    image: ghcr.io/kumarvin123/retina/test/e2e-test-event-writer:latest
+    image: ghcr.io/matthewige/retina/test/e2e-test-event-writer:latest
     command: ["powershell", "-Command", "while ($true) { Start-Sleep -Seconds 3600 }"]
     securityContext:
         windowsOptions:

--- a/test/e2e/yaml/windows/non-hpc-pod.yaml
+++ b/test/e2e/yaml/windows/non-hpc-pod.yaml
@@ -9,7 +9,7 @@ spec:
     "kubernetes.io/os": windows
   containers:
   - name: non-hpc-container
-    image: ghcr.io/matthewige/retina/test/e2e-test-event-writer:latest
+    image: ghcr.io/microsoft/retina/test/e2e-test-event-writer:latest
     command: ["powershell", "-Command", "while ($true) { Start-Sleep -Seconds 3600 }"]
     securityContext:
         windowsOptions:


### PR DESCRIPTION
# Description
- Updates RetinaEbpfApi version
- Updates processing of Metrics Map due to API changes
- Adds processing for lost events API
- Updates tests to utilize added windows_metrics map

## Related Issue


## Checklist

- [X] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [X] I have correctly attributed the author(s) of the code.
- [X] I have tested the changes locally.
- [X] I have followed the project's style guidelines.
- [X] I have updated the documentation, if necessary.
- [X] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
