### PR TITLE
feat(hotspot): Add hotspot-bpf to retina shell

### DIFF
--- a/docs/06-Troubleshooting/shell.md
+++ b/docs/06-Troubleshooting/shell.md
@@ -4,7 +4,7 @@
 
 The `retina shell` command allows you to start an interactive shell on a Kubernetes node or pod for adhoc debugging.
 
-This runs a container image built from the Dockerfile in the `/shell` directory, with many common networking tools installed (`ping`, `curl`, etc.), as well as specialized tools such as [bpftool](#bpftool), [bpftrace](#bpftrace) [pwru](#pwru) or [Inspektor Gadget](#inspektor-gadget-ig).
+This runs a container image built from the Dockerfile in the `/shell` directory, with many common networking tools installed (`ping`, `curl`, etc.), as well as specialized tools such as [bpftool](#bpftool), [bpftrace](#bpftrace), [pwru](#pwru), [hotspot-bpf](#hotspot-bpf), or [Inspektor Gadget](#inspektor-gadget-ig).
 
 Currently the Retina Shell only works in Linux environments. Windows support will be added in the future.
 
@@ -285,6 +285,44 @@ You can then run for example:
 ig -h
 ig run trace_dns:latest
 ```
+
+## [hotspot-bpf](https://github.com/SRodi/hotspot-bpf)
+
+eBPF performance lens for real-time root-cause diagnosis of Linux processes. hotspot-bpf correlates CPU time, scheduler contention, page-fault pressure, and RSS growth in a single terminal view, automatically classifying processes into diagnoses such as **CPU-bound**, **Starved**, **Noisy neighbor**, **Mem-thrashing**, or **OOM risk**.
+
+Requires the `SYS_ADMIN` and `PERFMON` capabilities (for eBPF program loading).
+
+```shell
+kubectl retina shell <node-name> --capabilities=SYS_ADMIN,PERFMON
+```
+
+You can then run for example:
+
+```shell
+# Run with default settings (5s sampling window, top 10 processes)
+hotspot -interval 5s -topk 5
+
+# Filter by cgroup (useful for targeting specific pods)
+hotspot -interval 5s -cgroup-filter <cgroup-substring>
+```
+
+### Custom thresholds
+
+All diagnosis thresholds are configurable via a YAML config file. To generate the default configuration as a starting point:
+
+```shell
+hotspot -generate-config > /tmp/thresholds.yaml
+```
+
+Edit the file to adjust thresholds for your environment, then pass it at runtime:
+
+```shell
+hotspot -config /tmp/thresholds.yaml -interval 5s
+```
+
+Any value not specified in the file retains its compiled-in default. This is especially useful on **multi-core machines** where single-threaded workloads produce low system-wide CPU percentages — lowering the thresholds helps avoid missed classifications.
+
+For detailed information on all configurable parameters, see the [hotspot-bpf documentation](https://github.com/SRodi/hotspot-bpf#custom-thresholds).
 
 ## [mpstat](https://www.man7.org/linux/man-pages/man1/mpstat.1.html)
 

--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -85,13 +85,13 @@ RUN set -eux; \
         *) echo "Skipping hotspot-bpf: unsupported arch $ARCH" && exit 0 ;; \
     esac; \
     HOTSPOT_TAR="hotspot-bpf-linux-${HOTSPOT_ARCH}.tar.gz"; \
-    curl -fL -o /tmp/hotspot.tar.gz "https://github.com/SRodi/hotspot-bpf/releases/download/${HOTSPOT_TAG}/${HOTSPOT_TAR}"; \
-    curl -fL -o /tmp/hotspot.tar.gz.sha256 "https://github.com/SRodi/hotspot-bpf/releases/download/${HOTSPOT_TAG}/${HOTSPOT_TAR}.sha256"; \
-    cd /tmp && sha256sum -c hotspot.tar.gz.sha256; \
-    tar -xz -C /usr/local/bin -f /tmp/hotspot.tar.gz "hotspot-bpf-linux-${HOTSPOT_ARCH}"; \
+    curl -fL -o "/tmp/${HOTSPOT_TAR}" "https://github.com/SRodi/hotspot-bpf/releases/download/${HOTSPOT_TAG}/${HOTSPOT_TAR}"; \
+    curl -fL -o "/tmp/${HOTSPOT_TAR}.sha256" "https://github.com/SRodi/hotspot-bpf/releases/download/${HOTSPOT_TAG}/${HOTSPOT_TAR}.sha256"; \
+    cd /tmp && sha256sum -c "${HOTSPOT_TAR}.sha256"; \
+    tar -xz -C /usr/local/bin -f "/tmp/${HOTSPOT_TAR}" "hotspot-bpf-linux-${HOTSPOT_ARCH}"; \
     mv "/usr/local/bin/hotspot-bpf-linux-${HOTSPOT_ARCH}" /usr/local/bin/hotspot; \
     chmod +x /usr/local/bin/hotspot; \
-    rm /tmp/hotspot.tar.gz /tmp/hotspot.tar.gz.sha256; \
+    rm "/tmp/${HOTSPOT_TAR}" "/tmp/${HOTSPOT_TAR}.sha256"; \
     file /usr/local/bin/hotspot | grep -q 'ELF'
 
 CMD ["/bin/bash", "-l"]

--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -75,7 +75,7 @@ RUN set -eux; \
     file /usr/local/bin/pwru | grep -q 'ELF'
 
 # https://github.com/SRodi/hotspot-bpf/releases
-ARG HOTSPOT_TAG="v0.1.0"
+ARG HOTSPOT_TAG="v0.1.1"
 ENV HOTSPOT_TAG=${HOTSPOT_TAG}
 
 # Download and extract hotspot-bpf release (amd64 only for now)

--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -86,10 +86,12 @@ RUN set -eux; \
     esac; \
     HOTSPOT_TAR="hotspot-bpf-linux-${HOTSPOT_ARCH}.tar.gz"; \
     curl -fL -o /tmp/hotspot.tar.gz "https://github.com/SRodi/hotspot-bpf/releases/download/${HOTSPOT_TAG}/${HOTSPOT_TAR}"; \
+    curl -fL -o /tmp/hotspot.tar.gz.sha256 "https://github.com/SRodi/hotspot-bpf/releases/download/${HOTSPOT_TAG}/${HOTSPOT_TAR}.sha256"; \
+    cd /tmp && sha256sum -c hotspot.tar.gz.sha256; \
     tar -xz -C /usr/local/bin -f /tmp/hotspot.tar.gz "hotspot-bpf-linux-${HOTSPOT_ARCH}"; \
     mv "/usr/local/bin/hotspot-bpf-linux-${HOTSPOT_ARCH}" /usr/local/bin/hotspot; \
     chmod +x /usr/local/bin/hotspot; \
-    rm /tmp/hotspot.tar.gz; \
+    rm /tmp/hotspot.tar.gz /tmp/hotspot.tar.gz.sha256; \
     file /usr/local/bin/hotspot | grep -q 'ELF'
 
 CMD ["/bin/bash", "-l"]

--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -74,4 +74,22 @@ RUN set -eux; \
     rm /tmp/pwru.tar.gz; \
     file /usr/local/bin/pwru | grep -q 'ELF'
 
+# https://github.com/SRodi/hotspot-bpf/releases
+ARG HOTSPOT_TAG="v0.1.0"
+ENV HOTSPOT_TAG=${HOTSPOT_TAG}
+
+# Download and extract hotspot-bpf release (amd64 only for now)
+RUN set -eux; \
+    case "$ARCH" in \
+        amd64|x86_64) HOTSPOT_ARCH="amd64" ;; \
+        *) echo "Skipping hotspot-bpf: unsupported arch $ARCH" && exit 0 ;; \
+    esac; \
+    HOTSPOT_TAR="hotspot-bpf-linux-${HOTSPOT_ARCH}.tar.gz"; \
+    curl -fL -o /tmp/hotspot.tar.gz "https://github.com/SRodi/hotspot-bpf/releases/download/${HOTSPOT_TAG}/${HOTSPOT_TAR}"; \
+    tar -xz -C /usr/local/bin -f /tmp/hotspot.tar.gz "hotspot-bpf-linux-${HOTSPOT_ARCH}"; \
+    mv "/usr/local/bin/hotspot-bpf-linux-${HOTSPOT_ARCH}" /usr/local/bin/hotspot; \
+    chmod +x /usr/local/bin/hotspot; \
+    rm /tmp/hotspot.tar.gz; \
+    file /usr/local/bin/hotspot | grep -q 'ELF'
+
 CMD ["/bin/bash", "-l"]


### PR DESCRIPTION
### Description

This PR adds [hotspot-bpf](https://github.com/SRodi/hotspot-bpf) to the retina shell image, making it available as an interactive diagnostic tool via `kubectl retina shell`.

hotspot-bpf is an eBPF-based performance triage tool that correlates CPU time, scheduler contention, page-fault pressure, and RSS growth in a single terminal view. Instead of showing raw numbers, it automatically classifies processes into actionable diagnoses: **OOM risk**, **CPU-bound**, **mem-thrashing**, **starved**, **noisy neighbor**, or **OK**.

### What it detects

| Diagnosis | Meaning |
|-----------|---------|
| OOM risk | RSS growing monotonically + high page-fault rate |
| CPU-bound | Saturating a CPU core with no memory pressure |
| Mem-thrashing | Costly page faults or high fault volume with low CPU |
| Starved | Frequently preempted, getting little CPU |
| Noisy neighbor | Preempting others while consuming significant CPU |
| OK | No anomaly detected |

### Why add this to retina shell?

- **Complements existing tools**: fills the gap between `top`/`htop` (no root-cause labels) and `perf` (requires deep expertise) by providing instant triage
- **Zero runtime dependencies**: single statically-linked Go binary with embedded CO-RE eBPF programs — no kernel headers needed at runtime
- **Works across kernel versions**: uses BPF CO-RE (Compile Once, Run Everywhere) with BTF relocations, compatible with any kernel ≥ 5.5 with BTF enabled
- **Follows existing patterns**: installed the same way as `pwru` — downloaded from GitHub releases and placed in `/usr/local/bin`

### Changes

- `shell/Dockerfile`: Added hotspot-bpf v0.1.0 binary download and installation (amd64 only, matching current release availability)

### Usage

```sh
# Start a retina shell on a node
kubectl retina shell node001

# Run hotspot inside the shell
hotspot -interval 5s -topk 5

# Filter by cgroup (e.g. a specific container)
hotspot -interval 5s -cgroup-filter my-container
```

### Testing

```sh
# Build the shell image locally
docker build -t retina-shell:dev -f shell/Dockerfile .

# Verify binary is installed
docker run --rm retina-shell:dev ls -la /usr/local/bin/hotspot

# Test with eBPF (requires privileged + BTF-enabled kernel)
docker run --rm -it --privileged --pid=host \
  -v /sys/kernel:/sys/kernel:ro \
  retina-shell:dev hotspot -interval 5s -topk 5
```

### Requirements

- Host kernel ≥ 5.5 with BTF (`/sys/kernel/btf/vmlinux` must exist)
- Privileged container or `CAP_BPF` + `CAP_PERFMON` (already provided by retina shell)
- x86_64 architecture (arm64 support not yet available in hotspot-bpf)


## Related Issue

n/a

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

<img width="2056" height="1006" alt="image" src="https://github.com/user-attachments/assets/7598527a-e731-4b5a-ae8e-415790574bb7" />

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
