### PR TITLE
fix: convert hubble-generate-certs ClusterRole to Role to enforce least privilege

### DIFF
--- a/deploy/hubble/manifests/controller/helm/retina/templates/hubble/tls-cronjob/role.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/hubble/tls-cronjob/role.yaml
@@ -1,8 +1,9 @@
 {{- if and .Values.hubble.enabled .Values.hubble.tls.enabled .Values.hubble.tls.auto.enabled (eq .Values.hubble.tls.auto.method "cronJob") .Values.serviceAccounts.hubblecertgen.create }}
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+kind: Role
 metadata:
   name: hubble-generate-certs
+  namespace: {{ .Release.Namespace }}
   {{- with .Values.hubble.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/deploy/hubble/manifests/controller/helm/retina/templates/hubble/tls-cronjob/rolebinding.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/hubble/tls-cronjob/rolebinding.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/part-of: cilium
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: Role
   name: hubble-generate-certs
 subjects:
 - kind: ServiceAccount


### PR DESCRIPTION
# Description

Convert `hubble-generate-certs` ClusterRole to Role to enforce least privilege

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
