### PR TITLE
feat(cve-fix): revert Dockerfile builder digests to Go 1.26.1

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,5 +1,5 @@
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:azurelinux3.0 --format "{{.Name}}@{{.Digest}}"
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:42739e5cb9703e3e0908d0e393ef9e0acde9d7e2ef09edf7b910eda2ebde8eaf AS builder
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.26.1-azurelinux3.0 --format "{{.Name}}@{{.Digest}}"
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:7fbb3de047ac3df460e7f24cacf8ef70eb120b515dce2628e6ad8cc9ea2ce2be AS builder
 
 ARG VERSION
 ARG APP_INSIGHTS_ID

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,7 +1,7 @@
 # pinned base images
 
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:azurelinux3.0 --format "{{.Name}}@{{.Digest}}"
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:42739e5cb9703e3e0908d0e393ef9e0acde9d7e2ef09edf7b910eda2ebde8eaf AS golang
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.26.1-azurelinux3.0 --format "{{.Name}}@{{.Digest}}"
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:7fbb3de047ac3df460e7f24cacf8ef70eb120b515dce2628e6ad8cc9ea2ce2be AS golang
 
 # skopeo inspect docker://mcr.microsoft.com/azurelinux/base/core:3.0 --format "{{.Name}}@{{.Digest}}"
 FROM mcr.microsoft.com/azurelinux/base/core@sha256:a452d39c91576f5a2c983c7d3b62521fabd08e16b4a7237e24bf2be3b06e1651 AS azurelinux-core

--- a/controller/Dockerfile.gogen
+++ b/controller/Dockerfile.gogen
@@ -1,5 +1,5 @@
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:azurelinux3.0 --format "{{.Name}}@{{.Digest}}"
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:42739e5cb9703e3e0908d0e393ef9e0acde9d7e2ef09edf7b910eda2ebde8eaf
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.26.1-azurelinux3.0 --format "{{.Name}}@{{.Digest}}"
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:7fbb3de047ac3df460e7f24cacf8ef70eb120b515dce2628e6ad8cc9ea2ce2be
 
 # Default linux/architecture.
 ARG GOOS=linux

--- a/controller/Dockerfile.proto
+++ b/controller/Dockerfile.proto
@@ -1,5 +1,5 @@
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:azurelinux3.0 --format "{{.Name}}@{{.Digest}}"
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:42739e5cb9703e3e0908d0e393ef9e0acde9d7e2ef09edf7b910eda2ebde8eaf
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.26.1-azurelinux3.0 --format "{{.Name}}@{{.Digest}}"
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:7fbb3de047ac3df460e7f24cacf8ef70eb120b515dce2628e6ad8cc9ea2ce2be
 
 LABEL Name=retina-builder Version=0.0.1
 

--- a/controller/Dockerfile.windows-cgo
+++ b/controller/Dockerfile.windows-cgo
@@ -1,5 +1,5 @@
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:windowsservercore-ltsc2022 --override-os windows --format "{{.Name}}@{{.Digest}}"
-FROM --platform=windows/amd64 mcr.microsoft.com/oss/go/microsoft/golang@sha256:a6a40696becc6eae6a673f037349bbdccd4420cccd5c6f9336c71581c1395407 AS cgo
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.26.1-windowsservercore-ltsc2022 --override-os windows --format "{{.Name}}@{{.Digest}}"
+FROM --platform=windows/amd64 mcr.microsoft.com/oss/go/microsoft/golang@sha256:11f72a416664b71f9891f528fd5fdcb5de51d2c2f3946fa39a0fa549001058e6 AS cgo
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 

