### PR TITLE
fix(ci): install syft in goreleaser workflow for SBOM generation

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -28,6 +28,8 @@ jobs:
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
           go-version-file: go.mod
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@17ae1740179002c89186b61233e0f892c3118b11 # v0.23.0
       - name: Run GoReleaser build
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         env:
@@ -50,6 +52,8 @@ jobs:
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
           go-version-file: go.mod
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@17ae1740179002c89186b61233e0f892c3118b11 # v0.23.0
       - name: Run GoReleaser release
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:


### PR DESCRIPTION
# Description

The goreleaser workflow fails at the SBOM cataloging step because `syft` is not installed on the runner. `.goreleaser.yaml` declares `sboms: [artifacts: archive]` which requires Syft, but the workflow never installs it.

This was surfaced by the [v1.1.0 release run](https://github.com/microsoft/retina/actions/runs/22452857876):
```
⨯ release failed after 9m34s
  error=exec: "syft": executable file not found in $PATH
```

Add `anchore/sbom-action/download-syft@v0.23.0` (pinned to SHA) to both the `build` and `release` jobs.

## Related Issue

N/A

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

CI workflow change — will be validated by the next tag push or PR build.

## Additional Notes

N/A