### PR TITLE
feat(chart): Add HTTPRoute support for hubble-ui

### DIFF
--- a/deploy/hubble/manifests/controller/helm/retina/templates/hubble-ui/httproute.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/hubble-ui/httproute.yaml
@@ -1,0 +1,44 @@
+{{- if and (or .Values.hubble.enabled .Values.hubble.ui.standalone.enabled) .Values.hubble.ui.enabled .Values.hubble.ui.httpRoute.enabled }}
+{{- $baseUrl  := .Values.hubble.ui.baseUrl -}}
+{{- $port := .Values.hubble.ui.httpRoute.port | default .Values.hubble.ui.service.port | default 80 -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: hubble-ui
+  namespace: {{ .Release.Namespace }}
+  labels:
+    k8s-app: hubble-ui
+    app.kubernetes.io/name: hubble-ui
+    app.kubernetes.io/part-of: cilium
+  {{- with .Values.hubble.ui.httpRoute.labels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if or .Values.hubble.ui.httpRoute.annotations .Values.hubble.ui.annotations }}
+  annotations:
+    {{- with .Values.hubble.ui.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.hubble.ui.httpRoute.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- if .Values.hubble.ui.httpRoute.parentRefs }}
+  parentRefs:
+    {{- toYaml .Values.hubble.ui.httpRoute.parentRefs | nindent 4 }}
+  {{- end }}
+  {{- if .Values.hubble.ui.httpRoute.hostnames }}
+  hostnames:
+    {{- range .Values.hubble.ui.httpRoute.hostnames }}
+    - {{ . }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ $baseUrl | quote }}
+      backendRefs:
+        - name: hubble-ui
+          port: {{ $port }}
+{{- end }}

--- a/deploy/hubble/manifests/controller/helm/retina/values.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/values.yaml
@@ -128,7 +128,7 @@ securityContext:
       - SYS_ADMIN
       - SYS_RESOURCE # for setting rlimit
       - NET_ADMIN # for packetparser plugin
-      - IPC_LOCK # for mmap() calls made by NewReader(), ref: https://man7.org/linux/man-pages/man2/mmap.2.html 
+      - IPC_LOCK # for mmap() calls made by NewReader(), ref: https://man7.org/linux/man-pages/man2/mmap.2.html
   windowsOptions:
     runAsUserName: "NT AUTHORITY\\SYSTEM"
 
@@ -830,6 +830,23 @@ hubble:
       #  - secretName: chart-example-tls
       #    hosts:
       #      - chart-example.local
+
+    # -- hubble-ui HTTPRoute configuration (Gateway API).
+    # Requires Kubernetes 1.26+ or Gateway API CRDs to be pre-installed.
+    httpRoute:
+      enabled: false
+      annotations: {}
+      labels: {}
+      # -- Parent Gateways that this route is attached to.
+      parentRefs:
+        - name: example-gateway
+          namespace: default
+          sectionName: example-listener
+      # -- Hostnames for this HTTPRoute.
+      hostnames:
+        - chart-example.local
+      # -- Backend port number. Defaults to the service port (80).
+      port: ~
 
   # -- Hubble flows export.
   export:


### PR DESCRIPTION
# Description

Add HTTPRoute support for hubble-ui for clusters using Gateway API

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