--- a/controller/Dockerfile.windows-native
+++ b/controller/Dockerfile.windows-native
@@ -3,8 +3,8 @@
 # buildx targets, and this one requires legacy build.
 # Maybe one day: https://github.com/moby/buildkit/issues/616
 ARG BUILDER_IMAGE
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:windowsservercore-ltsc2022 --override-os windows --format "{{.Name}}@{{.Digest}}"
-FROM --platform=windows/amd64 mcr.microsoft.com/oss/go/microsoft/golang@sha256:a6a40696becc6eae6a673f037349bbdccd4420cccd5c6f9336c71581c1395407 AS builder
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.26.1-windowsservercore-ltsc2022 --override-os windows --format "{{.Name}}@{{.Digest}}"
+FROM --platform=windows/amd64 mcr.microsoft.com/oss/go/microsoft/golang@sha256:11f72a416664b71f9891f528fd5fdcb5de51d2c2f3946fa39a0fa549001058e6 AS builder
 WORKDIR C:\\retina
 COPY go.mod .
 COPY go.sum .

--- a/hack/tools/kapinger/Dockerfile
+++ b/hack/tools/kapinger/Dockerfile
@@ -1,6 +1,6 @@
 # Linux builder - runs natively on the target platform (amd64 or arm64)
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:latest --format "{{.Name}}@{{.Digest}}"
-FROM mcr.microsoft.com/oss/go/microsoft/golang@sha256:aa201ad216d45d4e8c8f2512392cc8259c5daa4fa6348973235d715aa2c84c9c AS builder
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.26.1 --format "{{.Name}}@{{.Digest}}"
+FROM mcr.microsoft.com/oss/go/microsoft/golang@sha256:4650f4a1d3e9bcd39aa39df373837a7fe3f2d0ef75ce2836d1e8e44249c03e82 AS builder
 
 WORKDIR /build
 ADD . .
@@ -16,8 +16,8 @@ COPY --from=builder /build/kapinger .
 CMD ["./kapinger"]
 
 # Windows builder - cross-compiles from Linux amd64 (GOOS=windows is not affected by systemcrypto)
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:latest --format "{{.Name}}@{{.Digest}}"
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:aa201ad216d45d4e8c8f2512392cc8259c5daa4fa6348973235d715aa2c84c9c AS windows-builder
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.26.1 --format "{{.Name}}@{{.Digest}}"
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:4650f4a1d3e9bcd39aa39df373837a7fe3f2d0ef75ce2836d1e8e44249c03e82 AS windows-builder
 
 WORKDIR /build
 ADD . .

--- a/hack/tools/toolbox/Dockerfile
+++ b/hack/tools/toolbox/Dockerfile
@@ -1,5 +1,5 @@
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:latest --format "{{.Name}}@{{.Digest}}"
-FROM mcr.microsoft.com/oss/go/microsoft/golang@sha256:aa201ad216d45d4e8c8f2512392cc8259c5daa4fa6348973235d715aa2c84c9c AS build
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.26.1 --format "{{.Name}}@{{.Digest}}"
+FROM mcr.microsoft.com/oss/go/microsoft/golang@sha256:4650f4a1d3e9bcd39aa39df373837a7fe3f2d0ef75ce2836d1e8e44249c03e82 AS build
 ADD . .
 WORKDIR /go/toolbox/
 RUN GOOS=linux go build -o server .

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,5 +1,5 @@
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:azurelinux3.0 --format "{{.Name}}@{{.Digest}}"
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:42739e5cb9703e3e0908d0e393ef9e0acde9d7e2ef09edf7b910eda2ebde8eaf AS builder
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.26.1-azurelinux3.0 --format "{{.Name}}@{{.Digest}}"
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:7fbb3de047ac3df460e7f24cacf8ef70eb120b515dce2628e6ad8cc9ea2ce2be AS builder
 
 ARG VERSION
 ARG APP_INSIGHTS_ID

--- a/operator/Dockerfile.windows-2022
+++ b/operator/Dockerfile.windows-2022
@@ -1,5 +1,5 @@
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:azurelinux3.0 --format "{{.Name}}@{{.Digest}}"
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:42739e5cb9703e3e0908d0e393ef9e0acde9d7e2ef09edf7b910eda2ebde8eaf AS builder
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.26.1-azurelinux3.0 --format "{{.Name}}@{{.Digest}}"
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:7fbb3de047ac3df460e7f24cacf8ef70eb120b515dce2628e6ad8cc9ea2ce2be AS builder
 
 # Build args
 ARG VERSION

