### PR TITLE
fix: adapt operator, Helm, and tests for Cilium v1.19

### DIFF
--- a/deploy/hubble/manifests/controller/helm/retina/templates/agent/daemonset.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/agent/daemonset.yaml
@@ -124,7 +124,7 @@ spec:
             - name: cilium
               mountPath: /var/run/cilium
             - name: host-os-release
-              mountPath: /etc/os-release  
+              mountPath: /etc/os-release
           {{- if .Values.hubble.tls.enabled }}
             - name: tls
               mountPath: /var/lib/cilium/tls/hubble
@@ -154,7 +154,7 @@ spec:
       - name: host-os-release
         hostPath:
           path: /etc/os-release
-          type: FileOrCreate   
+          type: FileOrCreate
       {{- if .Values.hubble.tls.enabled }}
       - name: tls
         projected:

--- a/operator/cilium-crds/k8s/apis/cell.go
+++ b/operator/cilium-crds/k8s/apis/cell.go
@@ -8,8 +8,8 @@ package apis
 
 import (
 	"fmt"
+	"log/slog"
 
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/pflag"
 
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
@@ -48,7 +48,7 @@ type RegisterCRDsFunc func(k8sClient.Clientset) error
 type params struct {
 	cell.In
 
-	Logger    logrus.FieldLogger
+	Logger    *slog.Logger
 	Lifecycle cell.Lifecycle
 
 	Clientset k8sClient.Clientset

--- a/operator/cilium-crds/k8s/apis/register.go
+++ b/operator/cilium-crds/k8s/apis/register.go
@@ -101,8 +101,10 @@ func createCRD(crdVersionedName, crdMetaName string) func(clientset apiextension
 			clientset,
 			constructV1CRD(crdMetaName, ciliumCRD),
 			crdhelpers.NewDefaultPoller(),
-			k8sconst.CustomResourceDefinitionSchemaVersionKey,
-			versioncheck.MustVersion(k8sconst.CustomResourceDefinitionSchemaVersion),
+			crdhelpers.NeedsUpdateV1Factory(
+				k8sconst.CustomResourceDefinitionSchemaVersionKey,
+				versioncheck.MustVersion(k8sconst.CustomResourceDefinitionSchemaVersion),
+			),
 		)
 		if err != nil {
 			return fmt.Errorf("Unable to create CRD %s: %w", crdMetaName, err)

--- a/operator/cilium-crds/k8s/resources.go
+++ b/operator/cilium-crds/k8s/resources.go
@@ -39,7 +39,7 @@ var ResourcesCell = cell.Module(
 		func() resource.Resource[*cilium_api_v2.CiliumNode] {
 			return &fakeresource[*cilium_api_v2.CiliumNode]{}
 		},
-		k8s.PodResource,
+		PodResource,
 		k8s.NamespaceResource,
 	),
 )

--- a/operator/cmd/cilium-crds/flags.go
+++ b/operator/cmd/cilium-crds/flags.go
@@ -42,10 +42,6 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	// NOTE: without this the option gets overridden from the default value to the zero value via option.Config.Populate(vp)
 	// specifically, here options.Config.AllocatorListTimeout gets overridden from the default value to 0s
 	flags.Duration(option.AllocatorListTimeoutName, defaults.AllocatorListTimeout, "timeout to list initial allocator state")
-	// similar overriding happens for option.Config.KVstoreConnectivityTimeout
-	flags.Duration(option.KVstoreConnectivityTimeout, defaults.KVstoreConnectivityTimeout, "Time after which an incomplete kvstore operation  is considered failed")
-	// similar overriding happens for option.Config.KVstorePeriodicSync
-	flags.Duration(option.KVstorePeriodicSync, defaults.KVstorePeriodicSync, "Periodic KVstore synchronization interval")
 
 	flags.Duration(operatorOption.EndpointGCInterval, operatorOption.EndpointGCIntervalDefault, "GC interval for cilium endpoints")
 	option.BindEnv(vp, operatorOption.EndpointGCInterval)
@@ -56,7 +52,7 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.StringSlice(option.LogDriver, []string{}, "Logging endpoints to use for example syslog")
 	option.BindEnv(vp, option.LogDriver)
 
-	flags.Var(option.NewNamedMapOptions(option.LogOpt, &option.Config.LogOpt, nil),
+	flags.Var(option.NewMapOptions(&option.Config.LogOpt),
 		option.LogOpt, `Log driver options for cilium-operator, `+
 			`configmap example for syslog driver: {"syslog.level":"info","syslog.facility":"local4"}`)
 	option.BindEnv(vp, option.LogOpt)

--- a/operator/cmd/cilium-crds/root_linux.go
+++ b/operator/cmd/cilium-crds/root_linux.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"log/slog"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -19,16 +20,16 @@ import (
 	operatorOption "github.com/cilium/cilium/operator/option"
 	"github.com/cilium/cilium/pkg/hive"
 	k8sClient "github.com/cilium/cilium/pkg/k8s/client"
-	k8sversion "github.com/cilium/cilium/pkg/k8s/version"
 	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/logging/logfields"
 	"github.com/cilium/cilium/pkg/metrics"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/hive/cell"
 	"github.com/microsoft/retina/internal/buildinfo"
+	"github.com/microsoft/retina/pkg/log"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
+	"go.uber.org/zap"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 )
@@ -36,19 +37,23 @@ import (
 var (
 	// set logger field: subsys=retina-operator
 	binaryName       = filepath.Base(os.Args[0])
-	logger           = logging.DefaultLogger.WithField(logfields.LogSubsys, binaryName)
+	slogLogger       = logging.DefaultSlogLogger.With(logfields.LogSubsys, binaryName)
 	operatorIDLength = 10
 )
 
 func Execute(h *hive.Hive) {
 	initEnv(h.Viper())
 
-	if err := h.Run(logging.DefaultSlogLogger); err != nil {
-		logger.Fatal(err)
+	// Use zap-backed slog logger for hive (routes to stdout + Application Insights)
+	if err := h.Run(log.SlogLogger()); err != nil {
+		logging.Fatal(slogLogger, err.Error())
 	}
 }
 
-func registerOperatorHooks(l logrus.FieldLogger, lc cell.Lifecycle, llc *LeaderLifecycle, clientset k8sClient.Clientset, shutdowner hive.Shutdowner) {
+func registerOperatorHooks(
+	l *slog.Logger, lc cell.Lifecycle, llc *LeaderLifecycle,
+	clientset k8sClient.Clientset, shutdowner hive.Shutdowner,
+) {
 	var wg sync.WaitGroup
 	lc.Append(cell.Hook{
 		OnStart: func(cell.HookContext) error {
@@ -77,19 +82,28 @@ func initEnv(vp *viper.Viper) {
 	// the default values provided in option.Config or operatorOption.Config respectively.
 	// The values will be overridden to the "zero value".
 	// Maybe could create a cell.Config for these instead?
-	option.Config.Populate(vp)
-	operatorOption.Config.Populate(vp)
+	// slogloggercheck: using default logger for configuration initialization
+	option.Config.Populate(logging.DefaultSlogLogger, vp)
+	operatorOption.Config.Populate(logging.DefaultSlogLogger, vp)
 
-	// add hooks after setting up metrics in the option.Confog
-	logging.DefaultLogger.Hooks.Add(metrics.NewLoggingHook())
+	// add hooks after setting up metrics in the option.Config
+	logging.AddHandlers(metrics.NewLoggingHook())
 
 	// Logging should always be bootstrapped first. Do not add any code above this!
 	if err := logging.SetupLogging(option.Config.LogDriver, logging.LogOptions(option.Config.LogOpt), binaryName, option.Config.Debug); err != nil {
-		logger.Fatal(err)
+		logging.Fatal(slogLogger, err.Error())
 	}
 
-	option.LogRegisteredOptions(vp, logger)
-	logger.Infof("retina operator version: %s", buildinfo.Version)
+	// Set up zap logger with Application Insights telemetry
+	_, _ = log.SetupZapLogger(&log.LogOpts{
+		Level:                 option.Config.LogOpt[logging.LevelOpt],
+		ApplicationInsightsID: buildinfo.ApplicationInsightsID,
+		EnableTelemetry:       buildinfo.ApplicationInsightsID != "",
+	}, zap.String("version", buildinfo.Version))
+	log.SetDefaultSlog()
+
+	option.LogRegisteredSlogOptions(vp, slogLogger)
+	slogLogger.Info("retina operator version", "version", buildinfo.Version)
 }
 
 func doCleanup() {
@@ -103,32 +117,20 @@ func doCleanup() {
 // runOperator implements the logic of leader election for cilium-operator using
 // built-in leader election capability in kubernetes.
 // See: https://github.com/kubernetes/client-go/blob/master/examples/leader-election/main.go
-func runOperator(l logrus.FieldLogger, lc *LeaderLifecycle, clientset k8sClient.Clientset, shutdowner hive.Shutdowner) {
+func runOperator(l *slog.Logger, lc *LeaderLifecycle, clientset k8sClient.Clientset, shutdowner hive.Shutdowner) {
 	isLeader.Store(false)
 
 	leaderElectionCtx, leaderElectionCtxCancel = context.WithCancel(context.Background())
-
-	// We only support Operator in HA mode for Kubernetes Versions having support for
-	// LeasesResourceLock.
-	// See docs on capabilities.LeasesResourceLock for more context.
-	if !k8sversion.Capabilities().LeasesResourceLock {
-		l.Info("Support for coordination.k8s.io/v1 not present, fallback to non HA mode")
-
-		if err := lc.Start(logging.DefaultSlogLogger, leaderElectionCtx); err != nil {
-			l.WithError(err).Fatal("Failed to start leading")
-		}
-		return
-	}
 
 	// Get hostname for identity name of the lease lock holder.
 	// We identify the leader of the operator cluster using hostname.
 	operatorID, err := os.Hostname()
 	if err != nil {
-		l.WithError(err).Fatal("Failed to get hostname when generating lease lock identity")
+		logging.Fatal(l, "Failed to get hostname when generating lease lock identity", logfields.Error, err)
 	}
 	operatorID, err = randomStringWithPrefix(operatorID+"-", operatorIDLength)
 	if err != nil {
-		l.WithError(err).Fatal("Failed to generate random string for lease lock identity")
+		logging.Fatal(l, "Failed to generate random string for lease lock identity", logfields.Error, err)
 	}
 
 	leResourceLock, err := resourcelock.NewFromKubeconfig(
@@ -142,7 +144,7 @@ func runOperator(l logrus.FieldLogger, lc *LeaderLifecycle, clientset k8sClient.
 		clientset.RestConfig(),
 		operatorOption.Config.LeaderElectionRenewDeadline)
 	if err != nil {
-		l.WithError(err).Fatal("Failed to create resource lock for leader election")
+		logging.Fatal(l, "Failed to create resource lock for leader election", logfields.Error, err)
 	}
 
 	// Start the leader election for running cilium-operators
@@ -160,12 +162,12 @@ func runOperator(l logrus.FieldLogger, lc *LeaderLifecycle, clientset k8sClient.
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: func(ctx context.Context) {
 				if err := lc.Start(logging.DefaultSlogLogger, ctx); err != nil {
-					l.WithError(err).Error("Failed to start when elected leader, shutting down")
+					l.Error("Failed to start when elected leader, shutting down", logfields.Error, err)
 					shutdowner.Shutdown(hive.ShutdownWithError(err))
 				}
 			},
 			OnStoppedLeading: func() {
-				l.WithField("operator-id", operatorID).Info("Leader election lost")
+				l.Info("Leader election lost", "operator-id", operatorID)
 				// Cleanup everything here, and exit.
 				shutdowner.Shutdown(hive.ShutdownWithError(errors.New("Leader election lost")))
 			},
@@ -173,10 +175,7 @@ func runOperator(l logrus.FieldLogger, lc *LeaderLifecycle, clientset k8sClient.
 				if identity == operatorID {
 					l.Info("Leading the operator HA deployment")
 				} else {
-					l.WithFields(logrus.Fields{
-						"newLeader":  identity,
-						"operatorID": operatorID,
-					}).Info("Leader re-election complete")
+					l.Info("Leader re-election complete", "newLeader", identity, "operatorID", operatorID)
 				}
 			},
 		},

--- a/operator/cmd/cilium-crds/zap_linux.go
+++ b/operator/cmd/cilium-crds/zap_linux.go
@@ -4,85 +4,34 @@
 package ciliumcrds
 
 import (
-	"fmt"
-	"io"
+	"log/slog"
 
-	zaphook "github.com/Sytten/logrus-zap-hook"
-	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/option"
 	"github.com/cilium/hive/cell"
 	"github.com/microsoft/retina/internal/buildinfo"
 	"github.com/microsoft/retina/pkg/log"
-	"github.com/sirupsen/logrus"
 	"go.uber.org/zap"
 	"k8s.io/client-go/rest"
 
 	"github.com/microsoft/retina/operator/cilium-crds/config"
 )
 
-// TODO refactor to another package? Like shared/telemetry/
-
-const logFileName = "retina-operator.log"
-
-var (
-	MaxFileSizeMB = 100
-	MaxBackups    = 3
-	MaxAgeDays    = 30
-)
-
 type params struct {
 	cell.In
 
-	Logger      logrus.FieldLogger
+	Logger      *slog.Logger
 	K8sCfg      *rest.Config
 	DaemonCfg   *option.DaemonConfig
 	OperatorCfg config.Config
 }
 
 func setupZapHook(p params) {
-	// modify default logger
-	// properly report the caller (otherwise, will get caller=zap.go every time)
-	logging.DefaultLogger.ReportCaller = true
-	// discard default logger output in favor of zap
-	logging.DefaultLogger.SetOutput(io.Discard)
-
-	level, err := logrus.ParseLevel(p.DaemonCfg.LogOpt[logging.LevelOpt])
-	if err != nil {
-		p.Logger.WithError(err).Error("failed to parse log level")
-	} else {
-		logging.DefaultLogger.SetLevel(level)
-	}
-
-	lOpts := &log.LogOpts{
-		Level:                 p.DaemonCfg.LogOpt[logging.LevelOpt],
-		File:                  false,
-		FileName:              logFileName,
-		MaxFileSizeMB:         MaxFileSizeMB,
-		MaxBackups:            MaxBackups,
-		MaxAgeDays:            MaxAgeDays,
-		ApplicationInsightsID: buildinfo.ApplicationInsightsID,
-		EnableTelemetry:       p.OperatorCfg.EnableTelemetry,
-	}
-
-	persistentFields := []zap.Field{
-		zap.String("version", buildinfo.Version),
-		zap.String("apiserver", p.K8sCfg.Host),
-	}
-
-	_, err = log.SetupZapLogger(lOpts, persistentFields...)
-	if err != nil {
-		fmt.Printf("failed to setup zap logger: %v", err)
-	}
-
+	// Note: Zap logger is now initialized in initEnv() before hive starts.
+	// This hook only logs startup info with operator-specific fields from the hive DI context.
 	namedLogger := log.Logger().Named("retina-operator-v2")
-	namedLogger.Info("Traces telemetry initialized with zapai", zap.String("version", buildinfo.Version), zap.String("appInsightsID", lOpts.ApplicationInsightsID))
-
-	var hook *zaphook.ZapHook
-	hook, err = zaphook.NewZapHook(namedLogger.Logger)
-	if err != nil {
-		p.Logger.WithError(err).Error("failed to create zap hook")
-		return
-	}
-
-	logging.DefaultLogger.Hooks.Add(hook)
+	namedLogger.Info("Traces telemetry initialized with zapai",
+		zap.String("version", buildinfo.Version),
+		zap.String("appInsightsID", buildinfo.ApplicationInsightsID),
+		zap.String("apiserver", p.K8sCfg.Host),
+	)
 }

--- a/operator/cmd/cilium_crds_cmd_linux.go
+++ b/operator/cmd/cilium_crds_cmd_linux.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/cilium/cilium/pkg/hive"
+	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/cilium/pkg/option"
 	ciliumcrds "github.com/microsoft/retina/operator/cmd/cilium-crds"
 	"github.com/spf13/cobra"
@@ -40,7 +41,7 @@ func init() {
 	}
 
 	cobra.OnInitialize(
-		option.InitConfig(cmd, "Retina-Operator", "retina-operators", h.Viper()),
+		option.InitConfig(logging.DefaultSlogLogger, cmd, "Retina-Operator", "retina-operators", h.Viper()),
 	)
 
 	rootCmd.AddCommand(cmd)

--- a/operator/cmd/standard/deployment.go
+++ b/operator/cmd/standard/deployment.go
@@ -98,6 +98,7 @@ func (o *Operator) Start() error {
 	}
 
 	defer zl.Close()
+	log.SetDefaultSlog() // Set Go's global slog to use zap-backed handler
 	mainLogger := zl.Named("main").Sugar()
 
 	mainLogger.Info("Operator configuration", zap.Any("configuration", oconfig))

--- a/pkg/controllers/operator/cilium-crds/endpoint/endpoint_controller_linux.go
+++ b/pkg/controllers/operator/cilium-crds/endpoint/endpoint_controller_linux.go
@@ -14,8 +14,6 @@ import (
 	"github.com/microsoft/retina/pkg/controllers/operator/cilium-crds/cache"
 
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
-	"go.uber.org/zap"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -28,6 +26,7 @@ import (
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	slim_clientset "github.com/cilium/cilium/pkg/k8s/slim/k8s/client/clientset/versioned"
 	"github.com/cilium/cilium/pkg/labels"
+	"github.com/cilium/cilium/pkg/logging"
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/workerpool"
 )
@@ -47,7 +46,7 @@ var ErrClientsetDisabled = errors.New("failure due to clientset disabled")
 // endpointReconciler managed the lifecycle of CiliumEndpoints and CiliumIdentities from Pods.
 type endpointReconciler struct {
 	*sync.Mutex
-	l                   logrus.FieldLogger
+	l                   *slog.Logger
 	clientset           versioned.Interface
 	ciliumSlimClientSet slim_clientset.Interface
 	// podEvents represents Pod CRUD events relayed from the Pod controller. If the Pod was deleted, the PodCacheObject.Pod field will be nil
@@ -76,7 +75,6 @@ type endpointReconciler struct {
 type params struct {
 	cell.In
 
-	Logger          logrus.FieldLogger
 	Lifecycle       cell.Lifecycle
 	Clientset       k8sClient.Clientset
 	CiliumEndpoints resource.Resource[*ciliumv2.CiliumEndpoint]
@@ -89,7 +87,7 @@ func registerEndpointController(p params) error {
 		return ErrClientsetDisabled
 	}
 
-	l := p.Logger.WithField("component", "endpointcontroller")
+	l := logging.DefaultSlogLogger.With("component", "endpointcontroller")
 	r := &endpointReconciler{
 		Mutex:               &sync.Mutex{},
 		l:                   l,
@@ -106,10 +104,10 @@ func registerEndpointController(p params) error {
 	return nil
 }
 
-func (r *endpointReconciler) Start(_ cell.HookContext) error {
+func (r *endpointReconciler) Start(ctx cell.HookContext) error {
 	// NOTE: we must create IdentityManager on leader election since its allocator auto-starts on creation.
 	// There is a way to disable auto-start but then there is no exposed function to simply start().
-	im, err := NewIdentityManager(r.l, r.clientset)
+	im, err := NewIdentityManager(ctx, r.l, r.clientset)
 	if err != nil {
 		return errors.Wrap(err, "failed to create identity manager")
 	}
@@ -152,7 +150,7 @@ func (r *endpointReconciler) run(pctx context.Context) error {
 			}
 
 			if ev.Object != nil && ev.Object.Spec.HostNetwork {
-				r.l.WithField("podKey", ev.Key.String()).Debug("pod is host networked, skipping")
+				r.l.Debug("pod is host networked, skipping", "podKey", ev.Key.String())
 				ev.Done(nil)
 				continue
 			}
@@ -161,7 +159,7 @@ func (r *endpointReconciler) run(pctx context.Context) error {
 				return r.runEventHandler(ctx, ev)
 			})
 			if err != nil {
-				r.l.WithError(err).WithField("podKey", ev.Key.String()).Error("failed to submit pod event handler")
+				r.l.Error("failed to submit pod event handler", "error", err, "podKey", ev.Key.String())
 			}
 
 		case <-pctx.Done():
@@ -180,7 +178,7 @@ func (r *endpointReconciler) runEventHandler(pctx context.Context, ev resource.E
 	case resource.Upsert:
 		// HANDLE UPSERT
 		if ev.Object != nil && ev.Object.Spec.HostNetwork {
-			r.l.WithField("podKey", ev.Key.String()).Debug("pod is host networked, skipping")
+			r.l.Debug("pod is host networked, skipping", "podKey", ev.Key.String())
 		} else {
 			err = r.ReconcilePod(ctx, ev.Key, ev.Object)
 		}
@@ -190,7 +188,7 @@ func (r *endpointReconciler) runEventHandler(pctx context.Context, ev resource.E
 	cancel()
 
 	if err != nil {
-		r.l.WithError(err).WithField("podKey", ev.Key.String()).Error("error creating cilium endpoint. requeuing pod")
+		r.l.Error("error creating cilium endpoint. requeuing pod", "error", err, "podKey", ev.Key.String())
 	}
 	ev.Done(err)
 
@@ -224,7 +222,7 @@ func (r *endpointReconciler) runNamespaceEvents(pctx context.Context) error {
 			cancel()
 
 			if err != nil {
-				r.l.WithError(err).WithField("namespaceKey", ev.Key.String()).Error("error creating cilium endpoint. requeuing namespace")
+				r.l.Error("error creating cilium endpoint. requeuing namespace", "error", err, "namespaceKey", ev.Key.String())
 			}
 			ev.Done(err)
 		case <-pctx.Done():
@@ -237,17 +235,17 @@ func (r *endpointReconciler) runNamespaceEvents(pctx context.Context) error {
 func (r *endpointReconciler) ReconcilePodsInNamespace(ctx context.Context, namespace string) error {
 	r.Mutex.Lock()
 	defer r.Mutex.Unlock()
-	r.l.Debug("reconciling pods in namespace", zap.String("namespace ", namespace))
+	r.l.Debug("reconciling pods in namespace", "namespace", namespace)
 	podList := r.store.ListPodKeysByNamespace(namespace)
 	for _, podKey := range podList {
 		pod, ok := r.store.GetPod(podKey)
 		if !ok {
-			r.l.WithField("podKey", podKey.String()).Debug("pod not found in cache, skipping")
+			r.l.Debug("pod not found in cache, skipping", "podKey", podKey.String())
 			continue
 		}
 
 		if pod.toDelete {
-			r.l.WithField("podKey", podKey.String()).Debug("pod marked for deletion, skipping")
+			r.l.Debug("pod marked for deletion, skipping", "podKey", podKey.String())
 			continue
 		}
 
@@ -259,17 +257,16 @@ func (r *endpointReconciler) ReconcilePodsInNamespace(ctx context.Context, names
 		newPEP.lbls = endpointsLabels
 
 		r.l.Debug("upserting pod in namespace",
-			zap.String("namespace ", namespace),
-			zap.String("podKey", podKey.String()),
-			zap.Any("old labels ", pod.lbls),
-			zap.Any("new labels ", newPEP.lbls),
+			"namespace", namespace,
+			"podKey", podKey.String(),
+			"old labels", pod.lbls,
+			"new labels", newPEP.lbls,
 		)
 
 		err = r.handlePodUpsert(ctx, newPEP)
 		if err != nil {
-			r.l.Error("failed to upsert pod", zap.Error(err), zap.String("podKey", podKey.String()))
+			r.l.Error("failed to upsert pod", "error", err, "podKey", podKey.String())
 		}
-
 		if err != nil {
 			return errors.Wrap(err, "failed to upsert pod")
 		}
@@ -282,7 +279,7 @@ func (r *endpointReconciler) ReconcilePodsInNamespace(ctx context.Context, names
 func (r *endpointReconciler) ReconcilePod(ctx context.Context, podKey resource.Key, pod *slim_corev1.Pod) error {
 	r.Mutex.Lock()
 	defer r.Mutex.Unlock()
-	r.l.Debug("reconciling pod with lock", zap.String("namespace", podKey.Namespace), zap.String("pod ", podKey.Name))
+	r.l.Debug("reconciling pod with lock", "namespace", podKey.Namespace, "pod", podKey.Name)
 	return r.reconcilePod(ctx, podKey, pod)
 }
 
@@ -297,7 +294,7 @@ func (r *endpointReconciler) reconcilePod(ctx context.Context, podKey resource.K
 	}
 
 	if pod.Status.PodIP == "" || pod.Status.HostIP == "" {
-		r.l.WithField("podKey", podKey.String()).Trace("pod missing an IP, skipping")
+		r.l.Debug("pod missing an IP, skipping", "podKey", podKey.String())
 		return nil
 	}
 
@@ -326,7 +323,7 @@ func (r *endpointReconciler) reconcilePod(ctx context.Context, podKey resource.K
 func (r *endpointReconciler) HandlePodDelete(ctx context.Context, n resource.Key) error {
 	r.Mutex.Lock()
 	defer r.Mutex.Unlock()
-	r.l.Debug("handling pod delete with lock", zap.String("podKey", n.String()))
+	r.l.Debug("handling pod delete with lock", "podKey", n.String())
 	return r.handlePodDelete(ctx, n)
 }
 
@@ -335,20 +332,20 @@ func (r *endpointReconciler) handlePodDelete(ctx context.Context, n resource.Key
 	if !ok {
 		// do not do anything if we have not processed the pod
 		// let endpointgc delete the CiliumEndpoint as necessary
-		r.l.WithField("podKey", n.String()).Trace("pod not found in cache, skipping deletion")
+		r.l.Debug("pod not found in cache, skipping deletion", "podKey", n.String())
 		return nil
 	}
 
-	r.l.WithField("podKey", n.String()).Trace("handling pod delete")
+	r.l.Debug("handling pod delete", "podKey", n.String())
 
 	// delete CEP even if we haven't processed the Pod (and incremented identity reference count)
 	err := r.clientset.CiliumV2().CiliumEndpoints(n.Namespace).Delete(ctx, n.Name, metav1.DeleteOptions{})
 	if err != nil && !k8serrors.IsNotFound(err) {
-		r.l.WithError(err).WithField("podKey", n.String()).Error("failed to delete CiliumEndpoint")
+		r.l.Error("failed to delete CiliumEndpoint", "error", err, "podKey", n.String())
 		return errors.Wrap(err, "failed to delete endpoint")
 	}
 
-	r.l.WithField("podKey", n.String()).Debug("deleted CiliumEndpoint")
+	r.l.Debug("deleted CiliumEndpoint", "podKey", n.String())
 
 	// Identity reference count must be modified after CiliumEndpoint is successfully deleted.
 	// Otherwise, we could decrement reference multiple times if CiliumEndpoint deletion fails and we retry this method.
@@ -359,15 +356,15 @@ func (r *endpointReconciler) handlePodDelete(ctx context.Context, n resource.Key
 }
 
 func (r *endpointReconciler) handlePodUpsert(ctx context.Context, newPEP *PodEndpoint) error { //nolint:gocyclo // This function is too complex and should be refactored
-	r.l.WithField("podKey", newPEP.key.String()).Trace("handling pod upsert")
+	r.l.Debug("handling pod upsert", "podKey", newPEP.key.String())
 
 	oldPEP, inCache := r.store.GetPod(newPEP.key)
 	inStore := false
 	if inCache {
-		r.l.WithFields(logrus.Fields{
-			"podKey": newPEP.key.String(),
-			"pep":    oldPEP,
-		}).Trace("PodEndpoint found in cache")
+		r.l.Debug("PodEndpoint found in cache",
+			"podKey", newPEP.key.String(),
+			"pep", oldPEP,
+		)
 	} else {
 		// this call will block until the store is synced with API Server
 		store, err := r.ciliumEndpoints.Store(ctx)
@@ -384,21 +381,21 @@ func (r *endpointReconciler) handlePodUpsert(ctx context.Context, newPEP *PodEnd
 		inStore = ok
 
 		if inStore {
-			r.l.WithFields(logrus.Fields{
-				"podKey":          newPEP.key.String(),
-				"ownerReferences": oldCEP.ObjectMeta.OwnerReferences,
-				"endpointID":      oldCEP.Status.ID,
-				"identity":        oldCEP.Status.Identity,
-				"networking":      oldCEP.Status.Networking,
-			}).Trace("CiliumEndpoint found in store")
+			r.l.Debug("CiliumEndpoint found in store",
+				"podKey", newPEP.key.String(),
+				"ownerReferences", oldCEP.OwnerReferences,
+				"endpointID", oldCEP.Status.ID,
+				"identity", oldCEP.Status.Identity,
+				"networking", oldCEP.Status.Networking,
+			)
 
 			if oldCEP.Status.Networking == nil || len(oldCEP.Status.Networking.Addressing) == 0 || oldCEP.Status.Networking.Addressing[0].IPV4 == "" {
 				// FIXME handle IPv6 and dual-stack
 				inStore = false
-				r.l.WithFields(logrus.Fields{
-					"podKey": newPEP.key.String(),
-					"cep":    oldCEP,
-				}).Warn("CiliumEndpoint has no ipv4 address, ignoring")
+				r.l.Warn("CiliumEndpoint has no ipv4 address, ignoring",
+					"podKey", newPEP.key.String(),
+					"cep", oldCEP,
+				)
 			} else {
 				oldPEP = &PodEndpoint{
 					key:        newPEP.key,
@@ -424,23 +421,23 @@ func (r *endpointReconciler) handlePodUpsert(ctx context.Context, newPEP *PodEnd
 		sameNetworking := newPEP.ipv4 == oldPEP.ipv4 && newPEP.nodeIP == oldPEP.nodeIP
 		equalLabels := newPEP.lbls.Equals(oldPEP.lbls)
 
-		r.l.WithFields(logrus.Fields{
-			"podKey":         newPEP.key.String(),
-			"inCache":        inCache,
-			"sameNetworking": sameNetworking,
-			"equalLabels":    equalLabels,
-			"oldLbls":        oldPEP.lbls,
-			"newLbls":        newPEP.lbls,
-		}).Trace("patching CiliumEndpoint")
+		r.l.Debug("patching CiliumEndpoint",
+			"podKey", newPEP.key.String(),
+			"inCache", inCache,
+			"sameNetworking", sameNetworking,
+			"equalLabels", equalLabels,
+			"oldLbls", oldPEP.lbls,
+			"newLbls", newPEP.lbls,
+		)
 
 		// allocate new identity if labels have changed or if we haven't assigned an identity ID to this pod yet
 		// TODO when implementing follower check if inCache or processedAsLeader
 		shouldAllocateNewIdentity := !inCache || !equalLabels || newPEP.identityID == 0
 		if shouldAllocateNewIdentity {
-			r.l.WithFields(logrus.Fields{
-				"podKey": newPEP.key.String(),
-				"pep":    oldPEP,
-			}).Trace("creating new identity for pod")
+			r.l.Debug("creating new identity for pod",
+				"podKey", newPEP.key.String(),
+				"pep", oldPEP,
+			)
 
 			identityID, err := r.identityManager.GetIdentityAndIncrementReference(ctx, newPEP.lbls)
 			if err != nil {
@@ -452,13 +449,13 @@ func (r *endpointReconciler) handlePodUpsert(ctx context.Context, newPEP *PodEnd
 
 		if sameNetworking && equalLabels {
 			// nothing to do. pod already has a CEP with the same networking and labels
-			r.l.WithField("podKey", newPEP.key.String()).Trace("pod already processed")
+			r.l.Debug("pod already processed", "podKey", newPEP.key.String())
 			r.store.AddPod(newPEP)
 			return nil
 		}
 
 		if !sameNetworking {
-			r.l.WithField("podKey", newPEP.key.String()).Trace("pod networking has changed")
+			r.l.Debug("pod networking has changed", "podKey", newPEP.key.String())
 			// change endpoint id since networking has changed
 			// FIXME use endpoint allocator to get new endpoint ID
 			newPEP.endpointID++
@@ -493,15 +490,15 @@ func (r *endpointReconciler) handlePodUpsert(ctx context.Context, newPEP *PodEnd
 
 		createStatusPatch, err := json.Marshal(replaceCEPStatus)
 		if err != nil {
-			r.l.WithFields(logrus.Fields{
-				"podKey": newPEP.key.String(),
-				"pep":    newPEP,
-				"uid":    newPEP.uid,
-			}).Debug("marshalling status failed")
+			r.l.Debug("marshalling status failed",
+				"podKey", newPEP.key.String(),
+				"pep", newPEP,
+				"uid", newPEP.uid,
+			)
 
 			if shouldAllocateNewIdentity {
 				// decrement reference for new identity
-				r.l.WithField("podKey", newPEP.key.String()).Trace("marshal failed, decrementing reference for new identity")
+				r.l.Debug("marshal failed, decrementing reference for new identity", "podKey", newPEP.key.String())
 				r.identityManager.DecrementReference(ctx, newPEP.lbls)
 			}
 
@@ -526,7 +523,7 @@ func (r *endpointReconciler) handlePodUpsert(ctx context.Context, newPEP *PodEnd
 			// Decrement reference for new identity.
 			// May end up incrementing reference count for this same identity again if we try to create the CEP below.
 			// No downside to decrementing reference here and then incrementing again below (will not affect API Server).
-			r.l.WithField("podKey", newPEP.key.String()).Trace("patch unsuccessful, decrementing reference for new identity")
+			r.l.Debug("patch unsuccessful, decrementing reference for new identity", "podKey", newPEP.key.String())
 			r.identityManager.DecrementReference(ctx, newPEP.lbls)
 		}
 
@@ -535,16 +532,18 @@ func (r *endpointReconciler) handlePodUpsert(ctx context.Context, newPEP *PodEnd
 		// No downside to this.
 
 		if !k8serrors.IsNotFound(err) {
-			r.l.WithError(err).WithFields(logrus.Fields{
-				"podKey": newPEP.key.String(),
-				"pep":    newPEP,
-				"uid":    newPEP.uid,
-			}).Error("failed to patch CiliumEndpoint")
+			r.l.Error("failed to patch CiliumEndpoint",
+				"error", err,
+				"podKey", newPEP.key.String(),
+				"pep", newPEP,
+				"uid", newPEP.uid,
+			)
 
 			return errors.Wrap(err, "failed to patch endpoint")
 		}
 
-		r.l.WithField("podKey", newPEP.key.String()).Debug("patch unsuccessful because CiliumEndpoint is not in API Server. now creating CiliumEndpoint")
+		r.l.Debug("patch unsuccessful because CiliumEndpoint is not in API Server. now creating CiliumEndpoint",
+			"podKey", newPEP.key.String())
 
 		// Endpoint was not found, create it below.
 		// Make sure the pod does not exist in the cache so that we don't try to patch it again (in case of a retry after a failure below).
@@ -585,13 +584,13 @@ func (r *endpointReconciler) handlePodUpsert(ctx context.Context, newPEP *PodEnd
 
 	_, err = r.clientset.CiliumV2().CiliumEndpoints(newPEP.key.Namespace).Create(ctx, newCEP, metav1.CreateOptions{})
 	if err != nil {
-		r.l.WithError(err).WithField("podKey", newPEP.key.String()).Error("failed to create CiliumEndpoint")
+		r.l.Error("failed to create CiliumEndpoint", "error", err, "podKey", newPEP.key.String())
 		r.identityManager.DecrementReference(ctx, newPEP.lbls)
 		// FIXME release newly allocated endpoint ID
 		return errors.Wrap(err, "failed to create endpoint")
 	}
 
-	r.l.WithField("podKey", newPEP.key.String()).Debug("created CiliumEndpoint")
+	r.l.Debug("created CiliumEndpoint", "podKey", newPEP.key.String())
 	r.store.AddPod(newPEP)
 	return nil
 }
@@ -609,7 +608,7 @@ func (r *endpointReconciler) reconcileNamespace(ctx context.Context, namespace *
 	// check if namespace is in cache
 	oldNs, ok := r.store.GetNamespace(namespace.GetName())
 	if !ok {
-		r.l.Debug("Adding new namespace to cache", zap.String("namespace ", namespace.GetName()))
+		r.l.Debug("Adding new namespace to cache", "namespace", namespace.GetName())
 		// if this is the first time we see this namespace, add it to cache
 		// there might not be any pods in this namespace yet
 		r.store.AddNamespace(namespace)
@@ -617,16 +616,16 @@ func (r *endpointReconciler) reconcileNamespace(ctx context.Context, namespace *
 	}
 
 	if oldNs.GetResourceVersion() == namespace.GetResourceVersion() {
-		r.l.Debug("Namespace already processed", zap.String("namespace ", namespace.GetName()))
+		r.l.Debug("Namespace already processed", "namespace", namespace.GetName())
 		return nil
 	}
 
 	if reflect.DeepEqual(oldNs.Labels, namespace.Labels) {
-		r.l.Debug("Namespace labels are the same", zap.String("namespace ", namespace.GetName()))
+		r.l.Debug("Namespace labels are the same", "namespace", namespace.GetName())
 		return nil
 	}
 
-	r.l.Debug("Updating namespace in cache", zap.String("namespace ", namespace.GetName()))
+	r.l.Debug("Updating namespace in cache", "namespace", namespace.GetName())
 	r.store.AddNamespace(namespace)
 
 	// now get all pods and update them as well
@@ -640,11 +639,11 @@ func (r *endpointReconciler) reconcileNamespace(ctx context.Context, namespace *
 func (r *endpointReconciler) handleNamespaceDelete(_ context.Context, namespaceName string) error {
 	_, ok := r.store.GetNamespace(namespaceName)
 	if !ok {
-		r.l.Debug("Adding new namespace to cache", zap.String("namespace ", namespaceName))
+		r.l.Debug("Adding new namespace to cache", "namespace", namespaceName)
 		return nil
 	}
 
-	r.l.Debug("Deleting namespace from cache", zap.String("namespace ", namespaceName))
+	r.l.Debug("Deleting namespace from cache", "namespace", namespaceName)
 	// Ignore deleting the pods for this NS, pod controller will eventually clean it up.
 	// Once deleting all the pods in the namespace, delete the namespace
 	r.store.DeleteNamespace(namespaceName)
@@ -658,20 +657,22 @@ func (r *endpointReconciler) ciliumEndpointsLabels(ctx context.Context, pod *sli
 	if !ok {
 		ns, err = r.ciliumSlimClientSet.CoreV1().Namespaces().Get(ctx, pod.Namespace, metav1.GetOptions{})
 		if err != nil {
-			r.l.WithError(err).WithFields(logrus.Fields{
-				"podKey": pod.Name,
-				"ns":     pod.Namespace,
-			}).Error("failed to get namespace")
+			r.l.Error("failed to get namespace",
+				"error", err,
+				"podKey", pod.Name,
+				"ns", pod.Namespace,
+			)
 			return nil, errors.Wrap(err, "failed to get namespace")
 		}
 		r.store.AddNamespace(ns)
 	}
 	_, ciliumLabels := k8s.GetPodMetadata(slog.Default(), ns, pod)
 	if err != nil {
-		r.l.WithError(err).WithFields(logrus.Fields{
-			"podKey": pod.Name,
-			"ns":     pod.Namespace,
-		}).Error("failed to get pod metadata")
+		r.l.Error("failed to get pod metadata",
+			"error", err,
+			"podKey", pod.Name,
+			"ns", pod.Namespace,
+		)
 		return nil, errors.Wrap(err, "failed to get pod metadata")
 	}
 	lbls := make(labels.Labels, len(ciliumLabels))

--- a/pkg/controllers/operator/retinaendpoint/retinaendpoint_controller_test.go
+++ b/pkg/controllers/operator/retinaendpoint/retinaendpoint_controller_test.go
@@ -224,12 +224,25 @@ func TestRetinaEndpointReconciler_ReconcilePod(t *testing.T) {
 					return apierrors.IsNotFound(err)
 				}, 5*time.Second, 1*time.Second, "RetinaEndpoint should not exist")
 			} else {
+				// Wait for the RetinaEndpoint to be created/updated with the expected values
 				require.Eventually(t, func() bool {
 					err := client.Get(context.Background(), tt.fields.newlyCachedPod.Key, &got)
-					fmt.Println(err)
-					return !apierrors.IsNotFound(err)
-				}, 5*time.Second, 1*time.Second, "RetinaEndpoint should be created")
-				require.Equal(t, *tt.wantedRetinaEndpoint, got)
+					if apierrors.IsNotFound(err) {
+						return false
+					}
+					// Check that the spec matches what we expect (indicating create/update completed)
+					return got.Spec.PodIP == tt.wantedRetinaEndpoint.Spec.PodIP
+				}, 5*time.Second, 100*time.Millisecond, "RetinaEndpoint should be created/updated with expected PodIP")
+
+				// Re-fetch to get the latest state
+				err := client.Get(context.Background(), tt.fields.newlyCachedPod.Key, &got)
+				require.NoError(t, err)
+
+				// Compare the spec and type meta (ignore ResourceVersion since it varies)
+				require.Equal(t, tt.wantedRetinaEndpoint.TypeMeta, got.TypeMeta)
+				require.Equal(t, tt.wantedRetinaEndpoint.Spec, got.Spec)
+				require.Equal(t, tt.wantedRetinaEndpoint.Name, got.Name)
+				require.Equal(t, tt.wantedRetinaEndpoint.Namespace, got.Namespace)
 			}
 		})
 	}

--- a/pkg/utils/testutil/cilium/endpoint_client.go
+++ b/pkg/utils/testutil/cilium/endpoint_client.go
@@ -6,8 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-
-	"github.com/sirupsen/logrus"
+	"log/slog"
 
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
@@ -21,13 +20,15 @@ import (
 var _ ciliumv2.CiliumEndpointInterface = &MockEndpointClient{}
 
 type MockEndpointClient struct {
-	l               logrus.FieldLogger
+	l               *slog.Logger
 	namespace       string
 	ciliumEndpoints *MockResource[*v2.CiliumEndpoint]
 	watchers        []watch.Interface
 }
 
-func NewMockEndpointClient(l logrus.FieldLogger, namespace string, ciliumEndpoints *MockResource[*v2.CiliumEndpoint]) *MockEndpointClient {
+func NewMockEndpointClient(
+	l *slog.Logger, namespace string, ciliumEndpoints *MockResource[*v2.CiliumEndpoint],
+) *MockEndpointClient {
 	return &MockEndpointClient{
 		l:               l,
 		namespace:       namespace,

--- a/pkg/utils/testutil/cilium/identity_client.go
+++ b/pkg/utils/testutil/cilium/identity_client.go
@@ -4,12 +4,11 @@ package ciliumutil
 
 import (
 	"context"
+	"log/slog"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
-
-	"github.com/sirupsen/logrus"
 
 	v2 "github.com/cilium/cilium/pkg/k8s/apis/cilium.io/v2"
 	ciliumv2 "github.com/cilium/cilium/pkg/k8s/client/clientset/versioned/typed/cilium.io/v2"
@@ -23,14 +22,14 @@ var _ ciliumv2.CiliumIdentityInterface = &MockIdentityClient{}
 // - CRDBackend within the Allocator within the IdentityManager
 // - identitygc cell
 type MockIdentityClient struct {
-	l logrus.FieldLogger
+	l *slog.Logger
 	// identities maps identity name to identity
 	// namespace is irrelevant since identity names must be globally unique numbers
 	identities map[string]*v2.CiliumIdentity
 	watchers   []watch.Interface
 }
 
-func NewMockIdentityClient(l logrus.FieldLogger) *MockIdentityClient {
+func NewMockIdentityClient(l *slog.Logger) *MockIdentityClient {
 	return &MockIdentityClient{
 		l:          l,
 		identities: make(map[string]*v2.CiliumIdentity),

--- a/pkg/utils/testutil/cilium/resource.go
+++ b/pkg/utils/testutil/cilium/resource.go
@@ -4,9 +4,9 @@ package ciliumutil
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 
 	k8sRuntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
@@ -28,12 +28,12 @@ var (
 // i.e. Store() and GetByKey()
 // plus some helpers to add/remove items from the cache and error on the next call to Store()
 type MockResource[T k8sRuntime.Object] struct {
-	l                       logrus.FieldLogger
+	l                       *slog.Logger
 	cache                   map[resource.Key]T
 	shouldFailNextStoreCall bool
 }
 
-func NewMockResource[T k8sRuntime.Object](l logrus.FieldLogger) *MockResource[T] {
+func NewMockResource[T k8sRuntime.Object](l *slog.Logger) *MockResource[T] {
 	return &MockResource[T]{
 		l:     l,
 		cache: make(map[resource.Key]T),

--- a/pkg/utils/testutil/cilium/versioned_client.go
+++ b/pkg/utils/testutil/cilium/versioned_client.go
@@ -3,7 +3,7 @@
 package ciliumutil
 
 import (
-	"github.com/sirupsen/logrus"
+	"log/slog"
 
 	"k8s.io/client-go/rest"
 
@@ -23,11 +23,11 @@ var (
 // MockVersionedClient is a mock implementation of versioned.Interface
 // Currently it only returns a real value for CiliumV2()
 type MockVersionedClient struct {
-	l logrus.FieldLogger
+	l *slog.Logger
 	c *MockCiliumV2Client
 }
 
-func NewMockVersionedClient(l logrus.FieldLogger, ciliumEndpoints *MockResource[*v2.CiliumEndpoint]) *MockVersionedClient {
+func NewMockVersionedClient(l *slog.Logger, ciliumEndpoints *MockResource[*v2.CiliumEndpoint]) *MockVersionedClient {
 	return &MockVersionedClient{
 		l: l,
 		c: NewMockCiliumV2Client(l, ciliumEndpoints),
@@ -52,12 +52,12 @@ func (m *MockVersionedClient) CiliumV2alpha1() ciliumv2alpha1.CiliumV2alpha1Inte
 // MockCiliumV2Client is a mock implementation of ciliumv2.CiliumV2Interface.
 // Currently it only returns a real value for CiliumIdentities()
 type MockCiliumV2Client struct {
-	l               logrus.FieldLogger
+	l               *slog.Logger
 	identitiyClient *MockIdentityClient
 	ciliumEndpoints *MockResource[*v2.CiliumEndpoint]
 }
 
-func NewMockCiliumV2Client(l logrus.FieldLogger, ciliumEndpoints *MockResource[*v2.CiliumEndpoint]) *MockCiliumV2Client {
+func NewMockCiliumV2Client(l *slog.Logger, ciliumEndpoints *MockResource[*v2.CiliumEndpoint]) *MockCiliumV2Client {
 	return &MockCiliumV2Client{
 		l:               l,
 		identitiyClient: NewMockIdentityClient(l),
@@ -142,5 +142,15 @@ func (m *MockCiliumV2Client) CiliumBGPNodeConfigs() ciliumv2.CiliumBGPNodeConfig
 
 func (m *MockCiliumV2Client) CiliumBGPPeerConfigs() ciliumv2.CiliumBGPPeerConfigInterface {
 	m.l.Warn("MockCiliumV2Client.CiliumNetworkPoliciesForCRD() called but this returns nil because it's not implemented")
+	return nil
+}
+
+func (m *MockCiliumV2Client) CiliumCIDRGroups() ciliumv2.CiliumCIDRGroupInterface {
+	m.l.Warn("MockCiliumV2Client.CiliumCIDRGroups() called but this returns nil because it's not implemented")
+	return nil
+}
+
+func (m *MockCiliumV2Client) CiliumLoadBalancerIPPools() ciliumv2.CiliumLoadBalancerIPPoolInterface {
+	m.l.Warn("MockCiliumV2Client.CiliumLoadBalancerIPPools() called but this returns nil because it's not implemented")
 	return nil
 }

--- a/test/e2e/framework/prometheus/prometheus.go
+++ b/test/e2e/framework/prometheus/prometheus.go
@@ -13,6 +13,7 @@ import (
 	"github.com/microsoft/retina/test/retry"
 	promclient "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
+	"github.com/prometheus/common/model"
 )
 
 var (
@@ -164,13 +165,13 @@ func verifyValidMetricPresentPartial(metricName string, data map[string]*promcli
 }
 
 func getAllPrometheusMetricsFromBuffer(buf []byte) (map[string]*promclient.MetricFamily, error) {
-	var parser expfmt.TextParser
+	parser := expfmt.NewTextParser(model.LegacyValidation)
 	reader := strings.NewReader(string(buf))
 	return parser.TextToMetricFamilies(reader) //nolint
 }
 
 func ParseReaderPrometheusMetrics(input io.Reader) (map[string]*promclient.MetricFamily, error) {
-	var parser expfmt.TextParser
+	parser := expfmt.NewTextParser(model.LegacyValidation)
 	return parser.TextToMetricFamilies(input) //nolint
 }
 

--- a/test/managers/filtermanager/main.go
+++ b/test/managers/filtermanager/main.go
@@ -8,6 +8,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"log/slog"
 	"net"
 	"os"
 	"strings"
@@ -32,7 +33,7 @@ func main() {
 	log.SetupZapLogger(opts)
 	l := log.Logger().Named("test-packetparser")
 
-	metrics.InitializeMetrics()
+	metrics.InitializeMetrics(slog.Default())
 
 	ctx := context.Background()
 

--- a/test/plugin/infiniband/main_linux.go
+++ b/test/plugin/infiniband/main_linux.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"log/slog"
 	"time"
 
 	kcfg "github.com/microsoft/retina/pkg/config"
@@ -17,7 +18,7 @@ func main() {
 	log.SetupZapLogger(log.GetDefaultLogOpts()) //nolint std.
 	l := log.Logger().Named("test-infiniband")
 
-	metrics.InitializeMetrics()
+	metrics.InitializeMetrics(slog.Default())
 
 	cfg := &kcfg.Config{
 		MetricsInterval: 1 * time.Second,

--- a/test/plugin/linuxutil/main_linux.go
+++ b/test/plugin/linuxutil/main_linux.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"context"
+	"log/slog"
 	"time"
 
 	kcfg "github.com/microsoft/retina/pkg/config"
@@ -19,7 +20,7 @@ func main() {
 	log.SetupZapLogger(log.GetDefaultLogOpts())
 	l := log.Logger().Named("test-linuxutil")
 
-	metrics.InitializeMetrics()
+	metrics.InitializeMetrics(slog.Default())
 
 	cfg := &kcfg.Config{
 		MetricsInterval: 1 * time.Second,

--- a/test/plugin/packetforward/main_linux.go
+++ b/test/plugin/packetforward/main_linux.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"context"
+	"log/slog"
 	"time"
 
 	"github.com/microsoft/retina/pkg/log"
@@ -21,7 +22,7 @@ func main() {
 	log.SetupZapLogger(log.GetDefaultLogOpts())
 	l := log.Logger().Named("test-packetforward")
 
-	metrics.InitializeMetrics()
+	metrics.InitializeMetrics(slog.Default())
 
 	ctx := context.Background()
 


### PR DESCRIPTION
# Description

- Update operator CRD registration and endpoint/identity controllers for Cilium v1.19 API changes
- Add `PodResource` constructor for slim Pod resources (moved from Cilium core to operator in v1.19)
- Fix lint issues in `resource_ctors.go` (line length, unused params) and `retinaendpoint_controller_test.go`
- Update Helm chart values and templates (`enableDNSParsing` config)
- Update test utilities for new Cilium client interfaces

**PR 7 of 7** for Cilium v1.19 upgrade.

## Related Issue

- #1788
- #2038

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

- [ ] Verify operator endpoint controller tests pass
- [ ] Verify operator identity manager tests pass
- [ ] Verify retinaendpoint controller tests pass
- [ ] Verify Helm template renders correctly with new values
- [ ] Verify test utilities compile with updated Cilium client interfaces

## Additional Notes

None.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.