### PR TITLE
Add retina_build_info prometheus metric

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@
 RMDIR := rm -rf
 
 ## Globals
-GIT_CURRENT_BRANCH_NAME	:= $(shell git rev-parse --abbrev-ref HEAD) 
+GIT_CURRENT_BRANCH_NAME	:= $(shell git rev-parse --abbrev-ref HEAD)
+GIT_COMMIT := $(shell git rev-parse --short HEAD)
 
 REPO_ROOT = $(shell git rev-parse --show-toplevel)
 ifndef TAG
@@ -158,7 +159,7 @@ retina: ## builds retina binary
 
 retina-binary: ## build the Retina binary
 	go generate ./... && \
-	go build -v -o $(RETINA_BUILD_DIR)/retina$(EXE_EXT) -gcflags="-dwarflocationlists=true" -ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version=$(TAG) -X github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID=$(APP_INSIGHTS_ID)" $(RETINA_DIR)/main.go
+	go build -v -o $(RETINA_BUILD_DIR)/retina$(EXE_EXT) -gcflags="-dwarflocationlists=true" -ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version=$(TAG) -X github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID=$(APP_INSIGHTS_ID) -X github.com/microsoft/retina/internal/buildinfo.GitCommit=$(GIT_COMMIT)" $(RETINA_DIR)/main.go
 
 retina-capture-workload: ## build the Retina capture workload
 	cd $(CAPTURE_WORKLOAD_DIR) && go build -v -o $(RETINA_BUILD_DIR)/captureworkload$(EXE_EXT) -gcflags="-dwarflocationlists=true"  -ldflags "-X main.version=$(TAG)"
@@ -395,12 +396,14 @@ build-windows-binaries: ## Build Windows binaries
 	CGO_ENABLED=0 GOOS=windows GOARCH=$(GOARCH) go build -v \
 		-o $(BUILD_DIR)/captureworkload.exe \
 		-ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version=$(TAG) \
-		-X github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID=$(APP_INSIGHTS_ID)" \
+		-X github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID=$(APP_INSIGHTS_ID) \
+		-X github.com/microsoft/retina/internal/buildinfo.GitCommit=$(GIT_COMMIT)" \
 		$(CAPTURE_WORKLOAD_DIR)/main.go
 	CGO_ENABLED=0 GOOS=windows GOARCH=$(GOARCH) go build -v \
 		-o $(BUILD_DIR)/controller.exe \
 		-ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version=$(TAG) \
-		-X github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID=$(APP_INSIGHTS_ID)" \
+		-X github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID=$(APP_INSIGHTS_ID) \
+		-X github.com/microsoft/retina/internal/buildinfo.GitCommit=$(GIT_COMMIT)" \
 		$(RETINA_DIR)/main.go
 	@echo "Windows binaries built successfully in $(BUILD_DIR)"
 

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -9,5 +9,6 @@ var (
 	// If it is set, the application will send telemetry to the corresponding Application Insights resource.
 	ApplicationInsightsID string
 	Version               string
+	GitCommit             string
 	RetinaAgentImageName  = "ghcr.io/microsoft/retina/retina-agent"
 )

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -3,10 +3,14 @@
 package metrics
 
 import (
+	"runtime"
+
+	"github.com/microsoft/retina/internal/buildinfo"
 	"github.com/microsoft/retina/pkg/exporter"
 	"github.com/microsoft/retina/pkg/log"
 	"github.com/microsoft/retina/pkg/utils"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	dto "github.com/prometheus/client_model/go"
 )
 
@@ -200,6 +204,23 @@ func InitializeMetrics() {
 		expiredMetricsCounterDescription,
 		utils.Metric,
 	)
+
+	// Build info metric - exposes version/commit/platform as labels with a constant value of 1
+	buildInfo := promauto.With(exporter.DefaultRegistry).NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: exporter.RetinaNamespace,
+			Name:      buildInfoGaugeName,
+			Help:      buildInfoGaugeDescription,
+		},
+		[]string{"version", "git_commit", "goversion", "os", "arch"},
+	)
+	buildInfo.WithLabelValues(
+		buildinfo.Version,
+		buildinfo.GitCommit,
+		runtime.Version(),
+		runtime.GOOS,
+		runtime.GOARCH,
+	).Set(1)
 
 	isInitialized = true
 	metricsLogger.Info("Metrics initialized")

--- a/pkg/metrics/types.go
+++ b/pkg/metrics/types.go
@@ -42,6 +42,9 @@ const (
 	infinibandStatsGaugeDescription                = "InfiniBand statistics gauge"
 	infinibandStatusParamsGaugeDescription         = "InfiniBand Status Parameters gauge"
 
+	buildInfoGaugeName        = "build_info"
+	buildInfoGaugeDescription = "Build information for retina agent"
+
 	// Control plane metrics
 	pluginManagerFailedToReconcileCounterDescription = "Number of times the plugin manager failed to reconcile the plugins"
 	lostEventsCounterDescription                     = "Number of events lost in control plane"


### PR DESCRIPTION
Hey, this adds the `networkobservability_build_info` gauge metric that was requested in #338.

The metric exposes version, git commit hash, go version, os and arch as labels with a constant value of 1. Pretty standard pattern used by most prometheus exporters (node_exporter, kube-state-metrics, etc).

Example output:
```
networkobservability_build_info{version="v1.1.0", git_commit="abc1234", goversion="go1.22.0", os="linux", arch="amd64"} 1
```

Changes:
- Added `GitCommit` to `internal/buildinfo` and wired it through ldflags in the Makefile
- Registered the gauge in `InitializeMetrics()` using `promauto.With(DefaultRegistry)`
- Added metric name/description constants in types.go

Tested locally that it compiles and the metric shows up on `/metrics`.

Fixes #338