### PR TITLE
chore(deps): bump pwru to v1.0.11 and hubble to v1.18.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ PLATFORM		?= $(OS)/$(ARCH)
 PLATFORMS		?= linux/amd64 linux/arm64 windows/amd64
 OS_VERSION		?= ltsc2019
 
-HUBBLE_VERSION ?= v1.18.3
+HUBBLE_VERSION ?= v1.18.6
 
 CONTAINER_BUILDER ?= docker
 CONTAINER_RUNTIME ?= docker

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -19,21 +19,21 @@ ARG GOOS=linux # default to linux
 ENV GOARCH=${GOARCH}
 ENV GOOS=${GOOS}
 RUN if [ "$GOOS" = "linux" ] ; then \
-      tdnf install -y clang lld bpftool libbpf-devel; \
+    tdnf install -y clang lld bpftool libbpf-devel; \
     fi
 COPY ./pkg/plugin /go/src/github.com/microsoft/retina/pkg/plugin
 WORKDIR /go/src/github.com/microsoft/retina
 RUN if [ "$GOOS" = "linux" ] ; then \
-      go mod init github.com/microsoft/retina; \
-      go generate -skip "mockgen" -x /go/src/github.com/microsoft/retina/pkg/plugin/...; \
-      tar czf /gen.tar.gz ./pkg/plugin; \
-      rm go.mod; \
+    go mod init github.com/microsoft/retina; \
+    go generate -skip "mockgen" -x /go/src/github.com/microsoft/retina/pkg/plugin/...; \
+    tar czf /gen.tar.gz ./pkg/plugin; \
+    rm go.mod; \
     fi
 COPY ./go.mod ./go.sum ./
 RUN go mod download
 COPY . .
 RUN if [ "$GOOS" = "linux" ] ; then \
-      rm -rf ./pkg/plugin && tar xvf /gen.tar.gz ./pkg/plugin; \
+    rm -rf ./pkg/plugin && tar xvf /gen.tar.gz ./pkg/plugin; \
     fi
 
 # capture binary
@@ -87,7 +87,7 @@ RUN arr="clang tcpdump ip ss iptables-legacy iptables-legacy-save iptables-nft i
 ARG GOARCH=amd64
 ENV HUBBLE_ARCH=${GOARCH}
 # ARG HUBBLE_VERSION may be modified via the update-hubble GitHub Action
-ARG HUBBLE_VERSION=v1.18.3
+ARG HUBBLE_VERSION=v1.18.6
 ENV HUBBLE_VERSION=${HUBBLE_VERSION}
 RUN echo "Hubble version: $HUBBLE_VERSION" && \
     wget --no-check-certificate https://github.com/cilium/hubble/releases/download/$HUBBLE_VERSION/hubble-linux-${HUBBLE_ARCH}.tar.gz && \

--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -57,7 +57,7 @@ ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 ARG GOARCH=amd64
 ENV ARCH=${GOARCH}
 # https://github.com/cilium/pwru/releases
-ARG PWRU_TAG="v1.0.9"
+ARG PWRU_TAG="v1.0.11"
 ENV PWRU_TAG=${PWRU_TAG}
 
 # Download and extract latest pwru release for the correct architecture (amd64 or arm64)


### PR DESCRIPTION
## Description

Bump shell tool versions:
- **pwru**: v1.0.9 → v1.0.11 ([release notes](https://github.com/cilium/pwru/releases/tag/v1.0.11))
- **hubble CLI**: v1.18.3 → v1.18.6 ([release notes](https://github.com/cilium/hubble/releases/tag/v1.18.6))

## Related Issue

N/A

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

- Verified pwru v1.0.11 release asset URL resolves: `curl -sfIL "https://github.com/cilium/pwru/releases/download/v1.0.11/pwru-linux-amd64.tar.gz"`
- Verified hubble v1.18.6 release exists on GitHub