### PR TITLE
docs(metrics): clarify MetricsConfiguration metric names

### DIFF
--- a/docs/03-Metrics/modes/advanced.md
+++ b/docs/03-Metrics/modes/advanced.md
@@ -22,6 +22,24 @@ There are Pod-Level context labels for metrics prepended with `adv_`.
 
 To customize context labels, see [MetricsConfiguration CRD](../../05-Concepts/CRDs/MetricsConfiguration.md).
 
+## MetricsConfiguration Names
+
+The metric tables below list the exported Prometheus metric names. When configuring `spec.contextOptions[].metricName` in a `MetricsConfiguration` CRD, use the base metric name instead of the exported `adv_` name.
+
+| Exported Prometheus metric                 | `MetricsConfiguration` `metricName` |
+| ------------------------------------------ | ----------------------------------- |
+| `adv_drop_count`                           | `drop_count`                        |
+| `adv_drop_bytes`                           | `drop_bytes`                        |
+| `adv_dns_request_count`                    | `dns_request_count`                 |
+| `adv_dns_response_count`                   | `dns_response_count`                |
+| `adv_forward_count`                        | `forward_count`                     |
+| `adv_forward_bytes`                        | `forward_bytes`                     |
+| `adv_tcpflags_count`                       | `tcp_flag_gauges`                   |
+| `adv_node_apiserver_latency`               | `node_apiserver_latency`            |
+| `adv_node_apiserver_no_response`           | `node_apiserver_no_response`        |
+| `adv_node_apiserver_tcp_handshake_latency` | `node_apiserver_handshake_latency`  |
+| `adv_tcpretrans_count`                     | `tcp_retransmission_count`          |
+
 ### Remote Context
 
 For Advanced mode with *remote context*, default context labels are the following:

--- a/docs/05-Concepts/CRDs/MetricsConfiguration.md
+++ b/docs/05-Concepts/CRDs/MetricsConfiguration.md
@@ -22,7 +22,7 @@ The `MetricsConfiguration` CRD is defined with the following specifications:
 - **spec.contextOptions:** Specifies the configuration for retina plugin metrics context. It includes the following properties:
   - `additionalLabels`: Represents additional context labels to be collected, such as Direction (ingress/egress).
   - `destinationLabels`: Represents the destination context labels, such as IP, Pod, port, workload (deployment/replicaset/statefulset/daemonset).
-  - `metricName`: Indicates the name of the metric.
+  - `metricName`: Indicates the base metric name used by the CRD. This is not always identical to the exported Prometheus metric name. For the full mapping, see [MetricsConfiguration Names](../../03-Metrics/modes/advanced.md#metricsconfiguration-names).
   - `sourceLabels`: Represents the source context labels, such as IP, Pod, port.
   - `ttl`: Represents the time-to-live for the metric.  If there are no metric updates for a particular set of context labels for this duration the metric will be removed from export.  The value of `ttl` must be a valid Golang `time.Duration` string and non-negative.  A zero `ttl` (the default) means that metrics are never removed from export.
 


### PR DESCRIPTION
# Description

Clarifies that Advanced metrics documentation lists exported Prometheus metric names, while `MetricsConfiguration` uses base metric names in `spec.contextOptions[].metricName`.

Adds a mapping table for the Advanced metrics names, including the TCP retransmission case where the exported metric is `adv_tcpretrans_count` and the CRD value is `tcp_retransmission_count`.

## Related Issue

Fixes #1999

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-git-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

- `npx --yes markdownlint-cli2 --config .github/.markdownlint.json 'docs/**/*.md'`
- `npm install --prefix site/ && npm run build --prefix site/`

## Additional Notes

No runtime changes are included.
