### PR TITLE
fix: Release Container Images action for Windows

### DIFF
--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -2,8 +2,8 @@ name: Release Retina Container Images
 
 on:
   push:
-    branches: [main, kamilp/release-windows]
-    # tags: ["v*"]
+    branches: [main]
+    tags: ["v*"]
 
 permissions:
   contents: read
@@ -38,7 +38,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Log in to registry
-        run: echo "${{ secrets.GH_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
 
       - name: Build/Push Images
         shell: bash
@@ -113,7 +113,7 @@ jobs:
         uses: sigstore/cosign-installer@v4.0.0
 
       - name: Log in to registry
-        run: echo "${{ secrets.GH_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
 
       - name: Build/Push Images
         shell: bash
@@ -163,7 +163,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Log in to registry
-        run: echo "${{ secrets.GH_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
 
       - name: Build/Push Images
         shell: bash
@@ -208,7 +208,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Log in to registry
-        run: echo "${{ secrets.GH_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
 
       - name: Build/Push Images
         shell: bash
@@ -251,7 +251,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Log in to registry
-        run: echo "${{ secrets.GH_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
 
       - name: Build/Push Images
         shell: bash
@@ -296,7 +296,7 @@ jobs:
         uses: sigstore/cosign-installer@v4.0.0
 
       - name: Log in to registry
-        run: echo "${{ secrets.GH_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
 
       - name: Generate Manifests
         shell: bash


### PR DESCRIPTION
# Description

As part of PR #1997 I introduced changes to how the Windows images are built. This was not carried over into the 'Release Container Images' job and thus it failed after the PR was merged.

<img width="1253" height="497" alt="image" src="https://github.com/user-attachments/assets/b00cee42-6700-46cd-8af1-bb548b118cdf" />

This PR addresses that. I ran the action on my branch and everything was green.

<img width="1436" height="1015" alt="image" src="https://github.com/user-attachments/assets/376ac9ec-1e37-443a-aa7d-81e156e4fd15" />


## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.






