### PR TITLE
fix: migrate apiserver watcher from Endpoints to EndpointSlice

### DIFF
--- a/deploy/hubble/manifests/controller/helm/retina/templates/agent/clusterrole.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/agent/clusterrole.yaml
@@ -33,14 +33,13 @@ rules:
     - list
     - watch
   - apiGroups:
-    - ""
+    - discovery.k8s.io
     resources:
-      - namespaces
-      - endpoints
+    - endpointslices
     verbs:
-      - get
-      - list
-      - watch
+    - get
+    - list
+    - watch
   {{- if .Values.operator.enabled }}
   - apiGroups:
       - retina.sh
@@ -80,14 +79,6 @@ rules:
       - get
       - patch
       - update
-  - apiGroups:
-    - discovery.k8s.io
-    resources:
-    - endpointslices
-    verbs:
-    - get
-    - list
-    - watch
   {{- end }}
 
 {{- end}}

--- a/deploy/standard/manifests/controller/helm/retina/templates/rbac.yaml
+++ b/deploy/standard/manifests/controller/helm/retina/templates/rbac.yaml
@@ -9,7 +9,10 @@ metadata:
   name: retina-cluster-reader
 rules:
   - apiGroups: [""] # "" indicates the core API group
-    resources: ["endpoints", "pods", "services", "replicationcontrollers", "nodes", "namespaces"]
+    resources: ["pods", "services", "replicationcontrollers", "nodes", "namespaces"]
+    verbs: ["get", "watch", "list"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
     verbs: ["get", "watch", "list"]
   - apiGroups: ["apps"]
     resources: ["deployments", "replicasets"]
@@ -26,15 +29,6 @@ rules:
       - list
       - watch
   {{- if .Values.operator.enabled }}
-  - apiGroups:
-    - ""
-    resources:
-      - namespaces
-      - endpoints
-    verbs:
-      - get
-      - list
-      - watch
   - apiGroups:
       - retina.sh
     resources:

--- a/pkg/watchers/apiserver/apiserver.go
+++ b/pkg/watchers/apiserver/apiserver.go
@@ -18,6 +18,7 @@ import (
 	"github.com/microsoft/retina/pkg/utils"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -169,9 +170,9 @@ func (a *ApiServerWatcher) initNewCache(ctx context.Context) error {
 		return fmt.Errorf("failed to retrieve ips from kubernetes service: %w", err)
 	}
 
-	endpointIPs, err := a.ipsFromEndpoint(ctx)
+	endpointIPs, err := a.ipsFromEndpointSlice(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to retrieve ips from kubernetes endpoint: %w", err)
+		return fmt.Errorf("failed to retrieve ips from kubernetes endpointslices: %w", err)
 	}
 
 	ips, err := a.resolveIPs(ctx, a.apiServerHostName)
@@ -253,22 +254,21 @@ func (a *ApiServerWatcher) ipsFromService(ctx context.Context) ([]string, error)
 	return svc.Spec.ClusterIPs, nil
 }
 
-// ipsFromEndpoint retrieves IP addresses from the Endpoint resource "kubernetes" in the default namespace.
-// These IPs are the addresses for the kube-apiserver.
-func (a *ApiServerWatcher) ipsFromEndpoint(ctx context.Context) ([]string, error) {
-	ep := &corev1.Endpoints{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "kubernetes",
-			Namespace: "default",
-		},
-	}
-	if err := a.client.Get(ctx, kclient.ObjectKeyFromObject(ep), ep); err != nil {
-		return nil, fmt.Errorf("retrieving kubernetes endpoint: %w", err)
+// ipsFromEndpointSlice retrieves IP addresses from the EndpointSlices that
+// back the "kubernetes" service in the default namespace. These IPs are the
+// addresses for the kube-apiserver.
+func (a *ApiServerWatcher) ipsFromEndpointSlice(ctx context.Context) ([]string, error) {
+	var sliceList discoveryv1.EndpointSliceList
+	if err := a.client.List(ctx, &sliceList,
+		kclient.InNamespace("default"),
+		kclient.MatchingLabels{discoveryv1.LabelServiceName: "kubernetes"},
+	); err != nil {
+		return nil, fmt.Errorf("retrieving kubernetes endpointslices: %w", err)
 	}
 	ips := []string{}
-	for _, subset := range ep.Subsets {
-		for _, addr := range subset.Addresses {
-			ips = append(ips, addr.IP)
+	for i := range sliceList.Items {
+		for _, ep := range sliceList.Items[i].Endpoints {
+			ips = append(ips, ep.Addresses...)
 		}
 	}
 	return ips, nil

--- a/pkg/watchers/apiserver/apiserver_test.go
+++ b/pkg/watchers/apiserver/apiserver_test.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -198,21 +199,21 @@ func getMockKubeClient() client.Client {
 		},
 	}
 
-	ep := corev1.Endpoints{
+	slice := discoveryv1.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kubernetes",
 			Namespace: "default",
-		},
-		Subsets: []corev1.EndpointSubset{
-			{
-				Addresses: []corev1.EndpointAddress{
-					{IP: "100.64.83.200"},
-					{IP: "100.64.83.201"},
-				},
+			Labels: map[string]string{
+				discoveryv1.LabelServiceName: "kubernetes",
 			},
 		},
+		AddressType: discoveryv1.AddressTypeIPv4,
+		Endpoints: []discoveryv1.Endpoint{
+			{Addresses: []string{"100.64.83.200"}},
+			{Addresses: []string{"100.64.83.201"}},
+		},
 	}
-	return fake.NewFakeClient(&ep, &kubernetesSvc)
+	return fake.NewFakeClient(&slice, &kubernetesSvc)
 }
 
 func TestRefreshFailsFirstFourAttemptsSucceedsOnFifth(t *testing.T) {


### PR DESCRIPTION
# Description

The apiserver watcher currently reads the `kubernetes` service's backing IPs via `corev1.Endpoints`, which emits a deprecation warning on v1.33+ clusters:

```
W... warnings.go:70] v1 Endpoints is deprecated in v1.33+; use discovery.k8s.io/v1 EndpointSlice
```

The warning is sent by the kube-apiserver as an HTTP `Warning:` response header ([KEP-1693](https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/1693-warnings/README.md)) and surfaced by the client-go warning handler; it was added in [KEP-4974](https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/4974-deprecate-endpoints) for every read/write on `Endpoints` objects in v1.33.

This PR switches `ipsFromEndpoint` to list `discoveryv1.EndpointSlice` filtered by `kubernetes.io/service-name=kubernetes`, aggregating addresses across all slices (large services get split past 100 endpoints). The agent RBAC in both Helm charts is updated to grant `discovery.k8s.io/endpointslices` and drop the now-unused `core/endpoints` rules.

### Why EndpointSlice

EndpointSlice is a strict superset of `Endpoints` — it supports dual-stack, traffic distribution, and scales past the 100-endpoint cap. It's been the default path for service discovery for nearly five years:

| Stage | K8s version | Reference |
|---|---|---|
| Alpha | v1.16 | [KEP-0752](https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/0752-endpointslices/README.md), controller introduced in [#81048](https://github.com/kubernetes/kubernetes/pull/81048) |
| GA — kube-proxy + controller-manager default | v1.21 (Apr 2021) | [CHANGELOG-1.21](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.21.md); kube-proxy [#103306](https://github.com/kubernetes/kubernetes/pull/103306); controller-manager [#99870](https://github.com/kubernetes/kubernetes/pull/99870) |
| `v1.Endpoints` deprecated | v1.33 (Apr 2025) | [KEP-4974](https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/4974-deprecate-endpoints), [transition blog](https://kubernetes.io/blog/2025/04/24/endpoints-deprecation/) |

Canonical docs: [EndpointSlices](https://kubernetes.io/docs/concepts/services-networking/endpoint-slices/).

## Related Issue

N/A — surfaced during local testing on a v1.33 cluster.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`).
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary — no doc changes needed.
- [x] I have added tests, if applicable.

## Testing Completed

```bash
go test -tags=unit,dashboard ./pkg/watchers/apiserver/... -v -count=1
```

All tests pass. `TestRefresh` confirms the seeded EndpointSlice IPs flow through into the created IP set.