### PR TITLE
fix(utils): handle '+' suffix in kernel version parsing

### DIFF
--- a/pkg/utils/kernel_version_linux.go
+++ b/pkg/utils/kernel_version_linux.go
@@ -65,6 +65,7 @@ func kernelSemverFromParts(major, minor, patch int) string {
 
 func normalizeKernelReleaseToSemver(release string) (version string, major, minor, patch int, err error) {
 	base := strings.SplitN(release, "-", 2)[0]
+	base = strings.SplitN(base, "+", 2)[0]
 	parts := strings.Split(base, ".")
 	if len(parts) < 2 {
 		return "", 0, 0, 0, fmt.Errorf("%w: %q", errUnexpectedKernelReleaseFormat, release)

--- a/pkg/utils/kernel_version_linux_test.go
+++ b/pkg/utils/kernel_version_linux_test.go
@@ -55,6 +55,22 @@ func TestParseLinuxKernelRelease(t *testing.T) {
 			expectErr:   false,
 		},
 		{
+			name:        "plus suffix (GKE Container-Optimized OS)",
+			release:     "6.6.113+",
+			expectMajor: 6,
+			expectMinor: 6,
+			expectPatch: 113,
+			expectErr:   false,
+		},
+		{
+			name:        "plus suffix with build metadata",
+			release:     "6.6.113+gke-12345",
+			expectMajor: 6,
+			expectMinor: 6,
+			expectPatch: 113,
+			expectErr:   false,
+		},
+		{
 			name:      "invalid format",
 			release:   "foo",
 			expectErr: true,


### PR DESCRIPTION
## Description

Currently `normalizeKernelReleaseToSemver` only strips `-` suffixes from the uname release string before parsing version components. GKE Container-Optimized OS uses kernel versions like `6.6.113+`, which causes `strconv.Atoi` to fail on the patch component (`"113+"`).

This PR strips `+` suffixes from the base version string before splitting into parts, matching how `+` is used as a build metadata separator in semver.

## Related Issue

Fixes #2086

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

```bash
go test -tags=unit ./pkg/utils/ -run TestParseLinuxKernelRelease -v
```

All 8 test cases pass, including two new cases for `6.6.113+` and `6.6.113+gke-12345`.

## Additional Notes

N/A