### PR TITLE
deps: Updating hubble to mitigate cve

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ PLATFORM		?= $(OS)/$(ARCH)
 PLATFORMS		?= linux/amd64 linux/arm64 windows/amd64
 OS_VERSION		?= ltsc2019
 
-HUBBLE_VERSION ?= v1.17.5
+HUBBLE_VERSION ?= v1.18.3
 
 CONTAINER_BUILDER ?= docker
 CONTAINER_RUNTIME ?= docker


### PR DESCRIPTION
# Description

Please provide a brief description of the changes made in this pull request.

## Related Issue
This pull request updates the default version of Hubble used in the build process. The change ensures that future builds will use the newer `v1.18.3` version of Hubble instead of `v1.17.5`.

* Build configuration update:
  * Updated the `HUBBLE_VERSION` variable in the `Makefile` to use `v1.18.3` as the default Hubble version.
If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

<img width="1345" height="626" alt="image" src="https://github.com/user-attachments/assets/956f00d6-41d6-4c83-bd79-11066689ffa6" />


Hubble is currently using 1.25.3 go version, we cannot fix this cve from our side, I have highlight it in hubble slack channel. 

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
