### PR TITLE
fix(ci): run perf tests only after E2E passes

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -427,7 +427,7 @@ jobs:
 
   perf-test-basic:
     if: ${{ github.event_name == 'merge_group'}}
-    needs: [manifests, get-tag]
+    needs: [manifests, get-tag, e2e]
     uses: ./.github/workflows/perf-template.yaml
     with:
       image-registry: ${{ vars.ACR_NAME }}
@@ -443,7 +443,7 @@ jobs:
 
   perf-test-advanced:
     if: ${{ github.event_name == 'merge_group'}}
-    needs: [manifests, get-tag]
+    needs: [manifests, get-tag, e2e]
     uses: ./.github/workflows/perf-template.yaml
     with:
       image-registry: ${{ vars.ACR_NAME }}


### PR DESCRIPTION
# Description

Currently `perf-test-basic` and `perf-test-advanced` in `images.yaml` run in parallel with the `e2e` job. If E2E is already failing, both perf jobs still spin up AKS clusters, wasting ~2 hours of compute and 2 additional resource groups.

This adds `e2e` to the `needs` list for both perf jobs so they only run after E2E passes.

## Related Issue

N/A

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Workflow-only change. Verified YAML syntax is correct.

## Additional Notes

N/A