### PR TITLE
fix: enable annotations

### DIFF
--- a/docs/03-Metrics/annotations.md
+++ b/docs/03-Metrics/annotations.md
@@ -1,13 +1,16 @@
 # Annotations
 
+**This feature is only available in Standard Control Plane.**
+
 Annotations let you specify which Pods to observe (create metrics for).
-To configure this, specify `enableAnnotations=true` in Retina's [helm installation](../02-Installation/01-Setup.md) or [ConfigMap](../02-Installation/03-Config.md).
+
+To enable it, specify `enableAnnotations=true` in Retina's Standard Control Plane [helm installation](../02-Installation/01-Setup.md) or [ConfigMap](../02-Installation/03-Config.md).
 
 You can then add the annotation `retina.sh: observe` to either:
 
 - individual Pods
 - Namespaces (to observe all the Pods in the namespace).
 
-An exception: currently all Pods in `kube-system` are always monitored.
+**Note 1**: If you enable Annotations, you cannot use the `MetricsConfiguration` CRD to specify which Pods to observe.
 
-**Note**: If you enable Annotations, you cannot use the `MetricsConfiguration` CRD to specify which Pods to observe.
+**Note 2**: Currently DNS plugin does not consider annotations to generate DNS Metrics, hence it generates metrics for all pods.

--- a/pkg/plugin/packetparser/packetparser_linux.go
+++ b/pkg/plugin/packetparser/packetparser_linux.go
@@ -93,8 +93,8 @@ func (p *packetParser) Generate(ctx context.Context) error {
 	if p.cfg.BypassLookupIPOfInterest {
 		p.l.Info("bypassing lookup IP of interest")
 		bypassLookupIPOfInterest = 1
-		st = fmt.Sprintf("#define BYPASS_LOOKUP_IP_OF_INTEREST %d\n", bypassLookupIPOfInterest)
 	}
+	st = fmt.Sprintf("#define BYPASS_LOOKUP_IP_OF_INTEREST %d\n", bypassLookupIPOfInterest)
 
 	conntrackMetrics := 0
 	// Check if packetparser has Conntrack metrics enabled.


### PR DESCRIPTION
# Description

This PR is replacing #1471 which is now closed.

## Feature description
When using option `enableAnnotation: true`, metrics should only be generated for pods annotated with `retina.sh: observe` or pods in a namespace with that annotation. There's an exception regarding DNS plugin, which uses inspektor:
https://github.com/microsoft/retina/blob/750fddd9b06ed70d33d723c4cb730ef113761c61/pkg/plugin/dns/dns_linux.go#L7-L13
https://github.com/microsoft/retina/blob/750fddd9b06ed70d33d723c4cb730ef113761c61/pkg/plugin/dns/dns_linux.go#L52-L58

## Bug
When enableAnnotation: true advanced metrics are still being generated for all pods.
This was introduced in #1102 

## Explanation
PacketParser plugin overrides the file `pkg/plugin/packetparser/_cprog/dynamic.h` during runtime:
https://github.com/microsoft/retina/blob/750fddd9b06ed70d33d723c4cb730ef113761c61/pkg/plugin/packetparser/packetparser_linux.go#L120-L121
The bug was introduced by changing the code below to inside `if` block:
https://github.com/microsoft/retina/blob/750fddd9b06ed70d33d723c4cb730ef113761c61/pkg/plugin/packetparser/packetparser_linux.go#L96
So when `bypassLookupIPOfInterest := 0` (which is default), variable `BYPASS_LOOKUP_IP_OF_INTEREST` does not get defined and the block below gets skipped, generating metrics for all pods:
https://github.com/microsoft/retina/blob/750fddd9b06ed70d33d723c4cb730ef113761c61/pkg/plugin/packetparser/_cprog/packetparser.c#L151-L158

## Fix
1. Move code back to its original position
2. Adjust documentation to reflect actual behavior:
2.a. Metrics are not generated for all pods in `kube-system` by default
2.b. DNS plugin does is not configured to filter IPs

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed
### Without annotations

Retina with annotations enabled:
<img width="996" height="339" alt="image" src="https://github.com/user-attachments/assets/8540cc13-11c3-47ff-8b7c-36e515172b16" />

Namespaces without annotations:
<img width="514" height="373" alt="image" src="https://github.com/user-attachments/assets/3940bf03-f92f-4ffd-adb3-3ee7c09bbfa3" />

Fortio deployments communicating in `traffic`:
<img width="688" height="64" alt="image" src="https://github.com/user-attachments/assets/7782e9e4-f80b-449b-980e-d1999df7b6fb" />

Deployment to test DNS in `default`:
<img width="425" height="43" alt="image" src="https://github.com/user-attachments/assets/2df97b36-32d3-4db0-b16c-fa065e523230" />

`curl` execution from pod in `default` namespace:
<img width="793" height="148" alt="image" src="https://github.com/user-attachments/assets/3dbae870-4a26-446d-a044-709da2251796" />

`networkobservability_adv_forward_bytes` for both namespaces:
<img width="1846" height="281" alt="image" src="https://github.com/user-attachments/assets/e04cd5b1-c6c9-426a-b1f0-0a67862c8f10" />
<img width="1851" height="305" alt="image" src="https://github.com/user-attachments/assets/37b89f64-cb4b-4764-aa84-a6208062165d" />

`networkobservability_adv_dns_request_count` for `default`:
<img width="1828" height="540" alt="image" src="https://github.com/user-attachments/assets/5d17ccf3-2d99-48a4-ba1a-0d17a6fc89ee" />

### Add annotation to `default` namespace

`default` namespace with annotation:
<img width="515" height="166" alt="image" src="https://github.com/user-attachments/assets/9aef8b24-c26a-4bc5-bea9-3441f69a36da" />

New `curl` execution from pod in `default` namespace:
<img width="793" height="148" alt="image" src="https://github.com/user-attachments/assets/3dbae870-4a26-446d-a044-709da2251796" />

`networkobservability_adv_forward_bytes` for `default`:
<img width="1843" height="261" alt="image" src="https://github.com/user-attachments/assets/bbaebde0-3c42-493c-adc9-a335ca60b5a9" />

`networkobservability_adv_dns_request_count` for `default`:
<img width="1827" height="503" alt="image" src="https://github.com/user-attachments/assets/aec4b9df-3617-4646-8cc7-6b63856bc300" />

### Add annotation to `traffic` namespace

`traffic` namespace with annotation:
<img width="517" height="169" alt="image" src="https://github.com/user-attachments/assets/36745818-f70d-4b90-8058-51307795aeb5" />

`networkobservability_adv_forward_bytes` for `traffic`:
<img width="1839" height="321" alt="image" src="https://github.com/user-attachments/assets/c1be5d28-3b5b-4bf7-92ab-81c50b5e7622" />

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
