### PR TITLE
Return error when ip is nil

### DIFF
--- a/pkg/plugin/ebpfwindows/ebpf_windows.go
+++ b/pkg/plugin/ebpfwindows/ebpf_windows.go
@@ -281,6 +281,9 @@ func (p *Plugin) handleTraceEvent(data unsafe.Pointer, size uint32) error {
 		if fl.GetEventType() == nil {
 			return fmt.Errorf("%w", errNilDropNotifyEvent)
 		}
+		if fl.GetIP() == nil {
+			return fmt.Errorf("%w; perfdata: %v;", errNilDropNotifyEvent, perfData)
+		}
 		// Set the drop reason.
 		eventType := fl.GetEventType().GetSubType()
 		meta.DropReason = utils.DropReason(eventType)
@@ -304,6 +307,9 @@ func (p *Plugin) handleTraceEvent(data unsafe.Pointer, size uint32) error {
 		fl := e.GetFlow()
 		if fl == nil {
 			return fmt.Errorf("%w", errNilTraceNotifyFlow)
+		}
+		if fl.GetIP() == nil {
+			return fmt.Errorf("%w; perfdata: %v;", errNilDropNotifyEvent, perfData)
 		}
 		utils.AddRetinaMetadata(fl, meta)
 		p.enricher.Write(e)
@@ -329,6 +335,9 @@ func (p *Plugin) handleTraceEvent(data unsafe.Pointer, size uint32) error {
 		}
 		if fl.GetEventType() == nil {
 			return fmt.Errorf("%w", errNilDropNotifyEvent)
+		}
+		if fl.GetIP() == nil {
+			return fmt.Errorf("%w; perfdata: %v;", errNilDropNotifyEvent, perfData)
 		}
 		// Set the drop reason.
 		eventType := fl.GetEventType().GetSubType()


### PR DESCRIPTION
# Description

Retina pods crash when a nil ip is passed to the enricher.  Returning error in handleTraceEvent so that nil ip is not sent to enricher.

## Checklist

- [X] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [X] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
