### PR TITLE
fix: stop endpoint manager in the agent to regen endpoints periodically

### DIFF
--- a/pkg/k8s/cell_linux.go
+++ b/pkg/k8s/cell_linux.go
@@ -3,6 +3,7 @@ package k8s
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	daemonk8s "github.com/cilium/cilium/daemon/k8s"
 	cgmngr "github.com/cilium/cilium/pkg/cgroups/manager"
@@ -53,6 +54,13 @@ var Cell = cell.Module(
 			logrus.WithError(err).Fatal("Failed to register table")
 		}
 	}),
+
+	cell.Provide(func() endpointmanager.EndpointManagerConfig {
+		return endpointmanager.EndpointManagerConfig{
+			EndpointRegenInterval: time.Duration(0),
+		}
+	},
+	),
 
 	cell.Provide(
 		func() resource.Resource[*slim_corev1.Namespace] {


### PR DESCRIPTION
Disabling the Endpoint regeneration from the Agent endpoint manager by setting the regen interval to 0.

# Description

Please provide a brief description of the changes made in this pull request.

## Related Issue

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
