### PR TITLE
 [SFI - Service Tags] Retina Virtual Tags

### DIFF
--- a/test/e2e/framework/azure/create-cluster.go
+++ b/test/e2e/framework/azure/create-cluster.go
@@ -20,14 +20,15 @@ const (
 var defaultClusterCreateTimeout = 30 * time.Minute
 
 type CreateCluster struct {
-	SubscriptionID    string
-	ResourceGroupName string
-	Location          string
-	ClusterName       string
-	podCidr           string
-	vmSize            string
-	networkPluginMode string
-	Nodes             int32
+	SubscriptionID    		string
+	ResourceGroupName 		string
+	Location          		string
+	ClusterName       		string
+	podCidr           		string
+	vmSize            		string
+	networkPluginMode 		string
+	Nodes             		int32
+	loadBalancerOutboundIpId	string
 }
 
 func (c *CreateCluster) SetPodCidr(podCidr string) *CreateCluster {
@@ -42,6 +43,11 @@ func (c *CreateCluster) SetVMSize(vmSize string) *CreateCluster {
 
 func (c *CreateCluster) SetNetworkPluginMode(networkPluginMode string) *CreateCluster {
 	c.networkPluginMode = networkPluginMode
+	return c
+}
+
+func (c *CreateCluster) SetPublicIP(loadBalancerOutboundIpId string) *CreateCluster {
+	c.loadBalancerOutboundIpId = loadBalancerOutboundIpId
 	return c
 }
 
@@ -128,9 +134,16 @@ func GetStarterClusterTemplate(location string) armcontainerservice.ManagedClust
 			EnableRBAC:              to.Ptr(true),
 			LinuxProfile:            nil,
 			NetworkProfile: &armcontainerservice.NetworkProfile{
-				LoadBalancerSKU: to.Ptr(armcontainerservice.LoadBalancerSKUStandard),
-				OutboundType:    to.Ptr(armcontainerservice.OutboundTypeLoadBalancer),
-				NetworkPlugin:   to.Ptr(armcontainerservice.NetworkPluginAzure),
+				LoadBalancerSKU: 		to.Ptr(armcontainerservice.LoadBalancerSKUStandard),
+				OutboundType:    		to.Ptr(armcontainerservice.OutboundTypeLoadBalancer),
+				NetworkPlugin:   		to.Ptr(armcontainerservice.NetworkPluginAzure),
+				LoadBalancerProfile:	&armcontainerservice.ManagedClusterLoadBalancerProfile{
+					OutboundIPs:	&armcontainerservice.ManagedClusterLoadBalancerProfileOutboundIPs{
+						PublicIPs: []*armcontainerservice.ResourceReference{
+							ID: to.Ptr(c.loadBalancerOutboundIpId)
+						}
+					}
+				}
 			},
 			WindowsProfile: &armcontainerservice.ManagedClusterWindowsProfile{
 				AdminPassword: to.Ptr("replacePassword1234$"),

--- a/test/e2e/framework/azure/create-publicip.go
+++ b/test/e2e/framework/azure/create-publicip.go
@@ -1,0 +1,64 @@
+package azure
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	armnetwork "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v5"
+)
+
+
+type CreatePublicIp struct {
+	SubscriptionID    string
+	ResourceGroupName string
+	Location          string
+	PublicIpName      string
+	IPTagType         string
+	Tag               string
+}
+
+func (c *CreatePublicIp) Run() error {
+	cred, err := azidentity.NewAzureCLICredential(nil)
+	if err != nil {
+		return fmt.Errorf("failed to obtain a credential: %w", err)
+	}
+	ctx := context.Background()
+	clientFactory, err := armnetwork.NewClientFactory(c.SubscriptionID, cred, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+
+	log.Printf("creating public ip \"%s\" in resource group \"%s\"...", c.PublicIpName, c.ResourceGroupName)
+
+	poller, err := clientFactory.NewPublicIPAddressesClient().BeginCreateOrUpdate(ctx, c.ResourceGroupName, c.PublicIpName, armnetwork.PublicIpAddress{
+		Location: to.Ptr(c.Location),
+		Properties: &armnetwork.PublicIPAddressPropertiesFormat{
+			IPTags: []*armnetwork.IPTag{
+				{
+					IPTagType: to.Ptr(c.IPTagType),
+					Tag: to.Ptr(c.Tag),
+				}
+			},
+		},
+	}, nil)
+	if err != nil {
+		return fmt.Errorf("failed to finish the request for create public ip: %w", err)
+	}
+
+	_, err = poller.PollUntilDone(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to pull the result for create public ip: %w", err)
+	}
+	return nil
+}
+
+func (c *CreatePublicIp) Prevalidate() error {
+	return nil
+}
+
+func (c *CreatePublicIp) Stop() error {
+	return nil
+}

--- a/test/e2e/jobs/scale.go
+++ b/test/e2e/jobs/scale.go
@@ -57,9 +57,16 @@ func GetScaleTestInfra(subID, rg, clusterName, location, kubeConfigFilePath stri
 			Location:          location,
 		}, nil)
 
+		job.AddStep(&azure.CreatePublicIp{
+			PublicIpName: fmt.Sprintf("%s-lb-ip", clusterName)
+			IPTagType:    "FirstPartyUsage",
+			Tag:          "/NonProd"
+		}, nil)
+
 		job.AddStep((&azure.CreateCluster{
 			ClusterName: clusterName,
 			Nodes:       nodes,
+			loadBalancerOutboundIpId: fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers//Microsoft.Network/publicIPAddresses/%s-lb-ip", subID, rg, clusterName),
 		}).
 			SetPodCidr("100.64.0.0/10").
 			SetVMSize("Standard_D4_v3").


### PR DESCRIPTION
# Description
Run E2e Tests pipeline is failing during cluster creation with the following error:
```bash
#################### CreateNPMCluster ###################################################################
2025/08/14 18:58:11 when the cluster is ready, use the below command to access and debug
2025/08/14 18:58:11 az aks get-credentials --resource-group runner-e2e-netobs-1755197881 --name runner-e2e-netobs-1755197881 --subscription ***
2025/08/14 18:58:11 creating cluster "runner-e2e-netobs-1755197881" in resource group "runner-e2e-netobs-1755197881"...
2025/08/14 18:58:40 failed to create cluster: GET https://management.azure.com/subscriptions/***/providers/Microsoft.ContainerService/locations/eastus2/operations/fd882d18-319b-4200-aa9e-a2934886e35b
--------------------------------------------------------------------------------
RESPONSE 200: 200 OK
ERROR CODE: RequestDisallowedByPolicy
--------------------------------------------------------------------------------
{
  "name": "fd882d18-319b-4200-aa9e-a2934886e35b",
  "status": "Failed",
  "startTime": "2025-08-14T18:58:30.3284728Z",
  "endTime": "2025-08-14T18:58:38.5566866Z",
  "error": {
    "code": "RequestDisallowedByPolicy",
    "message": "Create or update public IP failed: Subscription: ***; resource group: MC_runner-e2e-netobs-1755197881_runner-e2e-netobs-1755197881_eastus2; public IP name: c1debc4c-7910-4441-b0ce-30b64f37b43c. Resource 'c1debc4c-7910-4441-b0ce-30b64f37b43c' was disallowed by policy. Reasons: 'The public ip needs to be tagged with either a service or virtual tag.'. See error details for policy resource IDs.",
    "details": [
      {
        "code": "RequestDisallowedByPolicy",
        "message": "Resource 'c1debc4c-7910-4441-b0ce-30b64f37b43c' was disallowed by policy. Reasons: 'The public ip needs to be tagged with either a service or virtual tag.'. See error details for policy resource IDs.",
        "target": "c1debc4c-7910-4441-b0ce-30b64f37b43c"
      }
    ]
  }
}
--------------------------------------------------------------------------------

    runner.go:38: 
        	Error Trace:	/home/runner/work/retina/retina/test/e2e/framework/types/runner.go:38
        	            				/home/runner/work/retina/retina/test/e2e/infra/azure_temp_infra_setup.go:47
        	            				/home/runner/work/retina/retina/test/e2e/retina_e2e_test.go:38
        	Error:      	Received unexpected error:
        	            	did not expect error from step CreateNPMCluster but got error: received notification, failed to create cluster: GET https://management.azure.com/subscriptions/***/providers/Microsoft.ContainerService/locations/eastus2/operations/fd882d18-319b-4200-aa9e-a2934886e35b
        	            	--------------------------------------------------------------------------------
        	            	RESPONSE 200: 200 OK
        	            	ERROR CODE: RequestDisallowedByPolicy
        	            	--------------------------------------------------------------------------------
        	            	{
        	            	  "name": "fd882d18-319b-4200-aa9e-a2934886e35b",
        	            	  "status": "Failed",
        	            	  "startTime": "2025-08-14T18:58:30.3284728Z",
        	            	  "endTime": "2025-08-14T18:58:38.5566866Z",
        	            	  "error": {
        	            	    "code": "RequestDisallowedByPolicy",
        	            	    "message": "Create or update public IP failed: Subscription: ***; resource group: MC_runner-e2e-netobs-1755197881_runner-e2e-netobs-1755197881_eastus2; public IP name: c1debc4c-7910-4441-b0ce-30b64f37b43c. Resource 'c1debc4c-7910-4441-b0ce-30b64f37b43c' was disallowed by policy. Reasons: 'The public ip needs to be tagged with either a service or virtual tag.'. See error details for policy resource IDs.",
        	            	    "details": [
        	            	      {
        	            	        "code": "RequestDisallowedByPolicy",
        	            	        "message": "Resource 'c1debc4c-7910-4441-b0ce-30b64f37b43c' was disallowed by policy. Reasons: 'The public ip needs to be tagged with either a service or virtual tag.'. See error details for policy resource IDs.",
        	            	        "target": "c1debc4c-7910-4441-b0ce-30b64f37b43c"
        	            	      }
        	            	    ]
        	            	  }
        	            	}
        	            	--------------------------------------------------------------------------------
```
Cherry-picked changes from this [draft pr](https://github.com/microsoft/retina/pull/1796/files) which adds a public IP address with the required tags to the load balancer. This should fix the above issue. 


## Checklist

- [X] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [X] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [X] I have followed the project's style guidelines.
- [X] I have updated the documentation, if necessary.
- [X] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
