### PR TITLE
Gracefully Handle the abscence of retinaebpfapi.dll

### DIFF
--- a/pkg/plugin/ebpfwindows/ebpf_windows.go
+++ b/pkg/plugin/ebpfwindows/ebpf_windows.go
@@ -40,6 +40,7 @@ var (
 	errInvalidDropNotifySize   = errors.New("invalid size for DropNotify")
 	errInvalidTraceNotifySize  = errors.New("invalid size for TraceNotify")
 	errNilTraceNotifyFlow      = errors.New("tracenotify flow object is nil")
+	isCiliumOnWindowsEnabled   = plugincommon.IsCiliumOnWindowsEnabled
 )
 
 // Plugin is the ebpfwindows plugin
@@ -83,7 +84,7 @@ func (p *Plugin) Name() string {
 func (p *Plugin) Start(ctx context.Context) error {
 	p.l.Info("Start ebpfWindows plugin...")
 
-	ciliumEnabled, err := plugincommon.IsCiliumOnWindowsEnabled()
+	ciliumEnabled, err := isCiliumOnWindowsEnabled()
 
 	if err != nil {
 		p.l.Error("Error while checking if Cilium is enabled on Windows", zap.Error(err))
@@ -95,9 +96,26 @@ func (p *Plugin) Start(ctx context.Context) error {
 		return nil
 	}
 
+	if err := p.ensureRetinaEbpfAPIAvailable(); err != nil {
+		p.l.Warn("retinaebpfapi.dll is unavailable, skipping ebpfWindows plugin initialization", zap.Error(err))
+		return nil
+	}
+
 	p.l.Info("Cilium is enabled on Windows, proceeding with ebpfWindows plugin initialization")
 	p.pullMetricsAndEvents(ctx)
 	p.l.Info("Complete ebpfWindows plugin...")
+	return nil
+}
+
+func (p *Plugin) ensureRetinaEbpfAPIAvailable() error {
+	if err := p.addEbpfToPath(); err != nil {
+		return err
+	}
+
+	if err := loadRetinaEbpfAPI(); err != nil {
+		return fmt.Errorf("loading retinaebpfapi.dll or required exports: %w", err)
+	}
+
 	return nil
 }
 
@@ -164,11 +182,6 @@ func (p *Plugin) pullMetricsAndEvents(ctx context.Context) {
 	eventsMap := NewEventsMap()
 	metricsMap := NewMetricsMap()
 	prevLostEventsCount := uint64(0)
-
-	err := p.addEbpfToPath()
-	if err != nil {
-		return
-	}
 
 	if enricher.IsInitialized() && p.cfg.EnablePodLevel {
 		p.enricher = enricher.Instance()

--- a/pkg/plugin/ebpfwindows/ebpf_windows_test.go
+++ b/pkg/plugin/ebpfwindows/ebpf_windows_test.go
@@ -6,6 +6,7 @@ package ebpfwindows
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -750,6 +751,33 @@ func TestRegisterForCallback_Error(t *testing.T) {
 	err := em.RegisterForCallback(logger, cb)
 	if err == nil {
 		t.Fatalf("expected error when registering callback with eventsmap, got nothing")
+	}
+}
+
+func TestStart_GracefullySkipsWhenRetinaEbpfAPIMissing(t *testing.T) {
+	origIsCiliumOnWindowsEnabled := isCiliumOnWindowsEnabled
+	origLoadRetinaEbpfAPI := loadRetinaEbpfAPI
+	isCiliumOnWindowsEnabled = func() (bool, error) {
+		return true, nil
+	}
+	loadRetinaEbpfAPI = func() error {
+		return fmt.Errorf("module not found")
+	}
+	defer func() {
+		isCiliumOnWindowsEnabled = origIsCiliumOnWindowsEnabled
+		loadRetinaEbpfAPI = origLoadRetinaEbpfAPI
+	}()
+
+	p := &Plugin{
+		cfg: &kcfg.Config{
+			MetricsInterval: 100 * time.Second,
+			EnablePodLevel:  true,
+		},
+		l: log.Logger().Named("test-ebpf"),
+	}
+
+	if err := p.Start(context.Background()); err != nil {
+		t.Fatalf("expected plugin to skip gracefully when retinaebpfapi.dll is missing, got %v", err)
 	}
 }
 

--- a/pkg/plugin/ebpfwindows/metricsmap_windows.go
+++ b/pkg/plugin/ebpfwindows/metricsmap_windows.go
@@ -85,6 +85,25 @@ var callEnumMetricsMap = func(callback uintptr) (uintptr, uintptr, error) {
 	return enumMetricsMap.Call(callback)
 }
 
+var loadRetinaEbpfAPI = func() error {
+	if err := retinaEbpfAPI.Load(); err != nil {
+		return err
+	}
+
+	for _, proc := range []*windows.LazyProc{
+		enumMetricsMap,
+		lostEventCount,
+		registerEventsMapCallback,
+		unregisterEventsMapCallback,
+	} {
+		if err := proc.Find(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // IterateWithCallback iterates through all the keys/values of a metrics map,
 // passing each key/value pair to the cb callback
 func (m metricsMap) IterateWithCallback(l *log.ZapLogger, cb IterateCallback) error {


### PR DESCRIPTION
# Description

This change makes the Windows eBPF plugin fail open when retinaebpfapi.dll is not installed or does not expose the expected entrypoints. Instead of deferring the failure until the first native call, startup now validates the DLL up front, logs a warning, and skips plugin initialization cleanly. It also adds a unit test covering the missing-DLL path.

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x ] I have correctly attributed the author(s) of the code.
- [x ] I have tested the changes locally.
- [x ] I have followed the project's style guidelines.
- [x ] I have updated the documentation, if necessary.
- [ x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
