### PR TITLE
fix(ci): prevent resource group leaks from cancelled E2E/perf workflows

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -84,6 +84,8 @@ jobs:
     name: E2E
     runs-on: ubuntu-latest
     timeout-minutes: 120
+    env:
+      CLUSTER_NAME: retina-e2e-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
       - name: Checkout code
@@ -116,4 +118,12 @@ jobs:
           fi
 
           go test -v ./test/e2e/. -timeout 60m -tags=e2e -count=1  -args -image-tag=${{ inputs.image_tag }} -image-registry=${{ inputs.image_registry }} -image-namespace=${{ inputs.image_namespace }} -create-infra=${{ !inputs.use_existing_infra }} -delete-infra=${{ !inputs.use_existing_infra }}
-      
+
+      - name: Cleanup resource group
+        if: always()
+        shell: bash
+        run: |
+          if az group exists --name "$CLUSTER_NAME" 2>/dev/null | grep -q true; then
+            echo "Deleting resource group $CLUSTER_NAME..."
+            az group delete --name "$CLUSTER_NAME" --yes --no-wait || true
+          fi

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -397,6 +397,8 @@ jobs:
     needs: [manifests]
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    env:
+      CLUSTER_NAME: retina-e2e-${{ github.run_id }}-${{ github.run_attempt }}
 
     steps:
       - name: Checkout code
@@ -424,6 +426,15 @@ jobs:
         run: |
           set -euo pipefail
           go test -v ./test/e2e/. -timeout 60m -tags=e2e -count=1  -args -image-tag=$(make version) -image-registry=${{ vars.ACR_NAME }}  -image-namespace=${{ github.repository}}
+
+      - name: Cleanup resource group
+        if: always()
+        shell: bash
+        run: |
+          if az group exists --name "$CLUSTER_NAME" 2>/dev/null | grep -q true; then
+            echo "Deleting resource group $CLUSTER_NAME..."
+            az group delete --name "$CLUSTER_NAME" --yes --no-wait || true
+          fi
 
   perf-test-basic:
     if: ${{ github.event_name == 'merge_group'}}

--- a/.github/workflows/perf-template.yaml
+++ b/.github/workflows/perf-template.yaml
@@ -47,6 +47,8 @@ jobs:
     name: Retina ${{ inputs.retina-mode }} Performance Test
     runs-on: ubuntu-latest
     timeout-minutes: 150
+    env:
+      CLUSTER_NAME: retina-perf-${{ inputs.retina-mode }}-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -72,11 +74,20 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          
+
           TAG="${{ inputs.tag }}"
           REGISTRY="${{ inputs.image-registry }}"
           NAMESPACE="${{ inputs.image-namespace }}"
           MODE="${{ inputs.retina-mode }}"
-          
+
           echo "Running in $MODE mode..."
           go test -v ./test/e2e/. -timeout 2h -tags=perf -count=1 -args -image-tag=$TAG -image-registry=$REGISTRY -image-namespace=$NAMESPACE -retina-mode=$MODE
+
+      - name: Cleanup resource group
+        if: always()
+        shell: bash
+        run: |
+          if az group exists --name "$CLUSTER_NAME" 2>/dev/null | grep -q true; then
+            echo "Deleting resource group $CLUSTER_NAME..."
+            az group delete --name "$CLUSTER_NAME" --yes --no-wait || true
+          fi


### PR DESCRIPTION
# Description

`images.yaml` sets `cancel-in-progress: true`, so when the merge queue re-checks the same ref, GitHub cancels the in-progress run. The runner sends SIGTERM to the Go test process, which gets killed before `t.Cleanup()` fires — orphaning the Azure resource group. Each merge queue run creates 3 RGs (E2E, perf-basic, perf-advanced), so a single cancellation leaks 3 clusters.

The second issue is that `CLUSTER_NAME` is generated inside Go code using a Unix timestamp, making it unknowable to the workflow. Without knowing the name, no external cleanup is possible.

This PR fixes both:

- **Naming**: Set `CLUSTER_NAME` deterministically at job level using `github.run_id` + `github.run_attempt`, so both the test step and cleanup step share the same name
- **Cleanup**: Add `if: always()` cleanup step to `e2e.yaml`, `images.yaml`, and `perf-template.yaml` that checks `az group exists` and deletes the RG if it's still around

The cleanup step is a no-op when the test already cleaned up (the `az group exists` check returns false), and runs even after workflow cancellation since GitHub executes `if: always()` steps after sending SIGKILL.

## Related Issue

N/A — found during investigation of 12 leaked `runner-e2e-netobs-*` RGs consuming all 96 DPDSv5 cores in the test subscription.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Verified root cause by correlating leaked RG timestamps with CI run logs:

- **Cancelled run `24145596870`** (Apr 8): E2E + perf-basic + perf-advanced all created RGs (`-1775665227`, `-1775665233`, `-1775665236`), cancelled at 16:21:50, no cleanup ran — all 3 in leaked list
- **Successful run `24311965309`** (Apr 12): 3 RGs created, all 3 deleted via `t.Cleanup()` — none in leaked list

The `if: always()` + `az group exists` pattern is well-established in GitHub Actions for exactly this failure mode.

## Additional Notes

The existing `t.Cleanup()` in Go test code still runs on normal test completion (success or failure). This workflow-level cleanup is a safety net for the cancellation path only.