### PR TITLE
Merging PR from main-  refactor: add dockerfile for windows build and make build-binaries #1720

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -339,6 +339,10 @@ all-gen: ## generate all code
 	$(MAKE) proto-gen
 	$(MAKE) go-gen
 
+build-windows-binaries:
+	GOOS=windows GOARCH=$(GOARCH) go build -v -o /go/bin/retina/captureworkload -ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version=$(TAG) -X github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID=$(APP_INSIGHTS_ID)" captureworkload/main.go
+	GOOS=windows GOARCH=$(GOARCH) go build -x -v -o /go/bin/retina/controller -ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version=$(TAG) -X github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID=$(APP_INSIGHTS_ID)" controller/main.go
+	
 ##@ Multiplatform
 
 manifest-retina-image: ## create a multiplatform manifest for the retina image

--- a/controller/Dockerfile.windows-retina-oss-build
+++ b/controller/Dockerfile.windows-retina-oss-build
@@ -1,0 +1,27 @@
+# Only applicable for windows images
+ARG OS_VERSION=ltsc2022
+# pinned base images
+
+# mcr.microsoft.com/windows/servercore:ltsc2019 
+FROM mcr.microsoft.com/windows/servercore@sha256:6fdf140282a2f809dae9b13fe441635867f0a27c33a438771673b8da8f3348a4 AS ltsc2019
+
+# mcr.microsoft.com/windows/servercore:ltsc2022
+FROM mcr.microsoft.com/windows/servercore@sha256:45952938708fbde6ec0b5b94de68bcdec3f8c838be018536b1e9e5bd95e6b943 AS ltsc2022
+
+FROM ${OS_VERSION} AS agent-win
+ARG GOARCH=amd64 # default to amd64
+ARG GOOS=windows # default to windows
+ARG OS_VERSION=ltsc2022
+ARG REPO_PATH
+ARG BINARIES_PATH
+ENV GOARCH=${GOARCH}
+ENV GOOS=${GOOS}
+ENV OS_VERSION=${OS_VERSION}
+ENV BINARIES_PATH=${BINARIES_PATH}
+ENV REPO_PATH=${REPO_PATH}
+COPY ${REPO_PATH}/retina/windows/kubeconfigtemplate.yaml kubeconfigtemplate.yaml
+COPY ${REPO_PATH}/retina/windows/setkubeconfigpath.ps1 setkubeconfigpath.ps1
+COPY ${BINARIES_PATH}/captureworkload.exe captureworkload.exe
+COPY ${BINARIES_PATH}/controller.exe controller.exe
+ADD https://github.com/microsoft/etl2pcapng/releases/download/v1.10.0/etl2pcapng.exe /etl2pcapng.exe
+CMD ["controller.exe", "start", "--kubeconfig=.\\kubeconfig"]


### PR DESCRIPTION
# Description

Merging PR from main-  refactor: add dockerfile for windows build and make build-binaries #1720

We want to separate the windows build into 2 steps

Build the binaries needed for the final image
Build the final image including the binaries built in step 1
For step 1, add a build-binaries task to the Makefile that builds the binaries needed for the final image.
For step 2, add a Dockerfile for the windows build that builds the final image including the binaries built in step 1

## Related Issue

Make window's build branch compatible with release pipeline


Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
