### PR TITLE
fix(chart): roll operator pod when its configmap changes

### DIFF
--- a/deploy/standard/manifests/controller/helm/retina/templates/operator-configmap.yaml
+++ b/deploy/standard/manifests/controller/helm/retina/templates/operator-configmap.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.operator.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ .Values.operator.name }}-config"
+  namespace: {{ .Values.namespace }}
+data:
+  operator-config.yaml: |-
+    installCRDs: {{ .Values.operator.installCRDs }}
+    enableTelemetry: {{ .Values.enableTelemetry }}
+    remoteContext: {{ .Values.remoteContext }}
+    captureDebug: {{ .Values.capture.debug }}
+    captureJobNumLimit: {{ .Values.capture.jobNumLimit }}
+    enableManagedStorageAccount: {{ .Values.capture.enableManagedStorageAccount }}
+    telemetryInterval: {{ .Values.operator.telemetryInterval }}
+{{- if .Values.capture.enableManagedStorageAccount }}
+    azureCredentialConfig: /etc/cloud-config/azure.json
+{{- end }}
+{{- end }}

--- a/deploy/standard/manifests/controller/helm/retina/templates/operator.yaml
+++ b/deploy/standard/manifests/controller/helm/retina/templates/operator.yaml
@@ -24,6 +24,10 @@ spec:
         kubectl.kubernetes.io/default-container: {{ .Values.operator.name }}
         prometheus.io/port: "{{ .Values.operatorService.port }}"
         prometheus.io/scrape: "true"
+        # Roll the operator pod whenever its ConfigMap rendering changes,
+        # so `helm upgrade` applies new config values (e.g. `remoteContext`)
+        # without requiring a manual `kubectl rollout restart`.
+        checksum/config: {{ include (print $.Template.BasePath "/operator-configmap.yaml") . | sha256sum }}
       labels:
         app: {{ .Values.operator.name }}
         control-plane: {{ .Values.operator.name }}
@@ -282,24 +286,6 @@ subjects:
 - kind: ServiceAccount
   name: {{ .Values.operator.name }}
   namespace: {{ .Values.namespace }}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: "{{ .Values.operator.name }}-config"
-  namespace: {{ .Values.namespace }}
-data:
-  operator-config.yaml: |-
-    installCRDs: {{ .Values.operator.installCRDs }}
-    enableTelemetry: {{ .Values.enableTelemetry }}
-    remoteContext: {{ .Values.remoteContext }}
-    captureDebug: {{ .Values.capture.debug }}
-    captureJobNumLimit: {{ .Values.capture.jobNumLimit }}
-    enableManagedStorageAccount: {{ .Values.capture.enableManagedStorageAccount }}
-    telemetryInterval: {{ .Values.operator.telemetryInterval }}
-{{- if .Values.capture.enableManagedStorageAccount }}
-    azureCredentialConfig: /etc/cloud-config/azure.json
-{{- end }}
 ---
 {{- if .Values.capture.enableManagedStorageAccount }}
 apiVersion: v1


### PR DESCRIPTION
## Description

The operator Deployment's pod template has no `checksum/config` annotation, so `helm upgrade` doesn't roll the operator when its ConfigMap rendering changes. The operator reads its config once at startup and caches it, so values like `remoteContext` stay stale until the pod is manually restarted — leaving the operator unable to create `retinaendpoint` resources that agents in remote-context mode rely on.

This PR adds the annotation, matching what `daemonset.yaml` already does. The operator ConfigMap is split out of `operator.yaml` into its own `operator-configmap.yaml` so the `include` used by the checksum doesn't recurse into itself.

Found while testing #2152 on a live cluster.

## Related Issue

Relates to #2152

## Checklist

- [x] I have read the [contributing guidelines](../CONTRIBUTING.md)
- [x] I have signed the CLA
- [ ] Unit tests added/updated — N/A, chart template change
- [ ] Integration tests added/updated — N/A, chart template change
- [ ] Documentation updated — N/A
- [x] Helm chart updated

## Testing

```bash
helm lint deploy/standard/manifests/controller/helm/retina/
# 1 chart(s) linted, 0 chart(s) failed
```

Verified the checksum annotation actually moves when operator config values change:

```bash
HASH1=$(helm template test deploy/standard/manifests/controller/helm/retina/ \
  --set operator.enabled=true --set remoteContext=false | grep 'checksum/config' | tail -1)
HASH2=$(helm template test deploy/standard/manifests/controller/helm/retina/ \
  --set operator.enabled=true --set remoteContext=true  | grep 'checksum/config' | tail -1)
# different → pod will roll on the next helm upgrade
```
