### PR TITLE
fix(ci): use native arm64 runners for shell image build

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -203,13 +203,18 @@ jobs:
           IS_MERGE_GROUP: ${{ github.event_name == 'merge_group' }}
 
   retina-shell-images:
-    name: Build Retina Shell Images
-    runs-on: ubuntu-latest
+    name: Build Retina Shell Images (${{ matrix.platform }}, ${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
 
     strategy:
       matrix:
-        platform: ["linux"]
-        arch: ["amd64", "arm64"]
+        include:
+          - platform: linux
+            arch: amd64
+            runner: ubuntu-latest
+          - platform: linux
+            arch: arm64
+            runner: ubuntu-24.04-arm
 
     steps:
       - name: Checkout code
@@ -219,9 +224,6 @@ jobs:
         with:
           go-version-file: go.mod
       - run: go version
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Az CLI login
         uses: azure/login@v2

--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -184,13 +184,18 @@ jobs:
           done
 
   retina-shell-images:
-    name: Build Retina Shell Images
-    runs-on: ubuntu-latest
+    name: Build Retina Shell Images (${{ matrix.platform }}, ${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
 
     strategy:
       matrix:
-        platform: ["linux"]
-        arch: ["amd64", "arm64"]
+        include:
+          - platform: linux
+            arch: amd64
+            runner: ubuntu-latest
+          - platform: linux
+            arch: arm64
+            runner: ubuntu-24.04-arm
 
     steps:
       - name: Checkout code
@@ -203,9 +208,6 @@ jobs:
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@v4.0.0
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Log in to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ ifndef TAG
 endif
 OUTPUT_DIR = $(REPO_ROOT)/output
 ARTIFACTS_DIR = $(REPO_ROOT)/artifacts
+OUTPUT_LOCAL ?= --output type=local,dest=$(ARTIFACTS_DIR)
 BUILD_DIR = $(OUTPUT_DIR)/$(GOOS)_$(GOARCH)
 RETINA_BUILD_DIR = $(BUILD_DIR)/retina
 RETINA_DIR = $(REPO_ROOT)/controller
@@ -234,7 +235,7 @@ container-docker: buildx # util target to build container images using docker bu
 		--build-arg VERSION=$(VERSION) $(EXTRA_BUILD_ARGS) \
 		--target=$(TARGET) \
 		-t $(IMAGE_REGISTRY)/$(IMAGE):$(TAG) \
-		--output type=local,dest=$(ARTIFACTS_DIR) \
+		$(OUTPUT_LOCAL) \
 		$(BUILDX_ACTION) \
 		$(CONTEXT_DIR) 
 
@@ -325,6 +326,7 @@ retina-shell-image:
 			IMAGE=$(RETINA_SHELL_IMAGE) \
 			VERSION=$(TAG) \
 			TAG=$(RETINA_PLATFORM_TAG) \
+			OUTPUT_LOCAL= \
 			CONTEXT_DIR=$(REPO_ROOT)
 
 kubectl-retina-image:


### PR DESCRIPTION
# Description

Use native arm64 runners (`ubuntu-24.04-arm`) for arm64 shell image builds instead of QEMU emulation on x86_64 runners.

The shell image build was getting stuck for 2+ hours when building arm64 images because installing `bpftrace` and its dependencies (LLVM 18.1, clang - 527MB total) under QEMU is extremely slow. The v1.0.3 release workflow has been stuck/retried 15+ times due to this.

Changes:
- Use native arm64 runners for shell image builds in `images.yaml` and `release-images.yaml`
- Skip local export for shell image in Makefile (no artifacts needed, speeds up build)

## Related Issue

Unblocks v1.0.3 release

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Tested locally - shell image builds in ~47 seconds without local export.