### PR TITLE
fix: fixed linting differences between Makefile and Actions

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -32,7 +32,7 @@ jobs:
         if: env.IS_NOT_MERGE_GROUP
         uses: golangci/golangci-lint-action@v8
         with:
-          version: latest
-          args: --concurrency 4 --verbose --config=.golangci.yaml --timeout=25m
+          version: latest 
+          args: --verbose --config=.golangci.yaml --timeout=10m --concurrency=4 ./...
           only-new-issues: true
           skip-cache: true


### PR DESCRIPTION
# Description

I fixed linting differences between Makefile and Actions.
However, I think that the error was with `only-new-issues`, it was false,  but I think somebody has already fixed it, I've done minor changes and tested it locally.

## Related Issue

this pull request is related to #1802 issue.

## Checklist

- [X] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [X] I have correctly attributed the author(s) of the code.
- [X] I have tested the changes locally.
- [X] I have followed the project's style guidelines.
- [X] I have updated the documentation, if necessary.
- [X] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Linting errors looks the same.

<img width="1280" height="611" alt="image" src="https://github.com/user-attachments/assets/981c4d31-502b-4e07-b946-7bbd7aa46d91" />

<img width="1280" height="704" alt="image" src="https://github.com/user-attachments/assets/7aa5a47f-609d-4c7f-b9f5-9f3f63dd4ce7" />


## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
