### PR TITLE
fix(chart): bump hubble relay image

### DIFF
--- a/deploy/hubble/manifests/controller/helm/retina/values.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/values.yaml
@@ -425,8 +425,8 @@ hubble:
     image:
       override: ~
       repository: "mcr.microsoft.com/oss/cilium/hubble-relay"
-      tag: "v1.15.0"
-      digest: "sha256:19cd56e7618832257bf88b2f281287cb57f9f7fcb9e04775a6198d4bc4daffae"
+      tag: "1.16.1"
+      digest: "sha256:c2812bce56602ac1c26a80db4b1671e087f4d4733cb6aceebeec2ac9c48e5aae"
       useDigest: false
       pullPolicy: "Always"
 

--- a/deploy/hubble/manifests/controller/helm/retina/values.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/values.yaml
@@ -424,7 +424,7 @@ hubble:
     # -- Hubble-relay container image.
     image:
       override: ~
-      repository: "mcr.microsoft.com/oss/cilium/hubble-relay"
+      repository: "quay.io/cilium/hubble-relay"
       tag: "1.16.1"
       digest: "sha256:c2812bce56602ac1c26a80db4b1671e087f4d4733cb6aceebeec2ac9c48e5aae"
       useDigest: false
@@ -668,10 +668,10 @@ hubble:
       # -- Hubble-ui backend image.
       image:
         override: ~
-        repository: "mcr.microsoft.com/oss/cilium/hubble-ui-backend"
+        repository: "quay.io/cilium/hubble-ui-backend"
         tag: "v0.12.2"
         digest: "sha256:b73dd1ac1b7159d42cdba31433964313e756daafefffad5e91c3b61b47c3782f"
-        useDigest: true
+        useDigest: false
         pullPolicy: "Always"
 
       # -- Hubble-ui backend security context.
@@ -707,10 +707,10 @@ hubble:
       # -- Hubble-ui frontend image.
       image:
         override: ~
-        repository: "mcr.microsoft.com/oss/cilium/hubble-ui"
+        repository: "quay.io/cilium/hubble-ui"
         tag: "v0.12.2"
         digest: "sha256:8c53cdaebb4ae863ad061387a68ea06e38777d2911e6c0e570be1932bb4ba526"
-        useDigest: true
+        useDigest: false
         pullPolicy: "Always"
 
       # -- Hubble-ui frontend security context.
@@ -887,7 +887,7 @@ hubble:
 certgen:
   image:
     override: ~
-    repository: "mcr.microsoft.com/oss/cilium/certgen"
+    repository: "quay.io/cilium/certgen"
     tag: "v0.1.9"
     #digest: "sha256:89a0847753686444daabde9474b48340993bd19c7bea66a46e45b2974b82041f"
     useDigest: false


### PR DESCRIPTION
# Description

Bumps the default Hubble Relay image in the retina-hubble chart from `mcr.microsoft.com/oss/cilium/hubble-relay:v1.15.0` to `mcr.microsoft.com/oss/cilium/hubble-relay:1.16.1`. The newer image includes the upstream Hubble Relay TLS ALPN handling needed by recent Hubble CLI / grpc-go clients.

The default digest value is updated to the manifest-list digest for `1.16.1`.

## Related Issue

Fixes #2165

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-git-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

- `curl -fsSL https://mcr.microsoft.com/v2/oss/cilium/hubble-relay/tags/list | jq -r '.tags[]' | sort -V | tail -40`
- `curl -fsSIL -H 'Accept: application/vnd.docker.distribution.manifest.list.v2+json' https://mcr.microsoft.com/v2/oss/cilium/hubble-relay/manifests/1.16.1`
- `helm lint deploy/hubble/manifests/controller/helm/retina`
- `helm template retina deploy/hubble/manifests/controller/helm/retina --namespace kube-system`

## Additional Notes

The MCR mirror currently exposes `1.16.1` as the newest Hubble Relay tag for this repository. Tags `v1.15.19` and `v1.18.6` were checked and are not present in the mirror.
