### PR TITLE
Update e2e-test-event-writer yml to trigger on dev branch

### DIFF
--- a/.github/workflows/e2e-test-event-writer.yml
+++ b/.github/workflows/e2e-test-event-writer.yml
@@ -1,7 +1,10 @@
 name: Build E2E Test Event Writer
 on:
   pull_request:
-    branches: [main]
+  push:
+    branches:
+      - main
+      - "dev/**"
   merge_group:
     types: [checks_requested]
   workflow_dispatch:


### PR DESCRIPTION
# Description
e2e-test-event-writer.yml was not triggering on dev branches

## Related Issue
n/a

## Checklist

- [X] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [X] I have correctly attributed the author(s) of the code.
- [X] I have tested the changes locally.
- [X] I have followed the project's style guidelines.
- [X] I have updated the documentation, if necessary.
- [X] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed
n/a

## Additional Notes
n/a
---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
