### PR TITLE
fix: widen API server latency histogram buckets for large clusters

### DIFF
--- a/pkg/module/metrics/latency.go
+++ b/pkg/module/metrics/latency.go
@@ -33,10 +33,11 @@ const (
 	apiServerHandshakeLatencyDesc                 = "Latency of node apiserver tcp handshake in ms"
 	TTL                             time.Duration = 500 * time.Millisecond
 	LIMIT                           uint64        = 100000
-	// Bucket size.
-	start = 0
-	width = 0.5
-	count = 10
+	// Histogram bucket parameters (units: milliseconds).
+	// Produces buckets: 0.5, 1.5, 2.5, ..., 63.5, +Inf.
+	start = 0.5
+	width = 1
+	count = 64
 )
 
 type key struct {


### PR DESCRIPTION
## Description

Fixes #82 — API Server Latency buckets are skewed in large scale clusters.

The previous histogram bucket configuration (`start=0, width=0.5ms, count=10`) produced buckets: `0, 0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, +Inf` (ms). In large clusters, API server latencies routinely exceed 4.5ms, causing all observations to land in the `+Inf` bucket and making the histogram unusable.

### Changes

- Start at 0.5ms instead of 0ms (removes useless 0ms bucket)
- Use 1ms bucket width instead of 0.5ms (wider coverage)
- Increase count from 10 to 64, covering up to 63.5ms

New buckets: `0.5, 1.5, 2.5, ..., 63.5, +Inf` (ms)

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s`).
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.

## Testing Completed

All existing latency tests pass:
- `TestNewLatencyMetrics` — PASS
- `TestInit` — PASS
- `TestProcessFlow` — PASS