### PR TITLE
fix(ci): fix markdownlint config not being applied after v22 action bump

### DIFF
--- a/.github/workflows/markdownlint.yaml
+++ b/.github/workflows/markdownlint.yaml
@@ -20,7 +20,5 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: DavidAnson/markdownlint-cli2-action@07035fd053f7be764496c0f8d8f9f41f98305101 # v22.0.0
         with:
-          command: config
-          globs: |
-            .github/.markdownlint.json
-            **/*.md
+          config: .github/.markdownlint.json
+          globs: '**/*.md'


### PR DESCRIPTION
# Description

The v9 → v22 bump of `markdownlint-cli2-action` in #2060 broke the Markdown Lint CI check for all PRs. The `command` input was removed in v22 and replaced with a dedicated `config` input. The old invocation silently ignored both `command: config` and the config file path inside `globs`, causing all files to be linted with default rules — including MD013 (line-length) which the project explicitly disables in `.github/.markdownlint.json`.

This PR switches to the v22 `config` input so the config file is actually applied.

## Related Issue

N/A

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

CI will validate — this is a workflow-only change. The fix is self-verifying: if the config is applied correctly, MD013 violations from existing files (e.g., `SECURITY.md`, `test/e2e/README.md`) will stop appearing.

## Additional Notes

N/A