### PR TITLE
fix: stop endpoint manager in the agent to regen endpoints periodically

### DIFF
--- a/cmd/hubble/daemon_main_linux.go
+++ b/cmd/hubble/daemon_main_linux.go
@@ -60,6 +60,9 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.String(option.ConfigDir, "/retina/config", `Configuration directory that contains a file for each option`)
 	option.BindEnv(vp, option.ConfigDir)
 
+	// Set the default value for the endpoint GC interval to 0, which disables it.
+	vp.Set(option.EndpointGCInterval, 0)
+
 	if err := vp.BindPFlags(flags); err != nil {
 		logger.Fatalf("BindPFlags failed: %s", err)
 	}


### PR DESCRIPTION
# Description

Disabling the Endpoint regeneration from the Agent endpoint manager by setting the regen interval to 0. Verified that retina pods are healthy and no regenerating endpoint logs in test cluster.

## Related Issue

Close #1514

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
