### PR TITLE
fix(ci): build kapinger arm64 natively instead of cross-compiling

### DIFF
--- a/.github/workflows/kapinger.yaml
+++ b/.github/workflows/kapinger.yaml
@@ -6,7 +6,68 @@ on:
       - main
 
 jobs:
-  build:
+  build-linux:
+    name: Build Linux Kapinger Image (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+
+    strategy:
+      matrix:
+        arch: ["amd64", "arm64"]
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set outputs
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Log in to GHCR
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Build Linux Kapinger Image
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: hack/tools/kapinger
+          file: hack/tools/kapinger/Dockerfile
+          platforms: linux/${{ matrix.arch }}
+          target: linux
+          load: true
+          push: false
+          provenance: false
+          tags: ghcr.io/${{ github.repository }}/kapinger:${{ steps.vars.outputs.sha_short }}-linux-${{ matrix.arch }}
+
+      - name: Smoke test kapinger binary
+        run: |
+          IMAGE=ghcr.io/${{ github.repository }}/kapinger:${{ steps.vars.outputs.sha_short }}-linux-${{ matrix.arch }}
+          # Verify the binary starts and prints the expected startup log.
+          # It will exit with an error because there's no K8s cluster, but
+          # that confirms the binary is correctly linked and executable.
+          docker run --rm "$IMAGE" 2>&1 | grep -q "starting kapinger"
+
+      - name: Push Linux Kapinger Image
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
+        with:
+          context: hack/tools/kapinger
+          file: hack/tools/kapinger/Dockerfile
+          platforms: linux/${{ matrix.arch }}
+          target: linux
+          push: true
+          provenance: false
+          tags: ghcr.io/${{ github.repository }}/kapinger:${{ steps.vars.outputs.sha_short }}-linux-${{ matrix.arch }}
+
+  build-windows:
+    name: Build Windows Kapinger Image
     runs-on: ubuntu-latest
 
     steps:
@@ -16,50 +77,83 @@ jobs:
       - name: Set outputs
         id: vars
         run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-      - name: Check outputs
-        run: echo ${{ steps.vars.outputs.sha_short }}
+
+      - name: Log in to GHCR
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      #      - name: Login to GitHub Container Registry
-      #        uses: docker/login-action@v1
-      #        with:
-      #          registry: ghcr.io
-      #          username: ${{ github.repository_owner }}
-      #          password: ${{ secrets.GITHUB_TOKEN }}
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build Windows Kapinger Image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: hack/tools/kapinger
           file: hack/tools/kapinger/Dockerfile
           platforms: windows/amd64
-          push: false
+          target: windows
+          push: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
           provenance: false
           tags: ghcr.io/${{ github.repository }}/kapinger:${{ steps.vars.outputs.sha_short }}-windows
 
-      - name: Build Linux Kapinger Image
-        uses: docker/build-push-action@v6
-        with:
-          context: hack/tools/kapinger
-          file: hack/tools/kapinger/Dockerfile
-          platforms: linux/amd64
-          push: false
-          provenance: false
-          tags: ghcr.io/${{ github.repository }}/kapinger:${{ steps.vars.outputs.sha_short }}-linux
+  manifest:
+    name: Create and Push Manifest
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+    needs: [build-linux, build-windows]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set outputs
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Create and push manifest
+        run: |
+          TAG=${{ steps.vars.outputs.sha_short }}
+          REPO=ghcr.io/${{ github.repository }}/kapinger
+          TAGS="-t $REPO:$TAG"
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            TAGS="$TAGS -t $REPO:${{ github.ref_name }}"
+          fi
+          docker buildx imagetools create $TAGS \
+            "$REPO:$TAG-linux-amd64" \
+            "$REPO:$TAG-linux-arm64" \
+            "$REPO:$TAG-windows"
+
+  build-toolbox:
+    name: Build Linux Toolbox Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set outputs
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Log in to GHCR
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build Linux Toolbox Image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: hack/tools
           file: hack/tools/toolbox/Dockerfile
           platforms: linux/amd64
-          push: false
+          push: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) }}
           provenance: false
           tags: ghcr.io/${{ github.repository }}/toolbox:${{ steps.vars.outputs.sha_short }}-linux
-#      - name: Create and push manifest
-#        id: docker_manifest
-#        run: |
-#          docker manifest create ghcr.io/${{ github.repository }}/kapinger:latest ghcr.io/${{ github.repository }}/kapinger:${{ steps.vars.outputs.sha_short }}-windows ghcr.io/${{ github.repository }}/kapinger:${{ steps.vars.outputs.sha_short }}-linux
-#          docker manifest push ghcr.io/${{ github.repository }}/kapinger:latest

