### PR TITLE
fix: add logging to K8sErrorHandler when error is nil

### DIFF
--- a/pkg/k8s/watcher_linux.go
+++ b/pkg/k8s/watcher_linux.go
@@ -43,7 +43,15 @@ func Start(ctx context.Context, k *watchers.K8sWatcher) {
 // retinaK8sErrorHandler is a custom error handler for the watcher
 // that logs the error and tags the error to easily identify
 func k8sWatcherErrorHandler(c context.Context, e error, s string, i ...interface{}) {
+	if e == nil {
+		// TODO: handle key/values pairs in a better way
+		// current example output: time="2009-11-10T23:00:00Z" level=error msg="msg: Some error message -- key/values: [int 1 str world]"
+		logger.WithContext(c).Errorf("msg: %s -- key/values: %+v", s, i)
+		return
+	}
+
 	errStr := e.Error()
+
 	logError := func(er, r string) {
 		logger.WithFields(logrus.Fields{
 			"underlyingError": er,


### PR DESCRIPTION
# Description

Add logging to K8sErrorHandler when error is nil
closes #1951 

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
