### PR TITLE
fix(tests): Fix packetparser tests

### DIFF
--- a/pkg/plugin/packetparser/packetparser_linux_test.go
+++ b/pkg/plugin/packetparser/packetparser_linux_test.go
@@ -344,6 +344,10 @@ func TestReadDataPodLevelEnabled(t *testing.T) {
 
 	metrics.LostEventsCounter = mICounterVec
 
+	mParsedPacketsCounter := metrics.NewMockCounterVec(ctrl)
+	mParsedPacketsCounter.EXPECT().WithLabelValues(gomock.Any()).Return(prometheus.NewCounter(prometheus.CounterOpts{})).AnyTimes()
+	metrics.ParsedPacketsCounter = mParsedPacketsCounter
+
 	exCh := make(chan *v1.Event, 10)
 	p.SetupChannel(exCh)
 
@@ -560,22 +564,22 @@ func TestPacketParseGenerate(t *testing.T) {
 		{
 			name:             "PodLevelEnabled",
 			cfg:              cfgPodLevelEnabled,
-			expectedContents: "#define BYPASS_LOOKUP_IP_OF_INTEREST 1\n#define DATA_AGGREGATION_LEVEL 0\n",
+			expectedContents: "#define BYPASS_LOOKUP_IP_OF_INTEREST 1\n#define DATA_AGGREGATION_LEVEL 0\n#define DATA_SAMPLING_RATE 0\n",
 		},
 		{
 			name:             "ConntrackMetricsEnabled",
 			cfg:              cfgConntrackMetricsEnabled,
-			expectedContents: "#define BYPASS_LOOKUP_IP_OF_INTEREST 1\n#define ENABLE_CONNTRACK_METRICS 1\n#define DATA_AGGREGATION_LEVEL 1\n",
+			expectedContents: "#define BYPASS_LOOKUP_IP_OF_INTEREST 1\n#define ENABLE_CONNTRACK_METRICS 1\n#define DATA_AGGREGATION_LEVEL 1\n#define DATA_SAMPLING_RATE 0\n",
 		},
 		{
 			name:             "DataAggregationLevelLow",
 			cfg:              cfgDataAggregationLevelLow,
-			expectedContents: "#define DATA_AGGREGATION_LEVEL 0\n",
+			expectedContents: "#define BYPASS_LOOKUP_IP_OF_INTEREST 0\n#define DATA_AGGREGATION_LEVEL 0\n#define DATA_SAMPLING_RATE 0\n",
 		},
 		{
 			name:             "DataAggregationLevelHigh",
 			cfg:              cfgDataAggregationLevelHigh,
-			expectedContents: "#define DATA_AGGREGATION_LEVEL 1\n",
+			expectedContents: "#define BYPASS_LOOKUP_IP_OF_INTEREST 0\n#define DATA_AGGREGATION_LEVEL 1\n#define DATA_SAMPLING_RATE 0\n",
 		},
 	}
 


### PR DESCRIPTION
# Description

This PR fixes unit test failures in the `packetparser` plugin:

- Mocks `metrics.ParsedPacketsCounter` in `TestReadDataPodLevelEnabled` to prevent a nil pointer dereference during test execution.
- Updates the expected dynamic header content in `TestPacketParseGenerate` to match the actual generated output, which now includes `DATA_SAMPLING_RATE` and `BYPASS_LOOKUP_IP_OF_INTEREST` definitions.

## Related PRs

This test was broken in the following PRs

- #624
- #1767 

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

<img width="1624" height="1343" alt="image" src="https://github.com/user-attachments/assets/9549ed15-7c62-4537-a806-2d2368d3fc66" />

## Additional Notes

We have a bigger issue which is CI is not showing a failure when single test fails, we will look into that and create another PR to fix that. See this example (FAIL not caught) - reference #1688 

https://github.com/microsoft/retina/actions/runs/20115412850/job/57723528708#step:4:3145

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