--- a/hack/tools/kapinger/Dockerfile
+++ b/hack/tools/kapinger/Dockerfile
@@ -1,36 +1,32 @@
+# Linux builder - runs natively on the target platform (amd64 or arm64)
 # skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.26.0 --format "{{.Name}}@{{.Digest}}"
-FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang@sha256:66a04c4bcea1fafc935246c96af236eb4d91d501387e061ae59f134c8993dae9 AS builder
+FROM mcr.microsoft.com/oss/go/microsoft/golang@sha256:9644874dae39c9ef28b59836911bc859c0a6c5c1c1d76429063f4b435275815b AS builder
 
 WORKDIR /build
 ADD . .
-RUN go mod download 
+RUN go mod download
+RUN go build -o kapinger . && mkdir -p /lib64
 
-# Build for Linux
-RUN GOOS=linux go build -o kapinger .
-
-# Build for Windows
-RUN GOOS=windows go build -o kapinger.exe .
-
-# Build for ARM64 Linux
-RUN GOOS=linux GOARCH=arm64 go build -o kapinger-arm64 .
-
-FROM --platform=linux/amd64 scratch AS linux-amd64
+FROM scratch AS linux
 COPY --from=builder /lib/ /lib
+COPY --from=builder /lib64/ /lib64
 COPY --from=builder /usr/lib/ /usr/lib
 WORKDIR /app
 COPY --from=builder /build/kapinger .
 CMD ["./kapinger"]
 
+# Windows builder - cross-compiles from Linux amd64 (GOOS=windows is not affected by systemcrypto)
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.26.0 --format "{{.Name}}@{{.Digest}}"
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:66a04c4bcea1fafc935246c96af236eb4d91d501387e061ae59f134c8993dae9 AS windows-builder
+
+WORKDIR /build
+ADD . .
+RUN go mod download
+RUN GOOS=windows go build -o kapinger.exe .
+
 # skopeo inspect docker://mcr.microsoft.com/windows/servercore:ltsc2022 --override-os windows --format "{{.Name}}@{{.Digest}}"
-FROM --platform=windows/amd64 mcr.microsoft.com/windows/servercore@sha256:a264df8cd8c329eed3fd1e0cafcd4f3dc453e2c72a277f9bb140fd6f10a2eefc AS windows-amd64
+FROM mcr.microsoft.com/windows/servercore@sha256:a264df8cd8c329eed3fd1e0cafcd4f3dc453e2c72a277f9bb140fd6f10a2eefc AS windows
 WORKDIR /app
-COPY --from=builder /build/kapinger.exe .
+COPY --from=windows-builder /build/kapinger.exe .
 ENTRYPOINT [ "cmd.exe" ]
 CMD [ "/c", "kapinger.exe" ]
-
-FROM --platform=linux/arm64 scratch AS linux-arm64
-COPY --from=builder /lib/ /lib
-COPY --from=builder /usr/lib/ /usr/lib
-WORKDIR /app
-COPY --from=builder /build/kapinger-arm64 .
-CMD ["./kapinger-arm64"]


### PR DESCRIPTION
# Description

Currently the kapinger workflow cross-compiles all architectures (linux/amd64, linux/arm64, windows/amd64) from a single `--platform=linux/amd64` builder. The arm64 binary is built with `GOOS=linux GOARCH=arm64 go build`, which doesn't work reliably for CGO-dependent code and prevents using platform-specific optimizations.

This PR restructures the workflow and Dockerfile for native builds:

- **Dockerfile**: Split into a native Linux builder (runs on target arch) and a cross-compiling Windows builder (`--platform=$BUILDPLATFORM` with `GOOS=windows`). Fixed missing `/lib64/` copy that caused "no such file or directory" at runtime.
- **Workflow**: Use a matrix strategy with native runners (`ubuntu-latest` for amd64, `ubuntu-24.04-arm` for arm64). Split into separate `build-linux`, `build-windows`, `manifest`, and `build-toolbox` jobs.
- **Smoke test**: Each Linux build loads the image and verifies the binary starts correctly via `docker run`.
- **Manifest**: After all builds pass, create a multi-arch manifest list (`docker buildx imagetools create`) combining linux-amd64, linux-arm64, and windows.
- **Toolbox**: Add GHCR login and enable push on merge to main (previously build-only).
- **CI hardening**: Add path filters, PR/merge_group triggers, `permissions`, GHCR login, and pin all action SHAs.

## Related Issue

N/A

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Additional Notes

- Images are pushed only on merge to main, not on PRs.