### PR TITLE
feat(utils): use structpb.Struct directly for flow extensions

### DIFF
--- a/pkg/module/metrics/dns.go
+++ b/pkg/module/metrics/dns.go
@@ -141,18 +141,15 @@ func (d *DNSMetrics) responseValues(flow *v1.Flow) []string {
 func (d *DNSMetrics) getLabelsForProcessFlow(flow *v1.Flow) ([]string, error) {
 	var labels []string
 	// Get the DNS query type
-	meta := utils.RetinaMetadata{}
-	if err := flow.GetExtensions().UnmarshalTo(&meta); err != nil {
-		return labels, errors.Wrapf(err, "failed to unmarshal flow extensions")
-	}
-	switch meta.GetDnsType() {
+	_, dnsType, _ := utils.GetDNS(flow)
+	switch dnsType {
 	case utils.DNSType_QUERY:
 		labels = d.requestValues(flow)
 	case utils.DNSType_RESPONSE:
 		labels = d.responseValues(flow)
 	case utils.DNSType_UNKNOWN:
 	default:
-		return labels, errors.Errorf("invalid DNS type %d", int32(meta.GetDnsType()))
+		return labels, errors.Errorf("invalid DNS type %d", int32(dnsType))
 	}
 	return labels, nil
 }

--- a/pkg/module/metrics/dns_test.go
+++ b/pkg/module/metrics/dns_test.go
@@ -94,19 +94,19 @@ func TestGetLabels(t *testing.T) {
 
 func TestValues(t *testing.T) {
 	testR := &flow.Flow{}
-	metaR := &utils.RetinaMetadata{}
-	utils.AddDNSInfo(testR, metaR, "R", 0, "bing.com", []string{"A"}, 1, []string{"1.1.1.1"})
-	utils.AddRetinaMetadata(testR, metaR)
+	extR := utils.NewExtensions()
+	utils.AddDNSInfo(testR, extR, "R", 0, "bing.com", []string{"A"}, 1, []string{"1.1.1.1"})
+	utils.SetExtensions(testR, extR)
 
 	testQ := &flow.Flow{}
-	metaQ := &utils.RetinaMetadata{}
-	utils.AddDNSInfo(testQ, metaQ, "Q", 0, "bing.com", []string{"A"}, 0, []string{})
-	utils.AddRetinaMetadata(testQ, metaQ)
+	extQ := utils.NewExtensions()
+	utils.AddDNSInfo(testQ, extQ, "Q", 0, "bing.com", []string{"A"}, 0, []string{})
+	utils.SetExtensions(testQ, extQ)
 
 	testU := &flow.Flow{}
-	metaU := &utils.RetinaMetadata{}
-	utils.AddDNSInfo(testU, metaU, "U", 0, "bing.com", []string{"A"}, 0, []string{})
-	utils.AddRetinaMetadata(testU, metaU)
+	extU := utils.NewExtensions()
+	utils.AddDNSInfo(testU, extU, "U", 0, "bing.com", []string{"A"}, 0, []string{})
+	utils.SetExtensions(testU, extU)
 
 	tests := []struct {
 		name   string
@@ -203,19 +203,19 @@ func TestProcessLocalCtx(t *testing.T) {
 	defer ctrl.Finish()
 
 	testR := &flow.Flow{}
-	metaR := &utils.RetinaMetadata{}
-	utils.AddDNSInfo(testR, metaR, "R", 0, "bing.com", []string{"A"}, 1, []string{"1.1.1.1"})
-	utils.AddRetinaMetadata(testR, metaR)
+	extR := utils.NewExtensions()
+	utils.AddDNSInfo(testR, extR, "R", 0, "bing.com", []string{"A"}, 1, []string{"1.1.1.1"})
+	utils.SetExtensions(testR, extR)
 
 	testIngress := &flow.Flow{TrafficDirection: flow.TrafficDirection_INGRESS}
-	metaIngress := &utils.RetinaMetadata{}
-	utils.AddDNSInfo(testIngress, metaIngress, "R", 0, "bing.com", []string{"A"}, 1, []string{"1.1.1.1"})
-	utils.AddRetinaMetadata(testIngress, metaIngress)
+	extIngress := utils.NewExtensions()
+	utils.AddDNSInfo(testIngress, extIngress, "R", 0, "bing.com", []string{"A"}, 1, []string{"1.1.1.1"})
+	utils.SetExtensions(testIngress, extIngress)
 
 	testEgress := &flow.Flow{TrafficDirection: flow.TrafficDirection_EGRESS}
-	metaEgress := &utils.RetinaMetadata{}
-	utils.AddDNSInfo(testEgress, metaEgress, "R", 0, "bing.com", []string{"A"}, 1, []string{"1.1.1.1"})
-	utils.AddRetinaMetadata(testEgress, metaEgress)
+	extEgress := utils.NewExtensions()
+	utils.AddDNSInfo(testEgress, extEgress, "R", 0, "bing.com", []string{"A"}, 1, []string{"1.1.1.1"})
+	utils.SetExtensions(testEgress, extEgress)
 
 	tests := []struct {
 		name           string

--- a/pkg/module/metrics/latency_test.go
+++ b/pkg/module/metrics/latency_test.go
@@ -122,20 +122,20 @@ func TestProcessFlow(t *testing.T) {
 	 */
 	// Node -> Api server.
 	f1 := utils.ToFlow(l, t1, apiSeverIp, nodeIp, 80, 443, 6, 3, 0)
-	metaf1 := &utils.RetinaMetadata{}
-	utils.AddTCPID(metaf1, 1234)
+	ext1 := utils.NewExtensions()
+	utils.AddTCPID(ext1, 1234)
 	utils.AddTCPFlags(f1, 1, 0, 0, 0, 0, 0, 0, 0, 0)
-	utils.AddRetinaMetadata(f1, metaf1)
+	utils.SetExtensions(f1, ext1)
 	f1.Destination = &flow.Endpoint{
 		PodName: "kubernetes-apiserver",
 	}
 
 	// Api server -> Node.
 	f2 := utils.ToFlow(l, t2, nodeIp, apiSeverIp, 443, 80, 6, 2, 0)
-	metaf2 := &utils.RetinaMetadata{}
-	utils.AddTCPID(metaf2, 1234)
+	ext2 := utils.NewExtensions()
+	utils.AddTCPID(ext2, 1234)
 	utils.AddTCPFlags(f2, 1, 1, 0, 0, 0, 0, 0, 0, 0)
-	utils.AddRetinaMetadata(f2, metaf2)
+	utils.SetExtensions(f2, ext2)
 	f2.Source = &flow.Endpoint{
 		PodName: "kubernetes-apiserver",
 	}

--- a/pkg/plugin/dns/dns_linux.go
+++ b/pkg/plugin/dns/dns_linux.go
@@ -136,12 +136,12 @@ func (d *dns) eventHandler(event *types.Event) {
 		utils.Verdict_DNS,
 	)
 
-	meta := &utils.RetinaMetadata{}
+	ext := utils.NewExtensions()
 
-	utils.AddDNSInfo(fl, meta, string(event.Qr), common.RCodeToFlow(event.Rcode), event.DNSName, []string{event.QType}, event.NumAnswers, event.Addresses)
+	utils.AddDNSInfo(fl, ext, string(event.Qr), common.RCodeToFlow(event.Rcode), event.DNSName, []string{event.QType}, event.NumAnswers, event.Addresses)
 
-	// Add metadata to the flow.
-	utils.AddRetinaMetadata(fl, meta)
+	// Set extensions on the flow.
+	utils.SetExtensions(fl, ext)
 
 	ev := (&v1.Event{
 		Event:     fl,

--- a/pkg/plugin/dropreason/dropreason_linux.go
+++ b/pkg/plugin/dropreason/dropreason_linux.go
@@ -318,16 +318,16 @@ func (dr *dropReason) processRecord(ctx context.Context, id int) {
 			// IsReply is not applicable for DROPPED verdicts.
 			fl.IsReply = nil
 
-			meta := &utils.RetinaMetadata{}
+			ext := utils.NewExtensions()
 
-			// Add drop reason to the flow's metadata.
-			utils.AddDropReason(fl, meta, bpfEvent.DropType)
+			// Add drop reason to the flow's extensions.
+			utils.AddDropReason(fl, ext, bpfEvent.DropType)
 
-			// Add packet size to the flow's metadata.
-			utils.AddPacketSize(meta, bpfEvent.SkbLen)
+			// Add packet size to the flow's extensions.
+			utils.AddPacketSize(ext, bpfEvent.SkbLen)
 
-			// Add metadata to the flow.
-			utils.AddRetinaMetadata(fl, meta)
+			// Set extensions on the flow.
+			utils.SetExtensions(fl, ext)
 
 			// This is only for development purposes.
 			// Removing this makes logs way too chatter-y.

--- a/pkg/utils/flow_utils.go
+++ b/pkg/utils/flow_utils.go
@@ -11,6 +11,7 @@ import (
 	"github.com/microsoft/retina/pkg/log"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
@@ -20,6 +21,18 @@ const (
 	Verdict_RETRANSMISSION flow.Verdict = 15
 	Verdict_DNS            flow.Verdict = 16
 	TypeUrl                string       = "retina.sh"
+)
+
+// Extension field keys for structpb.Struct
+const (
+	ExtKeyBytes                = "bytes"
+	ExtKeyDNSType              = "dns_type"
+	ExtKeyNumResponses         = "num_responses"
+	ExtKeyTCPID                = "tcp_id"
+	ExtKeyDropReason           = "drop_reason"
+	ExtKeyPrevObservedPackets  = "previously_observed_packets"
+	ExtKeyPrevObservedBytes    = "previously_observed_bytes"
+	ExtKeyPrevObservedTCPFlags = "previously_observed_tcp_flags"
 )
 
 // ToFlow returns a flow.Flow object.
@@ -95,8 +108,6 @@ func ToFlow(
 		verdict = flow.Verdict_FORWARDED
 	}
 
-	ext, _ := anypb.New(&RetinaMetadata{}) //nolint:typecheck
-
 	f := &flow.Flow{
 		Type: flow.FlowType_L3_L4,
 		EventType: &flow.CiliumEventType{
@@ -114,7 +125,6 @@ func ToFlow(
 		// Packetparser running with conntrack can determine the traffic direction correctly and will override this value.
 		TrafficDirection: direction,
 		Verdict:          verdict,
-		Extensions:       ext,
 		// Setting IsReply to false by default.
 		// Packetparser running with conntrack can determine the direction of the flow, and will override this value.
 		IsReply: &wrapperspb.BoolValue{Value: false},
@@ -127,10 +137,32 @@ func ToFlow(
 	return f
 }
 
-// AddRetinaMetadata adds the RetinaMetadata to the flow's extensions field.
-func AddRetinaMetadata(f *flow.Flow, meta *RetinaMetadata) {
-	ext, _ := anypb.New(meta)
+// NewExtensions creates a new structpb.Struct for use as flow extensions.
+func NewExtensions() *structpb.Struct {
+	return &structpb.Struct{Fields: make(map[string]*structpb.Value)}
+}
+
+// SetExtensions wraps the struct in Any and sets it on the flow.
+// Only call this after populating all extension fields.
+func SetExtensions(f *flow.Flow, s *structpb.Struct) {
+	if f == nil || s == nil || len(s.GetFields()) == 0 {
+		return
+	}
+	ext, _ := anypb.New(s)
 	f.Extensions = ext
+}
+
+// getExtensionsStruct extracts the structpb.Struct from flow.Extensions.
+// Returns nil if Extensions is nil or not a Struct.
+func getExtensionsStruct(f *flow.Flow) *structpb.Struct {
+	if f == nil || f.GetExtensions() == nil {
+		return nil
+	}
+	s := &structpb.Struct{}
+	if err := f.GetExtensions().UnmarshalTo(s); err != nil {
+		return nil
+	}
+	return s
 }
 
 func AddTCPFlags(f *flow.Flow, syn, ack, fin, rst, psh, urg, ece, cwr, ns uint16) {
@@ -151,68 +183,83 @@ func AddTCPFlags(f *flow.Flow, syn, ack, fin, rst, psh, urg, ece, cwr, ns uint16
 	}
 }
 
-// AddPreviouslyObservedTCPFlags adds the previously observed TCP flags to the flows's metadata.
-func AddPreviouslyObservedTCPFlags(meta *RetinaMetadata, syn, ack, fin, rst, psh, urg, ece, cwr, ns uint32) {
-	if meta == nil {
+// AddPreviouslyObservedTCPFlags adds the previously observed TCP flags to the flow's extensions.
+func AddPreviouslyObservedTCPFlags(s *structpb.Struct, syn, ack, fin, rst, psh, urg, ece, cwr, ns uint32) {
+	if s == nil {
 		return
 	}
-	meta.PreviouslyObservedTcpFlags = map[string]uint32{
-		SYN: syn,
-		ACK: ack,
-		FIN: fin,
-		RST: rst,
-		PSH: psh,
-		URG: urg,
-		ECE: ece,
-		CWR: cwr,
-		NS:  ns,
+	// Only add if at least one flag is non-zero
+	if syn == 0 && ack == 0 && fin == 0 && rst == 0 && psh == 0 && urg == 0 && ece == 0 && cwr == 0 && ns == 0 {
+		return
 	}
+	tcpFlags := &structpb.Struct{Fields: map[string]*structpb.Value{
+		SYN: structpb.NewNumberValue(float64(syn)),
+		ACK: structpb.NewNumberValue(float64(ack)),
+		FIN: structpb.NewNumberValue(float64(fin)),
+		RST: structpb.NewNumberValue(float64(rst)),
+		PSH: structpb.NewNumberValue(float64(psh)),
+		URG: structpb.NewNumberValue(float64(urg)),
+		ECE: structpb.NewNumberValue(float64(ece)),
+		CWR: structpb.NewNumberValue(float64(cwr)),
+		NS:  structpb.NewNumberValue(float64(ns)),
+	}}
+	s.Fields[ExtKeyPrevObservedTCPFlags] = structpb.NewStructValue(tcpFlags)
 }
 
 func PreviouslyObservedTCPFlags(f *flow.Flow) map[string]uint32 {
-	e := f.GetExtensions()
-	if e == nil {
+	s := getExtensionsStruct(f)
+	if s == nil {
 		return nil
 	}
-	k := &RetinaMetadata{}
-	e.UnmarshalTo(k) //nolint:errcheck // ignore errors
-	return k.GetPreviouslyObservedTcpFlags()
+	v, ok := s.GetFields()[ExtKeyPrevObservedTCPFlags]
+	if !ok || v.GetStructValue() == nil {
+		return nil
+	}
+	result := make(map[string]uint32)
+	for k, val := range v.GetStructValue().GetFields() {
+		result[k] = uint32(val.GetNumberValue())
+	}
+	return result
 }
 
-// AddPreviouslyObservedBytes adds the previously observed bytes to the flow's metadata.
-func AddPreviouslyObservedBytes(meta *RetinaMetadata, bytes uint32) {
-	if meta == nil {
+// AddPreviouslyObservedBytes adds the previously observed bytes to the flow's extensions.
+func AddPreviouslyObservedBytes(s *structpb.Struct, bytes uint32) {
+	if s == nil || bytes == 0 {
 		return
 	}
-	meta.PreviouslyObservedBytes = bytes
+	s.Fields[ExtKeyPrevObservedBytes] = structpb.NewNumberValue(float64(bytes))
 }
 
 func PreviouslyObservedBytes(f *flow.Flow) uint32 {
-	e := f.GetExtensions()
-	if e == nil {
+	s := getExtensionsStruct(f)
+	if s == nil {
 		return 0
 	}
-	k := &RetinaMetadata{}
-	e.UnmarshalTo(k) //nolint:errcheck // ignore errors
-	return k.GetPreviouslyObservedBytes()
+	v, ok := s.GetFields()[ExtKeyPrevObservedBytes]
+	if !ok {
+		return 0
+	}
+	return uint32(v.GetNumberValue())
 }
 
-// AddPreviouslyObservedPackets adds the previously observed packets to the flow's metadata.
-func AddPreviouslyObservedPackets(meta *RetinaMetadata, packets uint32) {
-	if meta == nil {
+// AddPreviouslyObservedPackets adds the previously observed packets to the flow's extensions.
+func AddPreviouslyObservedPackets(s *structpb.Struct, packets uint32) {
+	if s == nil || packets == 0 {
 		return
 	}
-	meta.PreviouslyObservedPackets = packets
+	s.Fields[ExtKeyPrevObservedPackets] = structpb.NewNumberValue(float64(packets))
 }
 
 func PreviouslyObservedPackets(f *flow.Flow) uint32 {
-	e := f.GetExtensions()
-	if e == nil {
+	s := getExtensionsStruct(f)
+	if s == nil {
 		return 0
 	}
-	k := &RetinaMetadata{}
-	e.UnmarshalTo(k) //nolint:errcheck // ignore errors
-	return k.GetPreviouslyObservedPackets()
+	v, ok := s.GetFields()[ExtKeyPrevObservedPackets]
+	if !ok {
+		return 0
+	}
+	return uint32(v.GetNumberValue())
 }
 
 func AddTCPFlagsBool(f *flow.Flow, syn, ack, fin, rst, psh, urg bool) {
@@ -230,28 +277,34 @@ func AddTCPFlagsBool(f *flow.Flow, syn, ack, fin, rst, psh, urg bool) {
 	}
 }
 
-// Add TSval/TSecr to the flow's metadata as TCP ID.
+// AddTCPID adds TSval/TSecr to the flow's extensions as TCP ID.
 // The TSval/TSecr works as ID for the flow.
 // We will use this ID to calculate latency.
-func AddTCPID(meta *RetinaMetadata, id uint64) {
-	if meta == nil {
+func AddTCPID(s *structpb.Struct, id uint64) {
+	if s == nil || id == 0 {
 		return
 	}
-	meta.TcpId = id
+	s.Fields[ExtKeyTCPID] = structpb.NewNumberValue(float64(id))
 }
 
 func GetTCPID(f *flow.Flow) uint64 {
 	if f.GetL4() == nil || f.GetL4().GetTCP() == nil {
 		return 0
 	}
-	k := &RetinaMetadata{}      //nolint:typecheck
-	f.Extensions.UnmarshalTo(k) //nolint:errcheck
-	return k.TcpId
+	s := getExtensionsStruct(f)
+	if s == nil {
+		return 0
+	}
+	v, ok := s.GetFields()[ExtKeyTCPID]
+	if !ok {
+		return 0
+	}
+	return uint64(v.GetNumberValue())
 }
 
-// AddDNSInfo adds DNS information to the flow's metadata.
-func AddDNSInfo(f *flow.Flow, meta *RetinaMetadata, qType string, rCode uint32, query string, qTypes []string, numAnswers int, ips []string) {
-	if f == nil || meta == nil {
+// AddDNSInfo adds DNS information to the flow and its extensions.
+func AddDNSInfo(f *flow.Flow, s *structpb.Struct, qType string, rCode uint32, query string, qTypes []string, numAnswers int, ips []string) {
+	if f == nil || s == nil {
 		return
 	}
 	// Set type to L7.
@@ -273,17 +326,18 @@ func AddDNSInfo(f *flow.Flow, meta *RetinaMetadata, qType string, rCode uint32, 
 	}
 	switch qType {
 	case "Q":
-		meta.DnsType = DNSType_QUERY
+		s.Fields[ExtKeyDNSType] = structpb.NewStringValue(DNSType_QUERY.String())
 		f.L7.Type = flow.L7FlowType_REQUEST
 	case "R":
-		meta.DnsType = DNSType_RESPONSE
+		s.Fields[ExtKeyDNSType] = structpb.NewStringValue(DNSType_RESPONSE.String())
 		f.L7.Type = flow.L7FlowType_RESPONSE
 		f.IsReply = &wrapperspb.BoolValue{Value: true} // we can definitely say that this is a reply
 	default:
-		meta.DnsType = DNSType_UNKNOWN
 		f.L7.Type = flow.L7FlowType_UNKNOWN_L7_TYPE
 	}
-	meta.NumResponses = uint32(numAnswers)
+	if numAnswers > 0 {
+		s.Fields[ExtKeyNumResponses] = structpb.NewNumberValue(float64(numAnswers))
+	}
 }
 
 func GetDNS(f *flow.Flow) (*flow.DNS, DNSType, uint32) {
@@ -291,13 +345,27 @@ func GetDNS(f *flow.Flow) (*flow.DNS, DNSType, uint32) {
 		return nil, DNSType_UNKNOWN, 0
 	}
 	dns := f.L7.GetDns()
-	if f.Extensions == nil {
+	s := getExtensionsStruct(f)
+	if s == nil {
 		return dns, DNSType_UNKNOWN, 0
 	}
-	k := &RetinaMetadata{}      //nolint:typecheck
-	f.Extensions.UnmarshalTo(k) //nolint:errcheck
 
-	return dns, k.DnsType, k.NumResponses
+	dnsType := DNSType_UNKNOWN
+	if v, ok := s.GetFields()[ExtKeyDNSType]; ok {
+		switch v.GetStringValue() {
+		case DNSType_QUERY.String():
+			dnsType = DNSType_QUERY
+		case DNSType_RESPONSE.String():
+			dnsType = DNSType_RESPONSE
+		}
+	}
+
+	var numResponses uint32
+	if v, ok := s.GetFields()[ExtKeyNumResponses]; ok {
+		numResponses = uint32(v.GetNumberValue())
+	}
+
+	return dns, dnsType, numResponses
 }
 
 // DNS Return code to string.
@@ -323,38 +391,42 @@ func DNSRcodeToString(f *flow.Flow) string {
 	}
 }
 
-// AddPacketSize adds the packet size to the flow's metadata.
-func AddPacketSize(meta *RetinaMetadata, packetSize uint32) {
-	if meta == nil {
+// AddPacketSize adds the packet size to the flow's extensions.
+func AddPacketSize(s *structpb.Struct, packetSize uint32) {
+	if s == nil || packetSize == 0 {
 		return
 	}
-	meta.Bytes = packetSize
+	s.Fields[ExtKeyBytes] = structpb.NewNumberValue(float64(packetSize))
 }
 
 func PacketSize(f *flow.Flow) uint32 {
-	if f.Extensions == nil {
+	s := getExtensionsStruct(f)
+	if s == nil {
 		return 0
 	}
-	k := &RetinaMetadata{}      //nolint:typecheck
-	f.Extensions.UnmarshalTo(k) //nolint:errcheck
-	return k.Bytes
+	v, ok := s.GetFields()[ExtKeyBytes]
+	if !ok {
+		return 0
+	}
+	return uint32(v.GetNumberValue())
 }
 
-// AddDropReason adds the drop reason to the flow's metadata.
-func AddDropReason(f *flow.Flow, meta *RetinaMetadata, dropReason uint16) {
-	if f == nil || meta == nil {
+// AddDropReason adds the drop reason to the flow and its extensions.
+func AddDropReason(f *flow.Flow, s *structpb.Struct, dropReason uint16) {
+	if f == nil || s == nil {
 		return
 	}
 
-	meta.DropReason = DropReason(dropReason)
+	dr := DropReason(dropReason)
+	s.Fields[ExtKeyDropReason] = structpb.NewStringValue(dr.String())
 
 	f.Verdict = flow.Verdict_DROPPED
 
 	// Set the drop reason.
 	// Retina drop reasons are different from the drop reasons available in flow library.
 	// We map the ones available in flow library to the ones available in Retina.
-	// Rest are set to UNKNOWN. The details are added in the metadata.
-	f.DropReasonDesc = GetDropReasonDesc(meta.GetDropReason())
+	// Rest are set to UNKNOWN. The details are added in the extensions.
+	f.DropReasonDesc = GetDropReasonDesc(dr)
 
 	f.EventType = &flow.CiliumEventType{
 		Type:    int32(api.MessageTypeDrop),
@@ -366,9 +438,15 @@ func DropReasonDescription(f *flow.Flow) string {
 	if f == nil {
 		return ""
 	}
-	k := &RetinaMetadata{}           //nolint:typecheck // Not required to check type as we are setting it.
-	f.GetExtensions().UnmarshalTo(k) //nolint:errcheck // Not required to check error as we are setting it.
-	return k.GetDropReason().String()
+	s := getExtensionsStruct(f)
+	if s == nil {
+		return ""
+	}
+	v, ok := s.GetFields()[ExtKeyDropReason]
+	if !ok {
+		return ""
+	}
+	return v.GetStringValue()
 }
 
 func decodeTime(nanoseconds int64) (pbTime *timestamppb.Timestamp, err error) {

--- a/pkg/utils/utils_linux_test.go
+++ b/pkg/utils/utils_linux_test.go
@@ -47,7 +47,8 @@ func TestToFlow(t *testing.T) {
 	assert.EqualValues(t, f.GetL4().Protocol.(*flow.Layer4_TCP).TCP.SourcePort, uint32(443))
 	assert.EqualValues(t, f.GetL4().Protocol.(*flow.Layer4_TCP).TCP.DestinationPort, uint32(80))
 	assert.NotNil(t, f.Time)
-	assert.NotNil(t, f.Extensions)
+	// Extensions are now set separately via SetExtensions() after populating extension fields
+	assert.Nil(t, f.Extensions)
 	assert.Equal(t, f.Type, flow.FlowType_L3_L4)
 
 	if !f.GetTime().IsValid() {
@@ -87,9 +88,9 @@ func TestAddPacketSize(t *testing.T) {
 		uint8(1),
 		flow.Verdict_FORWARDED,
 	)
-	meta := &RetinaMetadata{}
-	AddPacketSize(meta, uint32(100))
-	AddRetinaMetadata(fl, meta)
+	ext := NewExtensions()
+	AddPacketSize(ext, uint32(100))
+	SetExtensions(fl, ext)
 
 	res := PacketSize(fl)
 	assert.EqualValues(t, res, uint32(100))
@@ -111,9 +112,9 @@ func TestTcpID(t *testing.T) {
 		flow.Verdict_FORWARDED,
 	)
 
-	meta := &RetinaMetadata{}
-	AddTCPID(meta, uint64(1234))
-	AddRetinaMetadata(fl, meta)
+	ext := NewExtensions()
+	AddTCPID(ext, uint64(1234))
+	SetExtensions(fl, ext)
 	assert.EqualValues(t, GetTCPID(fl), uint64(1234))
 }
 
@@ -154,9 +155,9 @@ func TestAddDropReason(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			f := &flow.Flow{}
-			meta := &RetinaMetadata{}
-			AddDropReason(f, meta, tc.dropReason)
-			AddRetinaMetadata(f, meta)
+			ext := NewExtensions()
+			AddDropReason(f, ext, tc.dropReason)
+			SetExtensions(f, ext)
 			assert.Equal(t, f.DropReasonDesc, tc.expectedDesc)
 			assert.Equal(t, f.Verdict, flow.Verdict_DROPPED)
 			assert.NotNil(t, f.EventType.Type, 1)


### PR DESCRIPTION
# Description

Replace `RetinaMetadata` with `structpb.Struct` for flow extensions to enable Hubble CLI JSON marshaling without type registration

Changes:
- Add `NewExtensions()` and `SetExtensions()` helper functions
- Update Add* functions to take `*structpb.Struct` instead of `*RetinaMetadata`
- Update accessor functions to read from Struct
- Update all plugins and tests to use new API


## Related Issue
Closes https://github.com/microsoft/retina/issues/1080

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

```bash
{"flow":{"time":"2026-01-31T17:10:38.030385093Z","verdict":"FORWARDED","IP":{"source":"10.10.0.5","destination":"192.168.0.73","ipVersion":"IPv4"},"l4":{"TCP":{"source_port":4244,"destination_port":38112,"flags":{"SYN":true,"ACK":true}}},"source":{"ID":1,"identity":1,"labels":["reserved:host"]},"destination":{"ID":51516,"identity":51516,"namespace":"kube-system","labels":["k8s:io.cilium.k8s.namespace.labels.kubernetes.azure.com/managedby=aks","k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=kube-system","k8s:io.cilium.k8s.policy.cluster=default","k8s:k8s-app=hubble-relay","k8s:io.cilium.k8s.namespace.labels.addonmanager.kubernetes.io/mode=Reconcile","k8s:io.cilium.k8s.namespace.labels.control-plane=true","k8s:io.cilium.k8s.namespace.labels.kubernetes.io/cluster-service=true","k8s:io.cilium.k8s.policy.serviceaccount=hubble-relay","k8s:io.kubernetes.pod.namespace=kube-system","k8s:pod-template-hash=6b7c54d9ff","k8s:app.kubernetes.io/name=hubble-relay","k8s:app.kubernetes.io/part-of=cilium"],"pod_name":"hubble-relay-6b7c54d9ff-2lsqj"},"Type":"L3_L4","event_type":{"type":4},"traffic_direction":"EGRESS","trace_observation_point":"TO_ENDPOINT","is_reply":true,"Summary":"TCP Flags: SYN:true ACK:true","extensions":{"@type":"type.googleapis.com/google.protobuf.Struct","value":{"bytes":74,"previously_observed_tcp_flags":{"ACK":0,"CWR":0,"ECE":0,"FIN":0,"NS":0,"PSH":0,"RST":0,"SYN":0,"URG":0}}}},"time":"2026-01-31T17:10:38.030385093Z"}
{"flow":{"time":"2026-01-31T17:10:38.030403862Z","verdict":"FORWARDED","IP":{"source":"192.168.0.73","destination":"10.10.0.5","ipVersion":"IPv4"},"l4":{"TCP":{"source_port":38112,"destination_port":4244,"flags":{"ACK":true}}},"source":{"ID":51516,"identity":51516,"namespace":"kube-system","labels":["k8s:io.cilium.k8s.namespace.labels.kubernetes.azure.com/managedby=aks","k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=kube-system","k8s:io.cilium.k8s.policy.cluster=default","k8s:k8s-app=hubble-relay","k8s:io.cilium.k8s.namespace.labels.addonmanager.kubernetes.io/mode=Reconcile","k8s:io.cilium.k8s.namespace.labels.control-plane=true","k8s:io.cilium.k8s.namespace.labels.kubernetes.io/cluster-service=true","k8s:io.cilium.k8s.policy.serviceaccount=hubble-relay","k8s:io.kubernetes.pod.namespace=kube-system","k8s:pod-template-hash=6b7c54d9ff","k8s:app.kubernetes.io/name=hubble-relay","k8s:app.kubernetes.io/part-of=cilium"],"pod_name":"hubble-relay-6b7c54d9ff-2lsqj"},"destination":{"ID":1,"identity":1,"labels":["reserved:host"]},"Type":"L3_L4","event_type":{"type":4,"sub_type":3},"traffic_direction":"EGRESS","trace_observation_point":"TO_STACK","is_reply":false,"Summary":"TCP Flags: ACK:true","extensions":{"@type":"type.googleapis.com/google.protobuf.Struct","value":{"bytes":66,"previously_observed_tcp_flags":{"ACK":0,"CWR":0,"ECE":0,"FIN":0,"NS":0,"PSH":0,"RST":0,"SYN":0,"URG":0}}}},"time":"2026-01-31T17:10:38.030403862Z"}
{"flow":{"time":"2026-01-31T17:10:38.030513168Z","verdict":"DROPPED","IP":{"source":"0.0.0.0","destination":"0.0.0.0","ipVersion":"IPv4"},"source":{"ID":2,"identity":2,"labels":["reserved:world"]},"destination":{"ID":2,"identity":2,"labels":["reserved:world"]},"Type":"L3_L4","event_type":{"type":1},"traffic_direction":"INGRESS","trace_observation_point":"FROM_NETWORK","Summary":"Drop Reason: TCP_ACCEPT_BASIC\nNote: This reason is most accurate. Prefer over others while using Hubble CLI.","extensions":{"@type":"type.googleapis.com/google.protobuf.Struct","value":{"drop_reason":"TCP_ACCEPT_BASIC"}}},"time":"2026-01-31T17:10:38.030513168Z"}
{"flow":{"time":"2026-01-31T17:10:38.030525215Z","verdict":"FORWARDED","IP":{"source":"192.168.0.73","destination":"10.10.0.5","ipVersion":"IPv4"},"l4":{"TCP":{"source_port":38112,"destination_port":4244,"flags":{"PSH":true,"ACK":true}}},"source":{"ID":51516,"identity":51516,"namespace":"kube-system","labels":["k8s:io.cilium.k8s.namespace.labels.kubernetes.azure.com/managedby=aks","k8s:io.cilium.k8s.namespace.labels.kubernetes.io/metadata.name=kube-system","k8s:io.cilium.k8s.policy.cluster=default","k8s:k8s-app=hubble-relay","k8s:io.cilium.k8s.namespace.labels.addonmanager.kubernetes.io/mode=Reconcile","k8s:io.cilium.k8s.namespace.labels.control-plane=true","k8s:io.cilium.k8s.namespace.labels.kubernetes.io/cluster-service=true","k8s:io.cilium.k8s.policy.serviceaccount=hubble-relay","k8s:io.kubernetes.pod.namespace=kube-system","k8s:pod-template-hash=6b7c54d9ff","k8s:app.kubernetes.io/name=hubble-relay","k8s:app.kubernetes.io/part-of=cilium"],"pod_name":"hubble-relay-6b7c54d9ff-2lsqj"},"destination":{"ID":1,"identity":1,"labels":["reserved:host"]},"Type":"L3_L4","event_type":{"type":4,"sub_type":3},"traffic_direction":"EGRESS","trace_observation_point":"TO_STACK","is_reply":false,"Summary":"TCP Flags: PSH:true ACK:true","extensions":{"@type":"type.googleapis.com/google.protobuf.Struct","value":{"bytes":90,"previously_observed_tcp_flags":{"ACK":0,"CWR":0,"ECE":0,"FIN":0,"NS":0,"PSH":0,"RST":0,"SYN":0,"URG":0}}}},"time":"2026-01-31T17:10:38.030525215Z"}
```
<img width="2871" height="526" alt="image" src="https://github.com/user-attachments/assets/80d5b4a7-1ba8-47f6-9285-a9c82e9519bc" />

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
