### PR TITLE
fix: Add darwin drop reason mapping for GoReleaser builds

### DIFF
--- a/pkg/utils/utils_darwin.go
+++ b/pkg/utils/utils_darwin.go
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+package utils
+
+import (
+	"github.com/cilium/cilium/api/v1/flow"
+)
+
+func GetDropReasonDesc(dr DropReason) flow.DropReason {
+	// Keep mapping aligned with Linux where drop reasons overlap.
+	switch dr { //nolint:exhaustive // We are handling all the cases.
+	case DropReason_IPTABLE_RULE_DROP:
+		return flow.DropReason_POLICY_DENIED
+	case DropReason_IPTABLE_NAT_DROP:
+		return flow.DropReason_SNAT_NO_MAP_FOUND
+	case DropReason_CONNTRACK_ADD_DROP:
+		return flow.DropReason_UNKNOWN_CONNECTION_TRACKING_STATE
+	default:
+		return flow.DropReason_DROP_REASON_UNKNOWN
+	}
+}


### PR DESCRIPTION
# Description
- Add darwin implementation of `GetDropReasonDesc` to fix GoReleaser darwin builds.

## Context
- GoReleaser builds darwin targets; utils package lacked darwin implementation, causing undefined symbol.

## Testing
- Not run (build-only change).

## Related Issue

See issue in this job run (for an unrelated PR) https://github.com/microsoft/retina/actions/runs/21755953385/job/62766139385?pr=1981

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
