### PR TITLE
deps: Updating hubble to mitigate cve from v1.17.5 to v1.18.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ PLATFORM		?= $(OS)/$(ARCH)
 PLATFORMS		?= linux/amd64 linux/arm64 windows/amd64
 OS_VERSION		?= ltsc2019
 
-HUBBLE_VERSION ?= v1.17.5
+HUBBLE_VERSION ?= v1.18.3
 
 CONTAINER_BUILDER ?= docker
 CONTAINER_RUNTIME ?= docker


### PR DESCRIPTION
This pull request makes a minor update to the `Makefile`, specifically updating the default `HUBBLE_VERSION` to a newer release.

* Updated the default value of `HUBBLE_VERSION` from `v1.17.5` to `v1.18.3` in the `Makefile` to use the latest version.# Description

Please provide a brief description of the changes made in this pull request.

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

<img width="1192" height="609" alt="image" src="https://github.com/user-attachments/assets/2bcf325c-6513-42ba-8cef-fc5b06f2ac50" />

<img width="1215" height="439" alt="image" src="https://github.com/user-attachments/assets/f8e46a49-684b-47e2-92a1-746d0ce3168e" />

<img width="1079" height="389" alt="image" src="https://github.com/user-attachments/assets/7f631271-3a39-4372-85b6-1362df99d1d8" />

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
