### PR TITLE
fix: adapt Hubble/Cilium control plane for v1.19 DI changes

### DIFF
--- a/cmd/hubble/cells_linux.go
+++ b/cmd/hubble/cells_linux.go
@@ -5,18 +5,21 @@
 package hubble
 
 import (
+	"github.com/cilium/cilium/pkg/datapath/link"
 	"github.com/cilium/cilium/pkg/defaults"
 	"github.com/cilium/cilium/pkg/gops"
 	hubblecell "github.com/cilium/cilium/pkg/hubble/cell"
-	exportercell "github.com/cilium/cilium/pkg/hubble/exporter/cell"
+	ciliumparser "github.com/cilium/cilium/pkg/hubble/parser"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
+	"github.com/cilium/cilium/pkg/kpr"
+	"github.com/cilium/cilium/pkg/kvstore"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/node/manager"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/cilium/pkg/pprof"
-	"github.com/cilium/cilium/pkg/recorder"
 	"github.com/cilium/hive/cell"
+	"github.com/cilium/statedb"
 	"k8s.io/client-go/rest"
 
 	"github.com/microsoft/retina/internal/buildinfo"
@@ -31,6 +34,20 @@ import (
 	"github.com/microsoft/retina/pkg/shared/telemetry"
 )
 
+// disabledKVStoreClient wraps a kvstore.Client but returns IsEnabled() = false.
+// This is needed because K8sCiliumEndpointsWatcher only initializes if kvstore is disabled.
+// When kvstore is enabled, Cilium expects CiliumEndpoint data to come from kvstore,
+// but Retina watches CiliumEndpoint CRDs directly and needs the watcher to populate IPCache.
+type disabledKVStoreClient struct {
+	kvstore.Client
+}
+
+// IsEnabled returns false to indicate kvstore is not being used for CiliumEndpoint sync.
+// This allows the K8sCiliumEndpointsWatcher to initialize and populate IPCache with K8sMetadata.
+func (d *disabledKVStoreClient) IsEnabled() bool {
+	return false
+}
+
 var (
 	Agent = cell.Module(
 		"agent",
@@ -39,7 +56,7 @@ var (
 		ControlPlane,
 	)
 	daemonSubsys = "daemon"
-	logger       = logging.DefaultLogger.WithField(logfields.LogSubsys, daemonSubsys)
+	logger       = logging.DefaultSlogLogger.With(logfields.LogSubsys, daemonSubsys)
 
 	Infrastructure = cell.Module(
 		"infrastructure",
@@ -60,6 +77,19 @@ var (
 
 		// Kubernetes client
 		k8sClient.Cell,
+
+		// Kube proxy replacement config (needed by loadbalancer cells)
+		kpr.Cell,
+
+		// Provide a disabled kvstore client for Retina.
+		// This is important: the K8sCiliumEndpointsWatcher only initializes
+		// if kvstore.IsEnabled() returns false (because with a real kvstore,
+		// CiliumEndpoint data would come from kvstore instead of watching CRDs).
+		// Since Retina doesn't use etcd/consul and relies on watching CiliumEndpoint CRDs,
+		// we need IsEnabled() to return false so the watcher populates IPCache with K8sMetadata.
+		cell.Provide(func(db *statedb.DB) kvstore.Client {
+			return &disabledKVStoreClient{Client: kvstore.NewInMemoryClient(db, "default")}
+		}),
 
 		cell.Provide(func(cfg config.Config, k8sCfg *rest.Config) telemetry.Config {
 			return telemetry.Config{
@@ -92,11 +122,11 @@ var (
 
 		retinak8s.Cell,
 
-		recorder.Cell,
-
 		// Provides resources for hubble
 		resources.Cell,
-		cell.Provide(parser.New),
+
+		// Provides link cache needed by hubble parser
+		link.Cell,
 
 		// Provides the node reconciler as node manager
 		rnode.Cell,
@@ -106,9 +136,13 @@ var (
 			},
 		),
 
-		exportercell.Cell,
-		// Provides the hubble agent
-		hubblecell.Core,
+		// Provides the full hubble agent (includes parser, exporter, metrics, and TLS)
+		hubblecell.Cell,
+
+		// Override Cilium's parser with Retina's parser that understands v1.Event from plugins
+		cell.DecorateAll(func(_ ciliumparser.Decoder, params parser.Params) ciliumparser.Decoder {
+			return parser.New(params)
+		}),
 
 		telemetry.Heartbeat,
 	)

--- a/cmd/standard/daemon.go
+++ b/cmd/standard/daemon.go
@@ -4,6 +4,7 @@ package standard
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 
@@ -128,6 +129,7 @@ func (d *Daemon) Start() error {
 		panic(err)
 	}
 	defer zl.Close()
+	log.SetDefaultSlog() // Set Go's global slog to use zap-backed handler
 	mainLogger := zl.Named("main").Sugar()
 
 	// Allow the current process to lock memory for eBPF resources.
@@ -137,7 +139,7 @@ func (d *Daemon) Start() error {
 		mainLogger.Fatal("failed to remove memlock", zap.Error(err))
 	}
 
-	metrics.InitializeMetrics()
+	metrics.InitializeMetrics(slog.Default())
 
 	mainLogger.Info(zap.String("data aggregation level", daemonConfig.DataAggregationLevel.String()))
 
@@ -294,7 +296,7 @@ func (d *Daemon) Start() error {
 		}
 	}
 
-	controllerMgr, err := cm.NewControllerManager(daemonConfig, cl, tel)
+	controllerMgr, err := cm.NewControllerManager(daemonConfig, cl, tel, slog.Default())
 	if err != nil {
 		mainLogger.Fatal("Failed to create controller manager", zap.Error(err))
 	}

--- a/pkg/config/hubble_config_linux.go
+++ b/pkg/config/hubble_config_linux.go
@@ -3,12 +3,12 @@
 package config
 
 import (
+	"log/slog"
 	"path/filepath"
 
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/hive/cell"
 	sharedconfig "github.com/microsoft/retina/pkg/shared/config"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 )
 
@@ -64,14 +64,14 @@ var (
 
 		cell.Config(DefaultRetinaHubbleConfig),
 
-		cell.Provide(func(logger logrus.FieldLogger) (Config, error) {
+		cell.Provide(func(logger *slog.Logger) (Config, error) {
 			retinaConfigFile := filepath.Join(option.Config.ConfigDir, configFileName)
 			conf, err := GetConfig(retinaConfigFile)
 			if err != nil {
-				logger.Error(err)
+				logger.Error("failed to get config", "error", err)
 				conf = DefaultRetinaConfig
 			}
-			logger.Info(conf)
+			logger.Info("loaded config", "config", conf)
 			return *conf, nil
 		}),
 		sharedconfig.Cell,

--- a/pkg/controllers/daemon/nodereconciler/cell_linux.go
+++ b/pkg/controllers/daemon/nodereconciler/cell_linux.go
@@ -1,6 +1,7 @@
 package nodereconciler
 
 import (
+	"log/slog"
 	"os"
 
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
@@ -10,7 +11,6 @@ import (
 	"github.com/microsoft/retina/pkg/config"
 	"github.com/microsoft/retina/pkg/log"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -20,10 +20,10 @@ var Cell = cell.Module(
 	"Node Controller monitors Node CRUD events",
 	cell.Provide(newNodeController),
 	// Setting up the node controller with the controller manager
-	cell.Invoke(func(l logrus.FieldLogger, nr *NodeReconciler, ctrlManager ctrl.Manager) error {
+	cell.Invoke(func(l *slog.Logger, nr *NodeReconciler, ctrlManager ctrl.Manager) error {
 		l.Info("Setting up node controller with manager")
 		if err := nr.SetupWithManager(ctrlManager); err != nil {
-			l.Errorf("failed to setup node controller with manager: %v", err)
+			l.Error("failed to setup node controller with manager", "error", err)
 			return errors.Wrap(err, "failed to setup node controller with manager")
 		}
 		return nil

--- a/pkg/controllers/daemon/nodereconciler/node_controller_linux.go
+++ b/pkg/controllers/daemon/nodereconciler/node_controller_linux.go
@@ -246,8 +246,6 @@ func (r *NodeReconciler) ClusterSizeDependantInterval(time.Duration) time.Durati
 	return time.Second * 5
 }
 
-func (r *NodeReconciler) Enqueue(*types.Node) {}
-
 func (r *NodeReconciler) GetNodeIdentities() []types.Identity {
 	return []types.Identity{}
 }
@@ -263,10 +261,6 @@ func (r *NodeReconciler) NodeDeleted(types.Node) {}
 func (r *NodeReconciler) NodeSync() {}
 
 func (r *NodeReconciler) NodeUpdated(types.Node) {}
-
-func (r *NodeReconciler) StartNeighborRefresh(datapath.NodeNeighbors) {}
-
-func (r *NodeReconciler) StartNodeNeighborLinkUpdater(datapath.NodeNeighbors) {}
 
 func (r *NodeReconciler) SetPrefixClusterMutatorFn(func(*types.Node) []cmtypes.PrefixClusterOpts) {}
 

--- a/pkg/hubble/parser/layer34/parser_linux.go
+++ b/pkg/hubble/parser/layer34/parser_linux.go
@@ -2,6 +2,7 @@ package layer34
 
 import (
 	"fmt"
+	"log/slog"
 	"net/netip"
 
 	"github.com/cilium/cilium/api/v1/flow"
@@ -9,19 +10,17 @@ import (
 
 	"github.com/microsoft/retina/pkg/hubble/common"
 	"github.com/microsoft/retina/pkg/utils"
-	"github.com/sirupsen/logrus"
-	"go.uber.org/zap"
 )
 
 type Parser struct {
-	l   *logrus.Entry
+	l   *slog.Logger
 	svd common.SvcDecoder
 	epd common.EpDecoder
 }
 
-func New(l *logrus.Entry, svc common.SvcDecoder, c *ipc.IPCache, labelCache common.LabelCache) *Parser {
+func New(l *slog.Logger, svc common.SvcDecoder, c *ipc.IPCache, labelCache common.LabelCache) *Parser {
 	p := &Parser{
-		l:   l.WithField("subsys", "layer34"),
+		l:   l.With("subsys", "layer34"),
 		svd: svc,
 		epd: common.NewEpDecoder(c, labelCache),
 	}
@@ -35,17 +34,17 @@ func (p *Parser) Decode(f *flow.Flow) *flow.Flow {
 		return nil
 	}
 	if f.GetIP() == nil {
-		p.l.Warn("Failed to get IP from flow", zap.Any("flow", f))
+		p.l.Warn("Failed to get IP from flow", "flow", f)
 		return f
 	}
 	sourceIP, err := netip.ParseAddr(f.GetIP().GetSource())
 	if err != nil {
-		p.l.Warn("Failed to parse source IP", zap.Error(err))
+		p.l.Warn("Failed to parse source IP", "error", err)
 		return f
 	}
 	destIP, err := netip.ParseAddr(f.GetIP().GetDestination())
 	if err != nil {
-		p.l.Warn("Failed to parse destination IP", zap.Error(err))
+		p.l.Warn("Failed to parse destination IP", "error", err)
 		return f
 	}
 

--- a/pkg/hubble/parser/seven/parser_linux.go
+++ b/pkg/hubble/parser/seven/parser_linux.go
@@ -2,6 +2,7 @@ package seven
 
 import (
 	"fmt"
+	"log/slog"
 	"net/netip"
 	"strings"
 
@@ -9,19 +10,17 @@ import (
 	ipc "github.com/cilium/cilium/pkg/ipcache"
 	"github.com/google/gopacket/layers"
 	"github.com/microsoft/retina/pkg/hubble/common"
-	"github.com/sirupsen/logrus"
-	"go.uber.org/zap"
 )
 
 type Parser struct {
-	l   *logrus.Entry
+	l   *slog.Logger
 	svd common.SvcDecoder
 	epd common.EpDecoder
 }
 
-func New(l *logrus.Entry, svc common.SvcDecoder, c *ipc.IPCache, labelCache common.LabelCache) *Parser {
+func New(l *slog.Logger, svc common.SvcDecoder, c *ipc.IPCache, labelCache common.LabelCache) *Parser {
 	return &Parser{
-		l:   l.WithField("subsys", "seven"),
+		l:   l.With("subsys", "seven"),
 		svd: svc,
 		epd: common.NewEpDecoder(c, labelCache),
 	}
@@ -62,17 +61,17 @@ func (p *Parser) decodeIP(f *flow.Flow) {
 
 	// Decode the flow's source and destination IPs to their respective service.
 	if f.GetIP() == nil {
-		p.l.Warn("Failed to get IP from flow", zap.Any("flow", f))
+		p.l.Warn("Failed to get IP from flow", "flow", f)
 		return
 	}
 	sourceIP, err := netip.ParseAddr(f.GetIP().GetSource())
 	if err != nil {
-		p.l.Warn("Failed to parse source IP", zap.Error(err))
+		p.l.Warn("Failed to parse source IP", "error", err)
 		return
 	}
 	destIP, err := netip.ParseAddr(f.GetIP().GetDestination())
 	if err != nil {
-		p.l.Warn("Failed to parse destination IP", zap.Error(err))
+		p.l.Warn("Failed to parse destination IP", "error", err)
 		return
 	}
 

--- a/pkg/k8s/cell_linux.go
+++ b/pkg/k8s/cell_linux.go
@@ -2,14 +2,18 @@ package k8s
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	daemonk8s "github.com/cilium/cilium/daemon/k8s"
 	cgmngr "github.com/cilium/cilium/pkg/cgroups/manager"
+	cmtypes "github.com/cilium/cilium/pkg/clustermesh/types"
 	"github.com/cilium/cilium/pkg/datapath/iptables/ipset"
 	"github.com/cilium/cilium/pkg/datapath/tables"
 	datapath "github.com/cilium/cilium/pkg/datapath/types"
 	"github.com/cilium/cilium/pkg/endpointmanager"
+	"github.com/cilium/cilium/pkg/endpointstate"
+	"github.com/cilium/cilium/pkg/identity"
 	"github.com/cilium/cilium/pkg/identity/cache"
 	identitycachecell "github.com/cilium/cilium/pkg/identity/cache/cell"
 	"github.com/cilium/cilium/pkg/ipcache"
@@ -23,47 +27,118 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/synced"
 	k8sTypes "github.com/cilium/cilium/pkg/k8s/types"
 	"github.com/cilium/cilium/pkg/k8s/watchers"
+	"github.com/cilium/cilium/pkg/labelsfilter"
+	"github.com/cilium/cilium/pkg/loadbalancer"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/policy"
-	"github.com/cilium/cilium/pkg/redirectpolicy"
-	"github.com/cilium/cilium/pkg/service"
+	policycell "github.com/cilium/cilium/pkg/policy/cell"
+	"github.com/cilium/cilium/pkg/promise"
+	wgtypes "github.com/cilium/cilium/pkg/wireguard/types"
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/statedb"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/workqueue"
+
 	"github.com/microsoft/retina/pkg/common"
 	"github.com/microsoft/retina/pkg/pubsub"
-	"github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var Cell = cell.Module(
 	"k8s-watcher",
-	"Kubernetes watchers needed by the agent",
+	"Kubernetes watchers needed by Hubble flow enrichment",
 
+	// ============================================================
+	// CORE INFRASTRUCTURE
+	// Required by Cilium's internal components
+	// ============================================================
+
+	// StateDB tables for pods and namespaces (used by endpoint manager)
 	daemonk8s.PodTableCell,
+	daemonk8s.NamespaceTableCell,
 
+	// Device table (required by Cilium internals)
 	cell.Provide(
 		tables.NewDeviceTable,
 		statedb.RWTable[*tables.Device].ToTable,
 	),
 
-	cell.Invoke(func(db *statedb.DB, t statedb.Table[*tables.Device]) {
-		err := db.RegisterTable(t)
-		if err != nil {
-			logrus.WithError(err).Fatal("Failed to register table")
-		}
-	}),
+	// Node address table (required by service cache)
+	svcCacheCell,
 
+	// Metrics (used by endpoint manager and watchers)
+	metrics.Cell,
+
+	// Cgroups manager (required by endpoint manager)
+	cgmngr.Cell,
+
+	// ============================================================
+	// HUBBLE REQUIREMENTS
+	// These components are essential for Hubble flow enrichment
+	// ============================================================
+
+	// IPCache: Maps IPs to identities and K8s metadata
+	// This is the core component Hubble uses for flow enrichment
+	cell.Provide(newIPCache),
+
+	// Identity cache: Manages security identities for endpoints
+	// Required for IPCache to resolve identities
+	identitycachecell.Cell,
+
+	// Endpoint manager: Tracks local endpoints
+	// Used by watchers to populate IPCache with endpoint metadata
+	endpointmanager.Cell,
+
+	// Local node store: Tracks the local node's information
+	node.LocalNodeStoreCell,
+	cell.Provide(newNodeSynchronizer),
+
+	// ============================================================
+	// K8S RESOURCE WATCHERS
+	// Watch CiliumEndpoint CRDs to populate IPCache
+	// ============================================================
+
+	// Initialize label filter (required by endpoint manager)
+	cell.Invoke(initLabelFilter),
+
+	// CiliumEndpoint resource (watched to populate IPCache)
+	cell.Provide(newCiliumEndpointResource),
+
+	// Service and Endpoints resources (for service resolution)
+	cell.Provide(newEndpointsResource),
+	cell.Provide(newServiceResource),
+
+	// Watcher configuration and resource groups
+	cell.Provide(func() watchers.WatcherConfiguration { return &watcherconfig{} }),
+	cell.Provide(func() watchers.ResourceGroupFunc { return watcherResourceGroups }),
+
+	// Synced cell tracks when initial K8s sync is complete
+	synced.Cell,
+
+	// The actual K8s watchers (watches CiliumEndpoint)
+	watchers.Cell,
+
+	// API server event handler for pubsub integration
+	cell.Provide(newAPIServerEventHandler),
+	cell.Invoke(subscribeAPIServerEvents),
+
+	// ============================================================
+	// STUBS FOR UNUSED CILIUM FEATURES
+	// Retina doesn't use these, but Cilium's code requires them
+	// ============================================================
+
+	// Cluster info (required by some Cilium cells)
+	cell.Provide(func() cmtypes.ClusterInfo { return cmtypes.DefaultClusterInfo }),
+
+	// Loadbalancer config (required by some Cilium cells)
+	loadbalancer.ConfigCell,
+	cell.Provide(newFrontendsTable),
+
+	// Fake resources for features Retina doesn't use
 	cell.Provide(
-		func() resource.Resource[*slim_corev1.Namespace] {
-			return &fakeresource[*slim_corev1.Namespace]{}
-		},
-		func() daemonk8s.LocalNodeResource {
-			return &fakeresource[*slim_corev1.Node]{}
-		},
-		func() daemonk8s.LocalCiliumNodeResource {
-			return &fakeresource[*cilium_api_v2.CiliumNode]{}
-		},
+		func() resource.Resource[*slim_corev1.Namespace] { return &fakeresource[*slim_corev1.Namespace]{} },
+		func() daemonk8s.LocalNodeResource { return &fakeresource[*slim_corev1.Node]{} },
+		func() daemonk8s.LocalCiliumNodeResource { return &fakeresource[*cilium_api_v2.CiliumNode]{} },
 		func() resource.Resource[*slim_networkingv1.NetworkPolicy] {
 			return &fakeresource[*slim_networkingv1.NetworkPolicy]{}
 		},
@@ -76,156 +151,150 @@ var Cell = cell.Module(
 		func() resource.Resource[*cilium_api_v2alpha1.CiliumCIDRGroup] {
 			return &fakeresource[*cilium_api_v2alpha1.CiliumCIDRGroup]{}
 		},
+		func() resource.Resource[*cilium_api_v2.CiliumCIDRGroup] {
+			return &fakeresource[*cilium_api_v2.CiliumCIDRGroup]{}
+		},
 		func() resource.Resource[*cilium_api_v2alpha1.CiliumEndpointSlice] {
 			return &fakeresource[*cilium_api_v2alpha1.CiliumEndpointSlice]{}
 		},
-		func() resource.Resource[*cilium_api_v2.CiliumNode] {
-			return &fakeresource[*cilium_api_v2.CiliumNode]{}
-		},
-		func() watchers.WatcherConfiguration {
-			return &watcherconfig{}
-		},
+		func() resource.Resource[*cilium_api_v2.CiliumNode] { return &fakeresource[*cilium_api_v2.CiliumNode]{} },
 	),
 
-	svcCacheCell,
-
-	metrics.Cell,
-
-	endpointmanager.Cell,
-
-	cell.Provide(func() *policy.Updater {
-		return &policy.Updater{}
-	}),
-
-	cell.Provide(func() *redirectpolicy.Manager {
-		return &redirectpolicy.Manager{}
-	}),
-
-	cell.Provide(func() datapath.BandwidthManager {
-		return &fakeBandwidthManager{}
-	}),
-
-	cell.Provide(func() service.ServiceManager {
-		return &service.Service{}
-	}),
-
-	cgmngr.Cell,
-
-	// Provide the resources needed by the watchers.
-
-	cell.Provide(func(lc cell.Lifecycle, cs client.Clientset) (resource.Resource[*k8sTypes.CiliumEndpoint], error) {
-		return ciliumk8s.CiliumSlimEndpointResource(ciliumk8s.CiliumResourceParams{
-			Lifecycle: lc,
-			ClientSet: cs,
-		}, nil, func(*metav1.ListOptions) {})
-	}),
-
-	cell.Provide(func(l *slog.Logger, lc cell.Lifecycle, cs client.Clientset) (resource.Resource[*ciliumk8s.Endpoints], error) {
-		//nolint:wrapcheck // a wrapped error here is of dubious value
-		return ciliumk8s.EndpointsResource(l, lc, ciliumk8s.Config{
-			EnableK8sEndpointSlice: true,
-			K8sServiceProxyName:    "",
-		}, cs)
-	}),
-
-	cell.Provide(func(lc cell.Lifecycle, cs client.Clientset) (resource.Resource[*slim_corev1.Service], error) {
-		//nolint:wrapcheck // a wrapped error here is of dubious value
-		return ciliumk8s.ServiceResource(
-			lc,
-			ciliumk8s.Config{
-				EnableK8sEndpointSlice: false,
-			},
-			cs,
-			func(*metav1.ListOptions) {},
-		)
-	}),
-
+	// No-op implementations for policy/datapath (Retina doesn't use Cilium's policy engine)
 	cell.Provide(
-		func() policy.PolicyRepository {
-			return &NoOpPolicyRepository{}
-		},
-		func() datapath.Orchestrator {
-			return &NoOpOrchestrator{}
-		},
-	),
-
-	identitycachecell.Cell,
-
-	// Provide everything needed for the watchers.
-	cell.Provide(
-		func() *ipcache.IPCache {
-			alloc := cache.NewCachingIdentityAllocator(
-				&identityAllocatorOwner{},
-				cache.AllocatorConfig{},
-			)
-			idAlloc := &cachingIdentityAllocator{
-				alloc,
-				nil,
-			}
-			return ipcache.NewIPCache(&ipcache.Configuration{
-				Context:           context.Background(),
-				IdentityAllocator: idAlloc,
-				PolicyHandler:     &policyhandler{},
-				DatapathHandler:   &datapathhandler{},
-			})
+		func() policy.PolicyRepository { return &NoOpPolicyRepository{} },
+		func() datapath.Orchestrator { return &NoOpOrchestrator{} },
+		func() policycell.IdentityUpdater { return &noOpIdentityUpdater{} },
+		func() *policy.Updater { return &policy.Updater{} },
+		func() datapath.BandwidthManager { return &fakeBandwidthManager{} },
+		func() ipset.Manager { return &fakeIpsetMgr{} },
+		func() wgtypes.WireguardConfig { return fakeWireguardConfig{} },
+		func() datapath.IPsecConfig { return fakeIPsecConfig{} },
+		func() datapath.IptablesManager { return fakeIptablesManager{} },
+		func() promise.Promise[endpointstate.Restorer] {
+			r, p := promise.New[endpointstate.Restorer]()
+			r.Resolve(fakeRestorer{})
+			return p
 		},
 	),
-
-	cell.Provide(func() node.LocalNodeSynchronizer {
-		return &nodeSynchronizer{
-			l: logrus.WithField("module", "node-synchronizer"),
-		}
-	}),
-
-	cell.Provide(func() ipset.Manager {
-		return &fakeIpsetMgr{}
-	}),
-
-	node.LocalNodeStoreCell,
-
-	synced.Cell,
-	cell.Provide(newAPIServerEventHandler),
-
-	cell.Provide(func() watchers.ResourceGroupFunc { return watcherResourceGroups }),
-
-	watchers.Cell,
-
-	cell.Invoke(func(a *APIServerEventHandler) {
-		ps := pubsub.New()
-		fn := pubsub.CallBackFunc(a.handleAPIServerEvent)
-		uuid := ps.Subscribe(common.PubSubAPIServer, &fn)
-		a.l.WithFields(logrus.Fields{
-			"uuid": uuid,
-		}).Info("Subscribed to PubSub APIServer")
-	}),
 )
+
+// ============================================================
+// CELL HELPER FUNCTIONS
+// ============================================================
+
+func initLabelFilter(l *slog.Logger) {
+	if err := labelsfilter.ParseLabelPrefixCfg(l, nil, nil, ""); err != nil {
+		l.Error("Failed to parse label prefix config", "error", err)
+	}
+}
+
+func newIPCache(l *slog.Logger) *ipcache.IPCache {
+	alloc := cache.NewCachingIdentityAllocator(
+		l,
+		&identityAllocatorOwner{},
+		cache.AllocatorConfig{},
+	)
+	idAlloc := &cachingIdentityAllocator{alloc, nil}
+	return ipcache.NewIPCache(&ipcache.Configuration{
+		Context:           context.Background(),
+		Logger:            l.With("module", "ipcache"),
+		IdentityAllocator: idAlloc,
+	})
+}
+
+func newNodeSynchronizer(l *slog.Logger) node.LocalNodeSynchronizer {
+	return &nodeSynchronizer{l: l.With("module", "node-synchronizer")}
+}
+
+func newCiliumEndpointResource(
+	lc cell.Lifecycle, cs client.Clientset, mp workqueue.MetricsProvider,
+) (resource.Resource[*k8sTypes.CiliumEndpoint], error) {
+	//nolint:wrapcheck // wrapped error here is of dubious value
+	return ciliumk8s.CiliumSlimEndpointResource(ciliumk8s.CiliumResourceParams{
+		Lifecycle: lc,
+		ClientSet: cs,
+	}, nil, mp, func(*metav1.ListOptions) {})
+}
+
+func newEndpointsResource(
+	l *slog.Logger, lc cell.Lifecycle, cs client.Clientset, mp workqueue.MetricsProvider,
+) (resource.Resource[*ciliumk8s.Endpoints], error) {
+	//nolint:wrapcheck // wrapped error here is of dubious value
+	return ciliumk8s.EndpointsResource(l, lc, ciliumk8s.ConfigParams{
+		Config:      ciliumk8s.Config{K8sServiceProxyName: ""},
+		WatchConfig: ciliumk8s.ServiceWatchConfig{EnableHeadlessServiceWatch: true},
+	}, cs, mp)
+}
+
+func newServiceResource(
+	lc cell.Lifecycle, cs client.Clientset, mp workqueue.MetricsProvider,
+) (resource.Resource[*slim_corev1.Service], error) {
+	//nolint:wrapcheck // wrapped error here is of dubious value
+	return ciliumk8s.ServiceResource(
+		lc,
+		ciliumk8s.ConfigParams{
+			Config:      ciliumk8s.Config{K8sServiceProxyName: ""},
+			WatchConfig: ciliumk8s.ServiceWatchConfig{EnableHeadlessServiceWatch: false},
+		},
+		cs,
+		mp,
+		func(*metav1.ListOptions) {},
+	)
+}
+
+func newFrontendsTable(cfg loadbalancer.Config, db *statedb.DB) (statedb.Table[*loadbalancer.Frontend], error) {
+	tbl, err := loadbalancer.NewFrontendsTable(cfg, db)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create frontends table: %w", err)
+	}
+	return tbl, nil
+}
+
+func subscribeAPIServerEvents(a *APIServerEventHandler) {
+	ps := pubsub.New()
+	fn := pubsub.CallBackFunc(a.handleAPIServerEvent)
+	uuid := ps.Subscribe(common.PubSubAPIServer, &fn)
+	a.l.Info("Subscribed to PubSub APIServer", "uuid", uuid)
+}
+
+// ============================================================
+// SERVICE CACHE CELL
+// ============================================================
 
 var svcCacheCell = cell.Group(
-	cell.Provide(func() (statedb.Table[tables.NodeAddress], error) {
-		return statedb.NewTable(tables.NodeAddressTableName, tables.NodeAddressIndex)
+	cell.Provide(func(db *statedb.DB) (statedb.RWTable[tables.NodeAddress], error) {
+		return statedb.NewTable(db, tables.NodeAddressTableName, tables.NodeAddressIndex)
 	}),
-	cell.Invoke(func(db *statedb.DB, t statedb.Table[tables.NodeAddress]) {
-		err := db.RegisterTable(t)
-		if err != nil {
-			logrus.WithError(err).Fatal("Failed to register table")
-		}
-	}),
-	cell.Provide(ciliumk8s.NewSVCMetricsNoop),
-	cell.Provide(ciliumk8s.NewServiceCache),
-	cell.Provide(func(svcCache *ciliumk8s.ServiceCacheImpl) ciliumk8s.ServiceCache {
-		return svcCache
-	}),
+	cell.Provide(statedb.RWTable[tables.NodeAddress].ToTable),
 )
 
-const (
-	K8sAPIGroupCiliumEndpointV2 = "cilium/v2::CiliumEndpoint"
-	K8sAPIGroupServiceV1Core    = "core/v1::Service"
-)
+// ============================================================
+// WATCHER CONFIGURATION
+// ============================================================
 
-var k8sResources = []string{K8sAPIGroupCiliumEndpointV2, K8sAPIGroupServiceV1Core}
+const K8sAPIGroupCiliumEndpointV2 = "cilium/v2::CiliumEndpoint"
 
-// resourceGroups are all of the core Kubernetes and Cilium resource groups
-// which the Cilium agent watches to implement CNI functionality.
+// k8sResources defines which resources the watcher monitors.
+// Only CiliumEndpoint is needed for Hubble flow enrichment.
+var k8sResources = []string{K8sAPIGroupCiliumEndpointV2}
+
+// watcherResourceGroups returns the resource groups to watch.
+// Retina only needs CiliumEndpoint for IPCache population.
 func watcherResourceGroups(*slog.Logger, watchers.WatcherConfiguration) (r, w []string) {
 	return k8sResources, w
+}
+
+// ============================================================
+// NO-OP IDENTITY UPDATER
+// ============================================================
+
+// noOpIdentityUpdater is a no-op implementation of policycell.IdentityUpdater.
+// Retina doesn't use Cilium's policy features.
+type noOpIdentityUpdater struct{}
+
+func (n *noOpIdentityUpdater) UpdateIdentities(_, _ identity.IdentityMap) <-chan struct{} {
+	ch := make(chan struct{})
+	close(ch)
+	return ch
 }

--- a/pkg/k8s/local_node_synchronizer_linux.go
+++ b/pkg/k8s/local_node_synchronizer_linux.go
@@ -2,17 +2,17 @@ package k8s
 
 import (
 	"context"
+	"log/slog"
 	"net"
 	"os"
 
 	"github.com/cilium/cilium/pkg/node"
 	"github.com/cilium/cilium/pkg/node/addressing"
 	nodetypes "github.com/cilium/cilium/pkg/node/types"
-	"github.com/sirupsen/logrus"
 )
 
 type nodeSynchronizer struct {
-	l *logrus.Entry
+	l *slog.Logger
 }
 
 func (n *nodeSynchronizer) InitLocalNode(_ context.Context, ln *node.LocalNode) error {

--- a/pkg/managers/controllermanager/controllermanager_test.go
+++ b/pkg/managers/controllermanager/controllermanager_test.go
@@ -5,6 +5,7 @@ package controllermanager
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -33,7 +34,7 @@ func TestNewControllerManager(t *testing.T) {
 
 	log.SetupZapLogger(log.GetDefaultLogOpts())
 	kubeclient := k8sfake.NewSimpleClientset()
-	cm, err := NewControllerManager(c, kubeclient, telemetry.NewNoopTelemetry())
+	cm, err := NewControllerManager(c, kubeclient, telemetry.NewNoopTelemetry(), slog.Default())
 	assert.NoError(t, err, "Expected no error, instead got %+v", err)
 	assert.NotNil(t, cm)
 }
@@ -45,7 +46,7 @@ func TestNewControllerManagerWin(t *testing.T) {
 
 	log.SetupZapLogger(log.GetDefaultLogOpts())
 	kubeclient := k8sfake.NewSimpleClientset()
-	cm, err := NewControllerManager(c, kubeclient, telemetry.NewNoopTelemetry())
+	cm, err := NewControllerManager(c, kubeclient, telemetry.NewNoopTelemetry(), slog.Default())
 	assert.Error(t, err, "Expected error of not recognising windows plugins in linux, instead got no error")
 	assert.Nil(t, cm)
 }
@@ -57,7 +58,7 @@ func TestNewControllerManagerInit(t *testing.T) {
 
 	log.SetupZapLogger(log.GetDefaultLogOpts())
 	kubeclient := k8sfake.NewSimpleClientset()
-	cm, err := NewControllerManager(c, kubeclient, telemetry.NewNoopTelemetry())
+	cm, err := NewControllerManager(c, kubeclient, telemetry.NewNoopTelemetry(), slog.Default())
 	assert.NoError(t, err, "Expected no error, instead got %+v", err)
 	assert.NotNil(t, cm)
 
@@ -72,7 +73,7 @@ func TestControllerPluginManagerStartFail(t *testing.T) {
 
 	log.SetupZapLogger(log.GetDefaultLogOpts())
 	kubeclient := k8sfake.NewSimpleClientset()
-	cm, err := NewControllerManager(c, kubeclient, telemetry.NewNoopTelemetry())
+	cm, err := NewControllerManager(c, kubeclient, telemetry.NewNoopTelemetry(), slog.Default())
 	assert.NoError(t, err, "Expected no error, instead got %+v", err)
 	assert.NotNil(t, cm)
 
@@ -86,7 +87,7 @@ func TestControllerPluginManagerStartFail(t *testing.T) {
 		EnablePodLevel:  true,
 		EnabledPlugin:   []string{pluginName},
 	}
-	mgr, err := pm.NewPluginManager(cfg, telemetry.NewNoopTelemetry())
+	mgr, err := pm.NewPluginManager(cfg, telemetry.NewNoopTelemetry(), slog.Default())
 	require.NoError(t, err, "Expected no error, instead got %+v", err)
 
 	mockPlugin := plugin.NewMockPlugin(ctl)

--- a/pkg/managers/pluginmanager/pluginmanager_test.go
+++ b/pkg/managers/pluginmanager/pluginmanager_test.go
@@ -5,6 +5,7 @@ package pluginmanager
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"strings"
 	"testing"
 	"time"
@@ -82,7 +83,7 @@ func TestNewManager(t *testing.T) {
 
 	for _, tt := range tests {
 		tt.cfg.EnabledPlugin = append(tt.cfg.EnabledPlugin, tt.pluginName)
-		mgr, err := NewPluginManager(&tt.cfg, tel)
+		mgr, err := NewPluginManager(&tt.cfg, tel, slog.Default())
 		if tt.wantErr {
 			require.NotNil(t, err, "Expected error but got nil")
 			require.Nil(t, mgr, "Expected mgr to be nil but it isn't")
@@ -122,7 +123,7 @@ func TestNewManagerStart(t *testing.T) {
 
 	for _, tt := range tests {
 		tt.cfg.EnabledPlugin = append(tt.cfg.EnabledPlugin, tt.pluginName)
-		mgr, err := NewPluginManager(&tt.cfg, tel)
+		mgr, err := NewPluginManager(&tt.cfg, tel, slog.Default())
 		require.NoError(t, err)
 		mgr.watcherManager = setupWatcherManagerMock(gomock.NewController(t))
 		require.Nil(t, err, "Expected nil but got error:%w", err)
@@ -161,7 +162,7 @@ func TestNewManagerWithPluginStartFailure(t *testing.T) {
 	cfg := cfgPodLevelEnabled
 	mgr := &PluginManager{
 		cfg:            &cfg,
-		l:              log.Logger().Named("plugin-manager"),
+		l:              slog.Default().With("module", "plugin-manager"),
 		plugins:        make(map[string]plugin.Plugin),
 		tel:            telemetry.NewNoopTelemetry(),
 		watcherManager: setupWatcherManagerMock(ctl),
@@ -193,14 +194,14 @@ func TestNewManagerWithPluginReconcileFailure(t *testing.T) {
 	ctl := gomock.NewController(t)
 	defer ctl.Finish()
 	log.SetupZapLogger(log.GetDefaultLogOpts())
-	metrics.InitializeMetrics()
+	metrics.InitializeMetrics(slog.Default())
 
 	pluginName := "mockplugin"
 
 	cfg := cfgPodLevelEnabled
 	mgr := &PluginManager{
 		cfg:            &cfg,
-		l:              log.Logger().Named("plugin-manager"),
+		l:              slog.Default().With("module", "plugin-manager"),
 		plugins:        make(map[string]plugin.Plugin),
 		tel:            telemetry.NewNoopTelemetry(),
 		watcherManager: setupWatcherManagerMock(ctl),
@@ -257,7 +258,7 @@ func TestPluginInit(t *testing.T) {
 	}
 	for _, tt := range tests {
 		tt.cfg.EnabledPlugin = append(tt.cfg.EnabledPlugin, tt.pluginName)
-		mgr, err := NewPluginManager(&tt.cfg, tel)
+		mgr, err := NewPluginManager(&tt.cfg, tel, slog.Default())
 		require.Nil(t, err, "Expected nil but got error:%w", err)
 		for _, plugin := range mgr.plugins {
 			if tt.wantErr {
@@ -299,7 +300,7 @@ func TestPluginStartWithoutInit(t *testing.T) {
 	}
 	for _, tt := range tests {
 		tt.cfg.EnabledPlugin = append(tt.cfg.EnabledPlugin, tt.pluginName)
-		mgr, err := NewPluginManager(&tt.cfg, tel)
+		mgr, err := NewPluginManager(&tt.cfg, tel, slog.Default())
 		require.Nil(t, err, "Expected nil but got error:%w", err)
 		for _, plugin := range mgr.plugins {
 			if tt.initPlugin {
@@ -387,7 +388,7 @@ func TestPluginStop(t *testing.T) {
 	}
 	for _, tt := range tests {
 		tt.cfg.EnabledPlugin = append(tt.cfg.EnabledPlugin, tt.pluginName)
-		mgr, err := NewPluginManager(&tt.cfg, tel)
+		mgr, err := NewPluginManager(&tt.cfg, tel, slog.Default())
 		require.Nil(t, err, "Expected nil but got error:%w", err)
 		for _, plugin := range mgr.plugins {
 			if tt.initPlugin {
@@ -422,7 +423,7 @@ func TestStopPluginManagerGracefully(t *testing.T) {
 	cfg := cfgPodLevelEnabled
 	mgr := &PluginManager{
 		cfg:            &cfg,
-		l:              log.Logger().Named("plugin-manager"),
+		l:              slog.Default().With("module", "plugin-manager"),
 		plugins:        make(map[string]plugin.Plugin),
 		tel:            telemetry.NewNoopTelemetry(),
 		watcherManager: setupWatcherManagerMock(ctl),
@@ -462,7 +463,7 @@ func TestWatcherManagerFailure(t *testing.T) {
 	cfg := cfgPodLevelEnabled
 	mgr := &PluginManager{
 		cfg:            &cfg,
-		l:              log.Logger().Named("plugin-manager"),
+		l:              slog.Default().With("module", "plugin-manager"),
 		plugins:        make(map[string]plugin.Plugin),
 		tel:            telemetry.NewNoopTelemetry(),
 		watcherManager: m,

--- a/pkg/monitoragent/cell_linux.go
+++ b/pkg/monitoragent/cell_linux.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cilium/cilium/pkg/monitor/agent/listener"
 	"github.com/cilium/ebpf"
 	"github.com/cilium/hive/cell"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 )
 
@@ -24,7 +23,7 @@ var (
 		cell.Config(defaultConfig),
 	)
 
-	log = logging.DefaultLogger.WithField(logfields.LogSubsys, "monitor-agent")
+	log = logging.DefaultSlogLogger.With(logfields.LogSubsys, "monitor-agent")
 )
 
 type AgentConfig struct {
@@ -48,7 +47,6 @@ type agentParams struct {
 	cell.In
 
 	Lifecycle cell.Lifecycle
-	Log       logrus.FieldLogger
 	Config    AgentConfig
 }
 

--- a/pkg/shared/telemetry/cell_linux.go
+++ b/pkg/shared/telemetry/cell_linux.go
@@ -3,12 +3,12 @@ package telemetry
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
 	"github.com/cilium/hive/cell"
 	"github.com/microsoft/retina/pkg/telemetry"
-	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/rest"
 )
 
@@ -34,11 +34,11 @@ var (
 	Constructor = cell.Module(
 		"telemetry",
 		"provides telemetry",
-		cell.Provide(func(p params, l logrus.FieldLogger) (telemetry.Telemetry, error) {
-			l.WithFields(logrus.Fields{
-				"app-insights-id": p.Config.ApplicationInsightsID,
-				"retina-version":  p.Config.RetinaVersion,
-			}).Info("configuring telemetry")
+		cell.Provide(func(p params, l *slog.Logger) (telemetry.Telemetry, error) {
+			l.Info("configuring telemetry",
+				"app-insights-id", p.Config.ApplicationInsightsID,
+				"retina-version", p.Config.RetinaVersion,
+			)
 
 			if p.Config.EnableTelemetry {
 				if p.Config.ApplicationInsightsID == "" {
@@ -75,7 +75,7 @@ var (
 		"heartbeat",
 		"sends periodic telemetry heartbeat",
 		cell.Invoke(
-			func(tel telemetry.Telemetry, lifecycle cell.Lifecycle, l logrus.FieldLogger) {
+			func(tel telemetry.Telemetry, lifecycle cell.Lifecycle, l *slog.Logger) {
 				ctx, cancelCtx := context.WithCancel(context.Background())
 				lifecycle.Append(cell.Hook{
 					OnStart: func(cell.HookContext) error {


### PR DESCRIPTION
# Description

- Adapt Hubble daemon initialization for `hubblecell.Cell` (replacing `hubblecell.Core`) in Cilium v1.19
- Refactor `pkg/k8s/cell_linux.go` (348 lines) for new dependency injection patterns
- Update monitor agent, Hubble parsers, and managers for slog-based logging
- Add kvstore client stub for Cilium v1.19 compatibility
- Update plugin manager, controller manager, and server manager cells

**PR 6 of 7** for Cilium v1.19 upgrade.

## Related Issue

- #1788
- #2037

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

- [ ] Verify Hubble daemon starts correctly with new cell initialization
- [ ] Verify K8s watchers function correctly with refactored cell
- [ ] Verify monitor agent and parser pipeline work end-to-end
- [ ] Verify plugin manager and controller manager tests pass

## Additional Notes

None.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.