### PR TITLE
Cherry picking locactx fix form main branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -476,8 +476,8 @@ helm-install-advanced-local-context: manifests
 		--set image.pullPolicy=Always \
 		--set logLevel=info \
 		--set os.windows=true \
-		--set operator.enabled=true \
-		--set operator.enableRetinaEndpoint=true \
+		--set operator.enabled=false \
+		--set operator.enableRetinaEndpoint=false \
 		--set operator.repository=$(IMAGE_REGISTRY)/$(RETINA_OPERATOR_IMAGE) \
 		--skip-crds \
 		--set enabledPlugin_linux="\[dropreason\,packetforward\,linuxutil\,dns\,packetparser\]" \

--- a/deploy/standard/manifests/controller/helm/retina/templates/configmap.yaml
+++ b/deploy/standard/manifests/controller/helm/retina/templates/configmap.yaml
@@ -50,6 +50,7 @@ data:
     enableAnnotations: {{ .Values.enableAnnotations }}
     enablePodLevel: {{ .Values.enablePodLevel }}
     remoteContext: {{ .Values.remoteContext }}
+    enableAnnotations: {{ .Values.enableAnnotations }}
     telemetryInterval: {{ .Values.daemonset.telemetryInterval }}
 {{- end}}
 


### PR DESCRIPTION
Cherry picking following fix from main branch: fix(localctx+win): Fix the helm insatll command for localCtx (https://github.com/microsoft/retina/pull/1807)

# Description

- Disable operator installation for `localCtx` (not needed)
- Windows configmap is missing `enableAnnotations` config

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [X] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [X] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [X] I have followed the project's style guidelines.
- [X] I have updated the documentation, if necessary.
- [X] I have added tests, if applicable.


---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
