### PR TITLE
fix: Update busy box image for download pod

### DIFF
--- a/cli/cmd/capture/download.go
+++ b/cli/cmd/capture/download.go
@@ -172,7 +172,7 @@ func createDownloadPod(ctx context.Context, kubeClient *kubernetes.Clientset, na
 			Containers: []corev1.Container{
 				{
 					Name:    "download",
-					Image:   "busybox",
+					Image:   "mcr.microsoft.com/azurelinux/busybox:1.36",
 					Command: []string{"sh", "-c", "echo 'Download pod ready'; sleep 3600"},
 					VolumeMounts: []corev1.VolumeMount{
 						{


### PR DESCRIPTION
# Description

Update image of busybox pod used for capture download.
Testing steps
- Create kind cluster
- Install gatekeeper for policy inforcemente
- Apply constraint that denies
- Download a capture with the busybox docker image - check that it fails
- Download a capture with the busybox mcr image - downloads without issues
- Followed the same steps for an aks cluster and the mcr busybox as a sanity check

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
