### PR TITLE
fix(ci): use native arm64 runners for all image builds

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -14,12 +14,17 @@ permissions:
 jobs:
   retina-images:
     name: Build Agent Images - Linux
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
 
     strategy:
       matrix:
         platform: ["linux"]
         arch: ["amd64", "arm64"]
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
 
     steps:
       - name: Checkout code
@@ -29,9 +34,6 @@ jobs:
         with:
           go-version-file: go.mod
       - run: go version
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Az CLI login
         uses: azure/login@v2
@@ -154,12 +156,17 @@ jobs:
 
   operator-images:
     name: Build Operator Images
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
 
     strategy:
       matrix:
         platform: ["linux"]
         arch: ["amd64", "arm64"]
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
 
     steps:
       - name: Checkout code
@@ -169,9 +176,6 @@ jobs:
         with:
           go-version-file: go.mod
       - run: go version
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Az CLI login
         uses: azure/login@v2
@@ -255,12 +259,17 @@ jobs:
 
   kubectl-retina-images:
     name: Build Kubectl Retina Images
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
 
     strategy:
       matrix:
         platform: ["linux"]
         arch: ["amd64", "arm64"]
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
 
     steps:
       - name: Checkout code
@@ -270,9 +279,6 @@ jobs:
         with:
           go-version-file: go.mod
       - run: go version
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Az CLI login
         uses: azure/login@v2

--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -15,12 +15,17 @@ permissions:
 jobs:
   retina-images:
     name: Build Agent Images
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
 
     strategy:
       matrix:
         platform: ["linux"]
         arch: ["amd64", "arm64"]
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
 
     steps:
       - name: Checkout code
@@ -33,9 +38,6 @@ jobs:
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@v4.0.0
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Log in to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
@@ -140,12 +142,17 @@ jobs:
 
   operator-images:
     name: Build Operator Images
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
 
     strategy:
       matrix:
         platform: ["linux"]
         arch: ["amd64", "arm64"]
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
 
     steps:
       - name: Checkout code
@@ -158,9 +165,6 @@ jobs:
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@v4.0.0
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Log in to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
@@ -230,12 +234,17 @@ jobs:
 
   kubectl-retina-images:
     name: Build Kubectl Retina Images
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
 
     strategy:
       matrix:
         platform: ["linux"]
         arch: ["amd64", "arm64"]
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
 
     steps:
       - name: Checkout code
@@ -248,9 +257,6 @@ jobs:
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@v4.0.0
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Log in to registry
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin


### PR DESCRIPTION
# Description

Switch remaining ARM64 image build jobs to native `ubuntu-24.04-arm` runners instead of QEMU emulation on x86 `ubuntu-latest`. This follows the same pattern established for `retina-shell-images` in PR #2024.

## Related Issue

Follows up on #2024 (fix(ci): use native arm64 runners for shell image build).

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

YAML syntax validated. Changes are consistent with the existing `retina-shell-images` pattern already running in CI.

**Jobs migrated (6 total across 2 files):**

| Job | File |
|-----|------|
| `retina-images` | `images.yaml` |
| `operator-images` | `images.yaml` |
| `kubectl-retina-images` | `images.yaml` |
| `retina-images` | `release-images.yaml` |
| `operator-images` | `release-images.yaml` |
| `kubectl-retina-images` | `release-images.yaml` |

**Changes per job:**
- `runs-on`: `ubuntu-latest` → `${{ matrix.runner }}`
- Matrix converted from simple arrays to explicit `include` entries with `runner` field (`ubuntu-latest` for amd64, `ubuntu-24.04-arm` for arm64)
- Removed `docker/setup-qemu-action` step (no longer needed for native builds)
- Updated job names to include `(${{ matrix.platform }}, ${{ matrix.arch }})` for clarity

**Not changed:**
- `manifests` jobs — still use QEMU as needed for multi-arch manifest inspection
- `retina-shell-images` — already migrated in #2024

## Additional Notes

The only remaining `setup-qemu-action` references are in the `manifests` jobs, which correctly still need it.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.