--- a/test/image/Dockerfile
+++ b/test/image/Dockerfile
@@ -1,6 +1,6 @@
 # build stage
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:azurelinux3.0 --format "{{.Name}}@{{.Digest}}"
-FROM mcr.microsoft.com/oss/go/microsoft/golang@sha256:42739e5cb9703e3e0908d0e393ef9e0acde9d7e2ef09edf7b910eda2ebde8eaf AS builder
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.26.1-azurelinux3.0 --format "{{.Name}}@{{.Digest}}"
+FROM mcr.microsoft.com/oss/go/microsoft/golang@sha256:7fbb3de047ac3df460e7f24cacf8ef70eb120b515dce2628e6ad8cc9ea2ce2be AS builder
 ENV CGO_ENABLED=1
 COPY . /go/src/github.com/microsoft/retina 
 WORKDIR /go/src/github.com/microsoft/retina


### PR DESCRIPTION
This pull request updates all Dockerfiles in the repository to use newer, more specific, and pinned versions of the Microsoft Go base images. The changes ensure that builds are based on Go 1.26.1 images (with appropriate OS variants), improving reproducibility and consistency across Linux and Windows builds.

**Base image updates:**

* Updated all Linux-based Dockerfiles to use `mcr.microsoft.com/oss/go/microsoft/golang:1.26.1` or `1.26.1-azurelinux3.0` with the corresponding SHA256 digest for improved version pinning and reproducibility. [[1]](diffhunk://#diff-53fad39439c11209d1fd09c9c8dc733647e91161167f7daf14df477b78f06472L1-R2) [[2]](diffhunk://#diff-fb3f33cdd2a5865385222d244e9bdc9a7ebee2756d506f6495f83a5cff42b25aL1-R2) [[3]](diffhunk://#diff-49752700516c4cf7846baa53e3fcb9f628bff653b0364de4b273f9b900af954aL1-R2) [[4]](diffhunk://#diff-f0dd51cf34c442cdab8226a50e290ac00ab8276c9f8681dc4d8375ec07a8b3acL1-R2) [[5]](diffhunk://#diff-df234eb86d676bd9233f232e9dc9af4895969477a6a9ff9161e32621f6ce76d1L3-R4) [[6]](diffhunk://#diff-105352849a03a69e1cb5f3d40e843034731e66737f833014a4589a6aeee29646L2-R3) [[7]](diffhunk://#diff-6a4f3c9e54acfa9ffd27a142ad70e1a7bb68c5d3d454366569fb2f148ac94993L2-R3) [[8]](diffhunk://#diff-6a4f3c9e54acfa9ffd27a142ad70e1a7bb68c5d3d454366569fb2f148ac94993L19-R20) [[9]](diffhunk://#diff-0793df634d5904e90d444dade524fa1764c63179f1b3cca617f241a0e0711331L1-R2) [[10]](diffhunk://#diff-bc2ff77ba131a806e5fddea1973783d61fdba4e8a33f307a982dca3b29b3956bL1-R2)
* Updated all Windows-based Dockerfiles to use `mcr.microsoft.com/oss/go/microsoft/golang:1.26.1-windowsservercore-ltsc2022` with the corresponding SHA256 digest for consistent Windows builds. [[1]](diffhunk://#diff-1e96bef04d487cb2a4483d264828b723c73f33f3d8cd86facfd7b979b555b96cL1-R2) [[2]](diffhunk://#diff-909d3861ff2ca17f232d98e86c2bcb422c49017732b04357a88210be028f7f17L6-R7)

These updates help ensure that all builds use the same Go toolchain version and OS base, reducing the risk of inconsistencies and unexpected build issues.…ab10de78

Commit c08d8273 inadvertently reverted Go builder image digests from 1.26.1 back to the floating azurelinux3.0 tag (Go 1.24.x). This restores the Go 1.26.1 pinned digests to fix remaining stdlib CVEs (CVE-2026-25679, CVE-2026-27139, CVE-2026-27142) that cannot be fixed on Go 1.24.x.

# Description

Please provide a brief description of the changes made in this pull request.

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
