### PR TITLE
fix: add validation of error to k8sWatcherErrorHandler

### DIFF
--- a/pkg/k8s/watcher_linux.go
+++ b/pkg/k8s/watcher_linux.go
@@ -43,7 +43,12 @@ func Start(ctx context.Context, k *watchers.K8sWatcher) {
 // retinaK8sErrorHandler is a custom error handler for the watcher
 // that logs the error and tags the error to easily identify
 func k8sWatcherErrorHandler(c context.Context, e error, s string, i ...interface{}) {
+	if e == nil {
+		return
+	}
+
 	errStr := e.Error()
+
 	logError := func(er, r string) {
 		logger.WithFields(logrus.Fields{
 			"underlyingError": er,


### PR DESCRIPTION
# Description

add validation of error to k8sWatcherErrorHandler

## Related Issue

#1951 

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
