### PR TITLE
fix(localctx+win): Fix the helm insatll command for localCtx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -487,8 +487,8 @@ helm-install-advanced-local-context: manifests
 		--set image.pullPolicy=Always \
 		--set logLevel=info \
 		--set os.windows=true \
-		--set operator.enabled=true \
-		--set operator.enableRetinaEndpoint=true \
+		--set operator.enabled=false \
+		--set operator.enableRetinaEndpoint=false \
 		--set operator.repository=$(IMAGE_REGISTRY)/$(RETINA_OPERATOR_IMAGE) \
 		--skip-crds \
 		--set enabledPlugin_linux="\[dropreason\,packetforward\,linuxutil\,dns\,packetparser\]" \

--- a/deploy/standard/manifests/controller/helm/retina/templates/configmap.yaml
+++ b/deploy/standard/manifests/controller/helm/retina/templates/configmap.yaml
@@ -49,6 +49,7 @@ data:
     enableTelemetry: {{ .Values.enableTelemetry }}
     enablePodLevel: {{ .Values.enablePodLevel }}
     remoteContext: {{ .Values.remoteContext }}
+    enableAnnotations: {{ .Values.enableAnnotations }}
     telemetryInterval: {{ .Values.daemonset.telemetryInterval }}
 {{- end}}
 


### PR DESCRIPTION
# Description

- Disable operator installation for `localCtx` (not needed)
- Windows configmap is missing `enableAnnotations` config

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

```bash
$ kg cm retina-config-win -oyaml 
apiVersion: v1
data:
  config.yaml: "apiServer:\n  host: 0.0.0.0\n  port: 10093\nlogLevel: info\nenabledPlugin:
    [\"hnsstats\"]\nmetricsInterval: \nmetricsIntervalDuration: 10s\nenableTelemetry:
    false\nenablePodLevel: true\nremoteContext: false\nenableAnnotations: true\ntelemetryInterval:
    15m"
kind: ConfigMap
...
```

```bash
$  kg po -A -owide | grep -i retina    
kube-system         retina-agent-d47xk                                   1/1     Running   0               7m25s   10.224.0.4      aks-nodepool1-31204792-vmss000000   <none>           <none>
kube-system         retina-agent-g9m4b                                   1/1     Running   0               6m51s   10.224.0.5      aks-nodepool1-31204792-vmss000001   <none>           <none>
kube-system         retina-agent-kfdwx                                   1/1     Running   0               6m17s   10.224.0.6      aks-nodepool1-31204792-vmss000002   <none>           <none>
kube-system         retina-agent-win-52wkl                               1/1     Running   7 (12m ago)     32m     10.224.0.7      akswin000000                        <none>           <none>
kube-system         retina-agent-win-j4r4f                               1/1     Running   6 (9m27s ago)   29m     10.224.0.8      akswin2000000                       <none>           <none>
```

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
