### PR TITLE
refactor(cli): remove capture command global logger

### DIFF
--- a/cli/cmd/capture/capture.go
+++ b/cli/cmd/capture/capture.go
@@ -6,6 +6,7 @@ package capture
 import (
 	"time"
 
+	"github.com/microsoft/retina/pkg/log"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
@@ -47,7 +48,7 @@ var opts = Opts{
 
 const DefaultName = "retina-capture"
 
-func NewCommand(kubeClient kubernetes.Interface) *cobra.Command {
+func NewCommand(kubeClient kubernetes.Interface, logger *log.ZapLogger) *cobra.Command {
 	capture := &cobra.Command{
 		Use:   "capture",
 		Short: "Capture network traffic",
@@ -58,9 +59,9 @@ func NewCommand(kubeClient kubernetes.Interface) *cobra.Command {
 	opts.AddFlags(capture.PersistentFlags())
 	capture.PersistentFlags().StringVar(opts.Name, "name", DefaultName, "The name of the Retina Capture")
 
-	capture.AddCommand(NewCreateSubCommand(kubeClient))
-	capture.AddCommand(NewDeleteSubCommand(kubeClient))
-	capture.AddCommand(NewDownloadSubCommand())
+	capture.AddCommand(NewCreateSubCommand(kubeClient, logger))
+	capture.AddCommand(NewDeleteSubCommand(kubeClient, logger))
+	capture.AddCommand(NewDownloadSubCommand(logger))
 	capture.AddCommand(NewListSubCommand())
 
 	return capture

--- a/cli/cmd/capture/create.go
+++ b/cli/cmd/capture/create.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 
-	retinacmd "github.com/microsoft/retina/cli/cmd"
 	retinav1alpha1 "github.com/microsoft/retina/crd/api/v1alpha1"
 	"github.com/microsoft/retina/internal/buildinfo"
 	pkgcapture "github.com/microsoft/retina/pkg/capture"
@@ -31,6 +30,7 @@ import (
 	"github.com/microsoft/retina/pkg/capture/file"
 	captureUtils "github.com/microsoft/retina/pkg/capture/utils"
 	"github.com/microsoft/retina/pkg/config"
+	"github.com/microsoft/retina/pkg/log"
 )
 
 const (
@@ -88,7 +88,7 @@ var createExample = templates.Examples(i18n.T(`
 			--s3-secret-access-key "your-secret-access-key"
 		`))
 
-func create(kubeClient kubernetes.Interface) error {
+func create(kubeClient kubernetes.Interface, logger *log.ZapLogger) error {
 	// Set namespace. If --namespace is not set, use namespace on user's context
 	ns, _, err := opts.ConfigFlags.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
@@ -102,23 +102,23 @@ func create(kubeClient kubernetes.Interface) error {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM)
 	defer cancel()
 
-	capture, err := createCaptureF(ctx, kubeClient)
+	capture, err := createCaptureF(ctx, kubeClient, logger)
 	if err != nil {
 		return err
 	}
 
-	jobsCreated, err := createJobs(ctx, kubeClient, capture)
+	jobsCreated, err := createJobs(ctx, kubeClient, capture, logger)
 	if err != nil {
-		retinacmd.Logger.Error("Failed to create job", zap.Error(err))
+		logger.Error("Failed to create job", zap.Error(err))
 		return err
 	}
 	if opts.nowait {
-		retinacmd.Logger.Info("Please manually delete all capture jobs")
+		logger.Info("Please manually delete all capture jobs")
 		if capture.Spec.OutputConfiguration.BlobUpload != nil {
-			retinacmd.Logger.Info("Please manually delete capture secret", zap.String("namespace", *opts.Namespace), zap.String("secret name", *capture.Spec.OutputConfiguration.BlobUpload))
+			logger.Info("Please manually delete capture secret", zap.String("namespace", *opts.Namespace), zap.String("secret name", *capture.Spec.OutputConfiguration.BlobUpload))
 		}
 		if capture.Spec.OutputConfiguration.S3Upload != nil && capture.Spec.OutputConfiguration.S3Upload.SecretName != "" {
-			retinacmd.Logger.Info("Please manually delete capture secret", zap.String("namespace", *opts.Namespace), zap.String("secret name", capture.Spec.OutputConfiguration.S3Upload.SecretName))
+			logger.Info("Please manually delete capture secret", zap.String("namespace", *opts.Namespace), zap.String("secret name", capture.Spec.OutputConfiguration.S3Upload.SecretName))
 		}
 		printCaptureResult(jobsCreated)
 		return nil
@@ -126,22 +126,22 @@ func create(kubeClient kubernetes.Interface) error {
 
 	// Wait until all jobs finish then delete the jobs before the timeout, otherwise print jobs created to
 	// let the customer recycle them.
-	retinacmd.Logger.Info("Waiting for capture jobs to finish")
+	logger.Info("Waiting for capture jobs to finish")
 
-	allJobsCompleted := waitUntilJobsComplete(ctx, kubeClient, jobsCreated)
+	allJobsCompleted := waitUntilJobsComplete(ctx, kubeClient, jobsCreated, logger)
 
 	// Delete all jobs created only if they all completed, otherwise keep the jobs for debugging.
 	if allJobsCompleted {
-		retinacmd.Logger.Info("Deleting jobs as all jobs are completed")
-		jobsFailedToDelete := deleteJobs(ctx, kubeClient, jobsCreated)
+		logger.Info("Deleting jobs as all jobs are completed")
+		jobsFailedToDelete := deleteJobs(ctx, kubeClient, jobsCreated, logger)
 		if len(jobsFailedToDelete) != 0 {
-			retinacmd.Logger.Info("Please manually delete capture jobs failed to delete", zap.String("namespace", *opts.Namespace), zap.String("job list", strings.Join(jobsFailedToDelete, ",")))
+			logger.Info("Please manually delete capture jobs failed to delete", zap.String("namespace", *opts.Namespace), zap.String("job list", strings.Join(jobsFailedToDelete, ",")))
 		}
 
 		if capture.Spec.OutputConfiguration.BlobUpload != nil {
 			err = deleteSecret(ctx, kubeClient, capture.Spec.OutputConfiguration.BlobUpload)
 			if err != nil {
-				retinacmd.Logger.Error("Failed to delete capture secret, please manually delete it",
+				logger.Error("Failed to delete capture secret, please manually delete it",
 					zap.String("namespace", *opts.Namespace), zap.String("secret name", *capture.Spec.OutputConfiguration.BlobUpload), zap.Error(err))
 			}
 		}
@@ -149,7 +149,7 @@ func create(kubeClient kubernetes.Interface) error {
 		if capture.Spec.OutputConfiguration.S3Upload != nil && capture.Spec.OutputConfiguration.S3Upload.SecretName != "" {
 			err = deleteSecret(ctx, kubeClient, &capture.Spec.OutputConfiguration.S3Upload.SecretName)
 			if err != nil {
-				retinacmd.Logger.Error("Failed to delete capture secret, please manually delete it",
+				logger.Error("Failed to delete capture secret, please manually delete it",
 					zap.String("namespace", *opts.Namespace),
 					zap.String("secret name", capture.Spec.OutputConfiguration.S3Upload.SecretName),
 					zap.Error(err),
@@ -158,13 +158,13 @@ func create(kubeClient kubernetes.Interface) error {
 		}
 
 		if len(jobsFailedToDelete) == 0 && err == nil {
-			retinacmd.Logger.Info("Done for deleting jobs")
+			logger.Info("Done for deleting jobs")
 		}
 		return nil
 	}
 
-	retinacmd.Logger.Info("Not all job are completed in the given time")
-	retinacmd.Logger.Info("Please manually delete the Capture")
+	logger.Info("Not all job are completed in the given time")
+	logger.Info("Please manually delete the Capture")
 
 	return getCaptureAndPrintCaptureResult(ctx, kubeClient, capture.Name, *opts.Namespace)
 }
@@ -183,7 +183,7 @@ func GetClientset() (*kubernetes.Clientset, error) {
 	return kubeClient, nil
 }
 
-func NewCreateSubCommand(kubeClient kubernetes.Interface) *cobra.Command {
+func NewCreateSubCommand(kubeClient kubernetes.Interface, logger *log.ZapLogger) *cobra.Command {
 	createCapture := &cobra.Command{
 		Use:     "create",
 		Short:   "Create a Retina Capture",
@@ -191,7 +191,7 @@ func NewCreateSubCommand(kubeClient kubernetes.Interface) *cobra.Command {
 	}
 
 	createCapture.RunE = func(*cobra.Command, []string) error {
-		return create(kubeClient)
+		return create(kubeClient, logger)
 	}
 
 	createCapture.Flags().DurationVar(&opts.duration, "duration", DefaultDuration, "Duration of capturing packets")
@@ -278,7 +278,7 @@ func deleteSecret(ctx context.Context, kubeClient kubernetes.Interface, secretNa
 	return kubeClient.CoreV1().Secrets(*opts.Namespace).Delete(ctx, *secretName, metav1.DeleteOptions{}) //nolint:wrapcheck //internal return
 }
 
-func createCaptureF(ctx context.Context, kubeClient kubernetes.Interface) (*retinav1alpha1.Capture, error) {
+func createCaptureF(ctx context.Context, kubeClient kubernetes.Interface, logger *log.ZapLogger) (*retinav1alpha1.Capture, error) {
 	timestamp := file.Now()
 
 	capture := &retinav1alpha1.Capture{
@@ -299,17 +299,17 @@ func createCaptureF(ctx context.Context, kubeClient kubernetes.Interface) (*reti
 		},
 	}
 
-	retinacmd.Logger.Info(fmt.Sprintf("Capture timestamp: %s", timestamp))
+	logger.Info(fmt.Sprintf("Capture timestamp: %s", timestamp))
 
 	if opts.duration != 0 {
-		retinacmd.Logger.Info(fmt.Sprintf("The capture duration is set to %s", opts.duration))
+		logger.Info(fmt.Sprintf("The capture duration is set to %s", opts.duration))
 		capture.Spec.CaptureConfiguration.CaptureOption.Duration = &metav1.Duration{Duration: opts.duration}
 	}
 
 	if opts.namespaceSelectors != "" || opts.podSelectors != "" || opts.podNames != "" {
 		// if node selector is using the default value (aka hasn't been set by user), set it to nil to prevent clash with namespace and pod selector
 		if opts.nodeSelectors == DefaultNodeSelectors {
-			retinacmd.Logger.Info("Overriding default node selectors value and setting it to nil. Using namespace, pod selectors, or pod names. " +
+			logger.Info("Overriding default node selectors value and setting it to nil. Using namespace, pod selectors, or pod names. " +
 				"To use node selector, please remove namespace and pod selectors.")
 			opts.nodeSelectors = ""
 		}
@@ -365,17 +365,17 @@ func createCaptureF(ctx context.Context, kubeClient kubernetes.Interface) (*reti
 		for i := range podNameSlice {
 			podNameSlice[i] = strings.TrimSpace(podNameSlice[i])
 		}
-		retinacmd.Logger.Info(fmt.Sprintf("Capturing on specific pods: %v", podNameSlice))
+		logger.Info(fmt.Sprintf("Capturing on specific pods: %v", podNameSlice))
 		capture.Spec.CaptureConfiguration.CaptureTarget.PodNames = podNameSlice
 	}
 
 	if opts.maxSize != 0 {
-		retinacmd.Logger.Info(fmt.Sprintf("The capture file max size is set to %dMB", opts.maxSize))
+		logger.Info(fmt.Sprintf("The capture file max size is set to %dMB", opts.maxSize))
 		capture.Spec.CaptureConfiguration.CaptureOption.MaxCaptureSize = &opts.maxSize
 	}
 
 	if opts.packetSize != 0 {
-		retinacmd.Logger.Info(fmt.Sprintf("The capture packet size is set to %d bytes", opts.packetSize))
+		logger.Info(fmt.Sprintf("The capture packet size is set to %d bytes", opts.packetSize))
 		capture.Spec.CaptureConfiguration.CaptureOption.PacketSize = &opts.packetSize
 	}
 
@@ -384,7 +384,7 @@ func createCaptureF(ctx context.Context, kubeClient kubernetes.Interface) (*reti
 		for i := range interfaceSlice {
 			interfaceSlice[i] = strings.TrimSpace(interfaceSlice[i])
 		}
-		retinacmd.Logger.Info(fmt.Sprintf("Capturing on specific interfaces: %v", interfaceSlice))
+		logger.Info(fmt.Sprintf("Capturing on specific interfaces: %v", interfaceSlice))
 		capture.Spec.CaptureConfiguration.CaptureOption.Interfaces = interfaceSlice
 	}
 
@@ -445,8 +445,8 @@ func getCLICaptureConfig() config.CaptureConfig {
 	}
 }
 
-func createJobs(ctx context.Context, kubeClient kubernetes.Interface, capture *retinav1alpha1.Capture) ([]batchv1.Job, error) {
-	translator := pkgcapture.NewCaptureToPodTranslator(kubeClient, retinacmd.Logger, getCLICaptureConfig())
+func createJobs(ctx context.Context, kubeClient kubernetes.Interface, capture *retinav1alpha1.Capture, logger *log.ZapLogger) ([]batchv1.Job, error) {
+	translator := pkgcapture.NewCaptureToPodTranslator(kubeClient, logger, getCLICaptureConfig())
 	jobs, err := translator.TranslateCaptureToJobs(ctx, capture)
 	if err != nil {
 		return nil, err
@@ -459,12 +459,12 @@ func createJobs(ctx context.Context, kubeClient kubernetes.Interface, capture *r
 			return nil, err
 		}
 		jobsCreated = append(jobsCreated, *jobCreated)
-		retinacmd.Logger.Info("Packet capture job is created", zap.String("namespace", *opts.Namespace), zap.String("capture job", jobCreated.Name))
+		logger.Info("Packet capture job is created", zap.String("namespace", *opts.Namespace), zap.String("capture job", jobCreated.Name))
 	}
 	return jobsCreated, nil
 }
 
-func waitUntilJobsComplete(ctx context.Context, kubeClient kubernetes.Interface, jobs []batchv1.Job) bool {
+func waitUntilJobsComplete(ctx context.Context, kubeClient kubernetes.Interface, jobs []batchv1.Job, logger *log.ZapLogger) bool {
 	allJobsCompleted := false
 
 	// TODO: let's make the timeout and period to wait for all job to finish configurable.
@@ -478,7 +478,7 @@ func waitUntilJobsComplete(ctx context.Context, kubeClient kubernetes.Interface,
 	if period < opts.duration/10 {
 		period = opts.duration / 10
 	}
-	retinacmd.Logger.Info(fmt.Sprintf("Waiting timeout is set to %s", deadline))
+	logger.Info(fmt.Sprintf("Waiting timeout is set to %s", deadline))
 
 	ctx, cancel := context.WithTimeout(ctx, deadline)
 	defer cancel()
@@ -490,7 +490,7 @@ func waitUntilJobsComplete(ctx context.Context, kubeClient kubernetes.Interface,
 		for _, job := range jobs {
 			jobRet, err := kubeClient.BatchV1().Jobs(job.Namespace).Get(ctx, job.Name, metav1.GetOptions{})
 			if err != nil {
-				retinacmd.Logger.Error("Failed to get job", zap.String("namespace", job.Namespace), zap.String("job name", job.Name), zap.Error(err))
+				logger.Error("Failed to get job", zap.String("namespace", job.Namespace), zap.String("job name", job.Name), zap.Error(err))
 				jobsIncompleted = append(jobsIncompleted, job.Name)
 				continue
 			}
@@ -502,7 +502,7 @@ func waitUntilJobsComplete(ctx context.Context, kubeClient kubernetes.Interface,
 		}
 
 		if len(jobsIncompleted) != 0 {
-			retinacmd.Logger.Info("Not all jobs are completed",
+			logger.Info("Not all jobs are completed",
 				zap.String("namespace", *opts.Namespace),
 				zap.String("Completed jobs", strings.Join(jobsCompleted, ",")),
 				zap.String("Uncompleted packet capture jobs", strings.Join(jobsIncompleted, ",")),
@@ -517,7 +517,7 @@ func waitUntilJobsComplete(ctx context.Context, kubeClient kubernetes.Interface,
 	return allJobsCompleted
 }
 
-func deleteJobs(ctx context.Context, kubeClient kubernetes.Interface, jobs []batchv1.Job) []string {
+func deleteJobs(ctx context.Context, kubeClient kubernetes.Interface, jobs []batchv1.Job, logger *log.ZapLogger) []string {
 	jobsFailedtoDelete := []string{}
 	for _, job := range jobs {
 		// Child pods are preserved by default when jobs are deleted, we need to set propagationPolicy=Background to
@@ -528,7 +528,7 @@ func deleteJobs(ctx context.Context, kubeClient kubernetes.Interface, jobs []bat
 		})
 		if err != nil {
 			jobsFailedtoDelete = append(jobsFailedtoDelete, job.Name)
-			retinacmd.Logger.Error("Failed to delete job", zap.String("namespace", job.Namespace), zap.String("job name", job.Name), zap.Error(err))
+			logger.Error("Failed to delete job", zap.String("namespace", job.Namespace), zap.String("job name", job.Name), zap.Error(err))
 		}
 	}
 	return jobsFailedtoDelete

--- a/cli/cmd/capture/create.go
+++ b/cli/cmd/capture/create.go
@@ -278,34 +278,7 @@ func deleteSecret(ctx context.Context, kubeClient kubernetes.Interface, secretNa
 	return kubeClient.CoreV1().Secrets(*opts.Namespace).Delete(ctx, *secretName, metav1.DeleteOptions{}) //nolint:wrapcheck //internal return
 }
 
-func createCaptureF(ctx context.Context, kubeClient kubernetes.Interface, logger *log.ZapLogger) (*retinav1alpha1.Capture, error) {
-	timestamp := file.Now()
-
-	capture := &retinav1alpha1.Capture{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      *opts.Name,
-			Namespace: *opts.Namespace,
-		},
-		Spec: retinav1alpha1.CaptureSpec{
-			CaptureConfiguration: retinav1alpha1.CaptureConfiguration{
-				TcpdumpFilter:   &opts.tcpdumpFilter,
-				CaptureTarget:   retinav1alpha1.CaptureTarget{},
-				IncludeMetadata: opts.includeMetadata,
-				CaptureOption:   retinav1alpha1.CaptureOption{},
-			},
-		},
-		Status: retinav1alpha1.CaptureStatus{
-			StartTime: timestamp,
-		},
-	}
-
-	logger.Info(fmt.Sprintf("Capture timestamp: %s", timestamp))
-
-	if opts.duration != 0 {
-		logger.Info(fmt.Sprintf("The capture duration is set to %s", opts.duration))
-		capture.Spec.CaptureConfiguration.CaptureOption.Duration = &metav1.Duration{Duration: opts.duration}
-	}
-
+func applyCaptureTargetOptions(capture *retinav1alpha1.Capture, logger *log.ZapLogger) error {
 	if opts.namespaceSelectors != "" || opts.podSelectors != "" || opts.podNames != "" {
 		// if node selector is using the default value (aka hasn't been set by user), set it to nil to prevent clash with namespace and pod selector
 		if opts.nodeSelectors == DefaultNodeSelectors {
@@ -317,15 +290,15 @@ func createCaptureF(ctx context.Context, kubeClient kubernetes.Interface, logger
 
 	nodeSelectorLabelsMap, err := labels.ConvertSelectorToLabelsMap(opts.nodeSelectors)
 	if err != nil {
-		return nil, err
+		return fmt.Errorf("failed to parse node selectors: %w", err)
 	}
 	podSelectorLabelsMap, err := labels.ConvertSelectorToLabelsMap(opts.podSelectors)
 	if err != nil {
-		return nil, err
+		return fmt.Errorf("failed to parse pod selectors: %w", err)
 	}
 	namespaceSelectorLabelsMap, err := labels.ConvertSelectorToLabelsMap(opts.namespaceSelectors)
 	if err != nil {
-		return nil, err
+		return fmt.Errorf("failed to parse namespace selectors: %w", err)
 	}
 
 	if len(nodeSelectorLabelsMap) != 0 || opts.nodeNames != "" {
@@ -367,6 +340,41 @@ func createCaptureF(ctx context.Context, kubeClient kubernetes.Interface, logger
 		}
 		logger.Info(fmt.Sprintf("Capturing on specific pods: %v", podNameSlice))
 		capture.Spec.CaptureConfiguration.CaptureTarget.PodNames = podNameSlice
+	}
+
+	return nil
+}
+
+func createCaptureF(ctx context.Context, kubeClient kubernetes.Interface, logger *log.ZapLogger) (*retinav1alpha1.Capture, error) {
+	timestamp := file.Now()
+
+	capture := &retinav1alpha1.Capture{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      *opts.Name,
+			Namespace: *opts.Namespace,
+		},
+		Spec: retinav1alpha1.CaptureSpec{
+			CaptureConfiguration: retinav1alpha1.CaptureConfiguration{
+				TcpdumpFilter:   &opts.tcpdumpFilter,
+				CaptureTarget:   retinav1alpha1.CaptureTarget{},
+				IncludeMetadata: opts.includeMetadata,
+				CaptureOption:   retinav1alpha1.CaptureOption{},
+			},
+		},
+		Status: retinav1alpha1.CaptureStatus{
+			StartTime: timestamp,
+		},
+	}
+
+	logger.Info(fmt.Sprintf("Capture timestamp: %s", timestamp))
+
+	if opts.duration != 0 {
+		logger.Info(fmt.Sprintf("The capture duration is set to %s", opts.duration))
+		capture.Spec.CaptureConfiguration.CaptureOption.Duration = &metav1.Duration{Duration: opts.duration}
+	}
+
+	if err := applyCaptureTargetOptions(capture, logger); err != nil {
+		return nil, err
 	}
 
 	if opts.maxSize != 0 {

--- a/cli/cmd/capture/create_test.go
+++ b/cli/cmd/capture/create_test.go
@@ -233,7 +233,7 @@ func TestCreateJobsWithNamespace(t *testing.T) {
 		fmt.Println("\n### Running test case:", tc.name)
 		// Given
 		kubeClient := newKubeclient()
-		cmd := NewCommand(kubeClient)
+		cmd := NewCommand(kubeClient, testLogger(t))
 		cmd.SetArgs(argsFromTestCase(tc))
 		buf := new(bytes.Buffer)
 		cmd.SetOut(buf)
@@ -342,7 +342,7 @@ func TestCreateCaptureCommand_PodNamesWithNodeSelector_ShouldFail(t *testing.T) 
 	// Test that when pod-names is specified with node-selectors, the node selector is overridden
 	// and the command attempts to use pod names. Since the pod doesn't exist, this will fail.
 	// This verifies that pod names take precedence over default node selectors.
-	cmd := NewCommand(fake.NewClientset())
+	cmd := NewCommand(fake.NewClientset(), testLogger(t))
 
 	cmd.SetArgs([]string{
 		"create",

--- a/cli/cmd/capture/delete.go
+++ b/cli/cmd/capture/delete.go
@@ -9,9 +9,9 @@ import (
 	"os/signal"
 	"syscall"
 
-	retinacmd "github.com/microsoft/retina/cli/cmd"
 	captureConstants "github.com/microsoft/retina/pkg/capture/constants"
 	"github.com/microsoft/retina/pkg/label"
+	"github.com/microsoft/retina/pkg/log"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -27,7 +27,7 @@ var deleteExample = templates.Examples(i18n.T(`
 		kubectl retina capture delete --name retina-capture-8v6wd --namespace capture
 		`))
 
-func NewDeleteSubCommand(kubeClient kubernetes.Interface) *cobra.Command {
+func NewDeleteSubCommand(kubeClient kubernetes.Interface, logger *log.ZapLogger) *cobra.Command {
 	deleteCapture := &cobra.Command{
 		Use:     "delete",
 		Short:   "Delete a Retina capture",
@@ -70,7 +70,7 @@ func NewDeleteSubCommand(kubeClient kubernetes.Interface) *cobra.Command {
 				if err := kubeClient.BatchV1().Jobs(jobList.Items[idx].Namespace).Delete(ctx, jobList.Items[idx].Name, metav1.DeleteOptions{
 					PropagationPolicy: &deletePropagationBackground,
 				}); err != nil {
-					retinacmd.Logger.Info("Failed to delete job", zap.String("job name", jobList.Items[idx].Name), zap.Error(err))
+					logger.Info("Failed to delete job", zap.String("job name", jobList.Items[idx].Name), zap.Error(err))
 				}
 			}
 
@@ -82,7 +82,7 @@ func NewDeleteSubCommand(kubeClient kubernetes.Interface) *cobra.Command {
 					break
 				}
 			}
-			retinacmd.Logger.Info(fmt.Sprintf("Retina Capture %q delete", *opts.Name))
+			logger.Info(fmt.Sprintf("Retina Capture %q delete", *opts.Name))
 
 			return nil
 		},

--- a/cli/cmd/capture/delete_test.go
+++ b/cli/cmd/capture/delete_test.go
@@ -94,7 +94,7 @@ func createArgs(name, namespace, podSelectors string) []string {
 }
 
 func createCapture(t *testing.T, kubeClient kubernetes.Interface, name, namespace, podSelectors string) {
-	createCmd := NewCommand(kubeClient)
+	createCmd := NewCommand(kubeClient, testLogger(t))
 
 	createCmd.SetArgs(createArgs(name, namespace, podSelectors))
 
@@ -172,7 +172,7 @@ func TestDeleteCaptureJobs(t *testing.T) {
 			kubeClient := setupDeleteTest(t, tc)
 
 			// Create a delete command
-			deleteCmd := NewCommand(kubeClient)
+			deleteCmd := NewCommand(kubeClient, testLogger(t))
 
 			// Set command args
 			deleteCmd.SetArgs(deleteArgs(tc))

--- a/cli/cmd/capture/download.go
+++ b/cli/cmd/capture/download.go
@@ -20,11 +20,11 @@ import (
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/storage"
-	retinacmd "github.com/microsoft/retina/cli/cmd"
 	captureConstants "github.com/microsoft/retina/pkg/capture/constants"
 	captureFile "github.com/microsoft/retina/pkg/capture/file"
 	captureUtils "github.com/microsoft/retina/pkg/capture/utils"
 	captureLabels "github.com/microsoft/retina/pkg/label"
+	"github.com/microsoft/retina/pkg/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
@@ -103,6 +103,7 @@ type DownloadCmd struct {
 type DownloadService struct {
 	kubeClient kubernetes.Interface
 	config     *rest.Config
+	logger     *log.ZapLogger
 	namespace  string
 }
 
@@ -113,16 +114,17 @@ type Key struct {
 }
 
 // NewDownloadService creates a new download service with shared dependencies
-func NewDownloadService(kubeClient kubernetes.Interface, config *rest.Config, namespace string) *DownloadService {
+func NewDownloadService(kubeClient kubernetes.Interface, config *rest.Config, namespace string, logger *log.ZapLogger) *DownloadService {
 	return &DownloadService{
 		kubeClient: kubeClient,
 		config:     config,
+		logger:     logger,
 		namespace:  namespace,
 	}
 }
 
-func getDownloadCmd(node *corev1.Node, hostPath, fileName string) (*DownloadCmd, error) {
-	nodeOS, err := getNodeOS(node)
+func getDownloadCmd(node *corev1.Node, hostPath, fileName string, logger *log.ZapLogger) (*DownloadCmd, error) {
+	nodeOS, err := getNodeOS(node, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +138,7 @@ func getDownloadCmd(node *corev1.Node, hostPath, fileName string) (*DownloadCmd,
 		srcFilePath := "C:\\host" + strings.ReplaceAll(hostPath, "/", "\\") + "\\" + fileName + ".tar.gz"
 		mountPath := "C:\\host" + strings.ReplaceAll(hostPath, "/", "\\")
 		return &DownloadCmd{
-			ContainerImage:   getWindowsContainerImage(node),
+			ContainerImage:   getWindowsContainerImage(node, logger),
 			SrcFilePath:      srcFilePath,
 			MountPath:        mountPath,
 			KeepAliveCommand: []string{"cmd", "/c", "echo Download pod ready & ping -n 3601 127.0.0.1 > nul"},
@@ -159,16 +161,16 @@ func getDownloadCmd(node *corev1.Node, hostPath, fileName string) (*DownloadCmd,
 	}
 }
 
-func getNodeOS(node *corev1.Node) (NodeOS, error) {
+func getNodeOS(node *corev1.Node, logger *log.ZapLogger) (NodeOS, error) {
 	nodeOS := strings.ToLower(node.Status.NodeInfo.OperatingSystem)
 
 	if strings.Contains(nodeOS, "windows") {
-		retinacmd.Logger.Info("Detected node OS: Windows", zap.String("node", node.Name), zap.String("os", node.Status.NodeInfo.OperatingSystem))
+		logger.Info("Detected node OS: Windows", zap.String("node", node.Name), zap.String("os", node.Status.NodeInfo.OperatingSystem))
 		return Windows, nil
 	}
 
 	if strings.Contains(nodeOS, "linux") {
-		retinacmd.Logger.Info("Detected node OS: Linux", zap.String("node", node.Name), zap.String("os", node.Status.NodeInfo.OperatingSystem))
+		logger.Info("Detected node OS: Linux", zap.String("node", node.Name), zap.String("os", node.Status.NodeInfo.OperatingSystem))
 		return Linux, nil
 	}
 
@@ -176,7 +178,7 @@ func getNodeOS(node *corev1.Node) (NodeOS, error) {
 }
 
 // Detects the Windows LTSC version and returns the appropriate nanoserver image
-func getWindowsContainerImage(node *corev1.Node) string {
+func getWindowsContainerImage(node *corev1.Node, logger *log.ZapLogger) string {
 	osImage := strings.ToLower(node.Status.NodeInfo.OSImage)
 
 	var suffix string
@@ -188,14 +190,14 @@ func getWindowsContainerImage(node *corev1.Node) string {
 	case strings.Contains(osImage, "2016"):
 		suffix = "ltsc2016"
 	default:
-		retinacmd.Logger.Warn("Could not determine Windows LTSC version, defaulting to ltsc2022",
+		logger.Warn("Could not determine Windows LTSC version, defaulting to ltsc2022",
 			zap.String("node", node.Name),
 			zap.String("osImage", osImage))
 		suffix = "ltsc2022"
 	}
 
 	containerImage := "mcr.microsoft.com/windows/nanoserver:" + suffix
-	retinacmd.Logger.Info("Selected Windows container image", zap.String("image", containerImage))
+	logger.Info("Selected Windows container image", zap.String("image", containerImage))
 
 	return containerImage
 }
@@ -220,14 +222,14 @@ var downloadExample = templates.Examples(i18n.T(`
 		kubectl retina capture download --blob-url "<blob-url>"
 `))
 
-func downloadFromCluster(ctx context.Context, config *rest.Config, namespace string) error {
+func downloadFromCluster(ctx context.Context, config *rest.Config, namespace string, logger *log.ZapLogger) error {
 	fmt.Println("Downloading capture: ", captureName)
 	kubeClient, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return fmt.Errorf("failed to initialize k8s client: %w", err)
 	}
 
-	downloadService := NewDownloadService(kubeClient, config, namespace)
+	downloadService := NewDownloadService(kubeClient, config, namespace, logger)
 
 	pods, err := getCapturePods(ctx, kubeClient, captureName, namespace)
 	if err != nil {
@@ -290,7 +292,7 @@ func (ds *DownloadService) DownloadFileContent(ctx context.Context, nodeName, ho
 		return nil, errors.Join(ErrGetNodeInfo, err)
 	}
 
-	downloadCmd, err := getDownloadCmd(node, hostPath, fileName)
+	downloadCmd, err := getDownloadCmd(node, hostPath, fileName, ds.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -305,7 +307,7 @@ func (ds *DownloadService) DownloadFileContent(ctx context.Context, nodeName, ho
 	defer func() {
 		cleanupErr := ds.kubeClient.CoreV1().Pods(ds.namespace).Delete(ctx, downloadPod.Name, metav1.DeleteOptions{})
 		if cleanupErr != nil {
-			retinacmd.Logger.Warn("Failed to clean up debug pod", zap.String("name", downloadPod.Name), zap.Error(cleanupErr))
+			ds.logger.Warn("Failed to clean up debug pod", zap.String("name", downloadPod.Name), zap.Error(cleanupErr))
 		}
 	}()
 
@@ -480,16 +482,19 @@ func (ds *DownloadService) createDownloadExec(ctx context.Context, pod *corev1.P
 	return outBuf.String(), nil
 }
 
-func downloadFromBlob() error {
+func downloadFromBlob(logger *log.ZapLogger) error {
 	u, err := url.Parse(blobURL)
 	if err != nil {
-		retinacmd.Logger.Error("err: ", zap.Error(err))
+		logger.Error("err: ", zap.Error(err))
 		return fmt.Errorf("failed to parse SAS URL %s: %w", blobURL, err)
+	}
+	if u.RawQuery == "" {
+		return fmt.Errorf("blob URL must include a SAS token with read/list permissions")
 	}
 
 	b, err := storage.NewAccountSASClientFromEndpointToken(u.String(), u.Query().Encode())
 	if err != nil {
-		retinacmd.Logger.Error("err: ", zap.Error(err))
+		logger.Error("err: ", zap.Error(err))
 		return fmt.Errorf("failed to create storage account client: %w", err)
 	}
 
@@ -501,12 +506,12 @@ func downloadFromBlob() error {
 	params := storage.ListBlobsParameters{Prefix: *opts.Name}
 	blobList, err := blobService.GetContainerReference(containerName).ListBlobs(params)
 	if err != nil {
-		retinacmd.Logger.Error("err: ", zap.Error(err))
+		logger.Error("err: ", zap.Error(err))
 		return fmt.Errorf("failed to list blobstore: %w", err)
 	}
 
 	if len(blobList.Blobs) == 0 {
-		retinacmd.Logger.Error("err: ", zap.Error(err))
+		logger.Error("err: ", zap.Error(err))
 		return fmt.Errorf("%w: %s", ErrNoBlobsFound, *opts.Name)
 	}
 
@@ -520,21 +525,21 @@ func downloadFromBlob() error {
 		blobRef := blobService.GetContainerReference(containerName).GetBlobReference(blob.Name)
 		readCloser, err := blobRef.Get(&storage.GetBlobOptions{})
 		if err != nil {
-			retinacmd.Logger.Error("err: ", zap.Error(err))
+			logger.Error("err: ", zap.Error(err))
 			return fmt.Errorf("failed to read from blobstore: %w", err)
 		}
 
 		blobData, err := io.ReadAll(readCloser)
 		readCloser.Close()
 		if err != nil {
-			retinacmd.Logger.Error("err: ", zap.Error(err))
+			logger.Error("err: ", zap.Error(err))
 			return fmt.Errorf("failed to obtain blob from blobstore: %w", err)
 		}
 
 		outputFile := filepath.Join(outputPath, blob.Name)
 		err = os.WriteFile(outputFile, blobData, 0o600)
 		if err != nil {
-			retinacmd.Logger.Error("err: ", zap.Error(err))
+			logger.Error("err: ", zap.Error(err))
 			return fmt.Errorf("failed to write file: %w", err)
 		}
 
@@ -543,7 +548,7 @@ func downloadFromBlob() error {
 	return nil
 }
 
-func downloadAllCaptures(ctx context.Context, config *rest.Config, namespace string) error {
+func downloadAllCaptures(ctx context.Context, config *rest.Config, namespace string, logger *log.ZapLogger) error {
 	if downloadAllNamespaces {
 		fmt.Println("Downloading all captures from all namespaces...")
 	} else {
@@ -612,7 +617,7 @@ func downloadAllCaptures(ctx context.Context, config *rest.Config, namespace str
 	finalArchivePath := filepath.Join(outputPath, fmt.Sprintf("all-captures-%s.tar.gz", timestamp))
 
 	fmt.Printf("Creating final archive: %s\n", finalArchivePath)
-	err = createStreamingTarGzArchive(ctx, finalArchivePath, captureToJobs, kubeClient, config)
+	err = createStreamingTarGzArchive(ctx, finalArchivePath, captureToJobs, kubeClient, config, logger)
 	if err != nil {
 		return fmt.Errorf("failed to create final archive: %w", err)
 	}
@@ -622,7 +627,7 @@ func downloadAllCaptures(ctx context.Context, config *rest.Config, namespace str
 }
 
 // createStreamingTarGzArchive creates a tar.gz archive by streaming files one at a time to avoid memory issues
-func createStreamingTarGzArchive(ctx context.Context, outputPath string, captureToJobs map[Key][]batchv1.Job, kubeClient kubernetes.Interface, config *rest.Config) error {
+func createStreamingTarGzArchive(ctx context.Context, outputPath string, captureToJobs map[Key][]batchv1.Job, kubeClient kubernetes.Interface, config *rest.Config, logger *log.ZapLogger) error {
 	// Create the output file
 	outFile, err := os.Create(outputPath)
 	if err != nil {
@@ -651,7 +656,7 @@ func createStreamingTarGzArchive(ctx context.Context, outputPath string, capture
 		// Get or create download service for this namespace
 		downloadService, exists := downloadServices[currentNamespace]
 		if !exists {
-			downloadService = NewDownloadService(kubeClient, config, currentNamespace)
+			downloadService = NewDownloadService(kubeClient, config, currentNamespace, logger)
 			downloadServices[currentNamespace] = downloadService
 		}
 
@@ -732,7 +737,7 @@ func createStreamingTarGzArchive(ctx context.Context, outputPath string, capture
 	return nil
 }
 
-func NewDownloadSubCommand() *cobra.Command {
+func NewDownloadSubCommand(logger *log.ZapLogger) *cobra.Command {
 	downloadCapture := &cobra.Command{
 		Use:     "download",
 		Short:   "Download Retina Captures",
@@ -763,21 +768,21 @@ func NewDownloadSubCommand() *cobra.Command {
 			}
 
 			if captureName != "" {
-				err = downloadFromCluster(ctx, kubeConfig, captureNamespace)
+				err = downloadFromCluster(ctx, kubeConfig, captureNamespace, logger)
 				if err != nil {
 					return err
 				}
 			}
 
 			if blobURL != "" {
-				err = downloadFromBlob()
+				err = downloadFromBlob(logger)
 				if err != nil {
 					return err
 				}
 			}
 
 			if downloadAll {
-				err = downloadAllCaptures(ctx, kubeConfig, captureNamespace)
+				err = downloadAllCaptures(ctx, kubeConfig, captureNamespace, logger)
 				if err != nil {
 					return err
 				}

--- a/cli/cmd/capture/download.go
+++ b/cli/cmd/capture/download.go
@@ -58,23 +58,24 @@ const (
 )
 
 var (
-	blobURL               string
-	ErrCreateDirectory    = errors.New("failed to create directory")
-	ErrGetNodeInfo        = errors.New("failed to get node information")
-	ErrWriteFileToHost    = errors.New("failed to write file to host")
-	ErrObtainPodList      = errors.New("failed to obtain list of pods")
-	ErrExecFileDownload   = errors.New("failed to exec file download in container")
-	ErrCreateDownloadPod  = errors.New("failed to create download pod")
-	ErrGetDownloadPod     = errors.New("failed to get download pod")
-	ErrCheckFileExistence = errors.New("failed to check file existence")
-	ErrCreateExecutor     = errors.New("failed to create executor")
-	ErrExecCommand        = errors.New("failed to exec command")
-	ErrCreateOutputDir    = errors.New("failed to create output directory")
-	ErrNoBlobsFound       = errors.New("no blobs found with prefix")
-	captureName           string
-	outputPath            string
-	downloadAll           bool
-	downloadAllNamespaces bool
+	blobURL                string
+	ErrCreateDirectory     = errors.New("failed to create directory")
+	ErrGetNodeInfo         = errors.New("failed to get node information")
+	ErrWriteFileToHost     = errors.New("failed to write file to host")
+	ErrObtainPodList       = errors.New("failed to obtain list of pods")
+	ErrExecFileDownload    = errors.New("failed to exec file download in container")
+	ErrCreateDownloadPod   = errors.New("failed to create download pod")
+	ErrGetDownloadPod      = errors.New("failed to get download pod")
+	ErrCheckFileExistence  = errors.New("failed to check file existence")
+	ErrCreateExecutor      = errors.New("failed to create executor")
+	ErrExecCommand         = errors.New("failed to exec command")
+	ErrCreateOutputDir     = errors.New("failed to create output directory")
+	ErrNoBlobsFound        = errors.New("no blobs found with prefix")
+	ErrMissingBlobSASToken = errors.New("blob URL must include a SAS token with read/list permissions")
+	captureName            string
+	outputPath             string
+	downloadAll            bool
+	downloadAllNamespaces  bool
 )
 
 var (
@@ -489,7 +490,7 @@ func downloadFromBlob(logger *log.ZapLogger) error {
 		return fmt.Errorf("failed to parse SAS URL %s: %w", blobURL, err)
 	}
 	if u.RawQuery == "" {
-		return fmt.Errorf("blob URL must include a SAS token with read/list permissions")
+		return ErrMissingBlobSASToken
 	}
 
 	b, err := storage.NewAccountSASClientFromEndpointToken(u.String(), u.Query().Encode())

--- a/cli/cmd/capture/download_test.go
+++ b/cli/cmd/capture/download_test.go
@@ -257,7 +257,7 @@ func TestGetNodeOS(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := getNodeOS(tc.node)
+			result, err := getNodeOS(tc.node, testLogger(t))
 
 			if tc.wantErr && err == nil {
 				t.Errorf("Expected error for %s, but got none", tc.name)
@@ -373,7 +373,7 @@ func TestGetDownloadCmd(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := getDownloadCmd(tc.node, tc.hostPath, tc.fileName)
+			result, err := getDownloadCmd(tc.node, tc.hostPath, tc.fileName, testLogger(t))
 			tc.validate(t, result, err)
 		})
 	}
@@ -413,7 +413,7 @@ func TestGetWindowsContainerImage(t *testing.T) {
 				},
 			}
 
-			result := getWindowsContainerImage(node)
+			result := getWindowsContainerImage(node, testLogger(t))
 			expectedImage := "mcr.microsoft.com/windows/nanoserver:" + tc.expectedSuffix
 
 			if result != expectedImage {
@@ -428,7 +428,7 @@ func TestDownloadService(t *testing.T) {
 	config := &rest.Config{}
 	namespace := "test-namespace"
 
-	service := NewDownloadService(kubeClient, config, namespace)
+	service := NewDownloadService(kubeClient, config, namespace, testLogger(t))
 
 	// Test service creation
 	if service == nil {
@@ -525,7 +525,7 @@ func TestDownloadFromBlobValidation(t *testing.T) {
 			blobURL = tc.blobURL
 			defer func() { blobURL = originalBlobURL }()
 
-			err := downloadFromBlob()
+			err := downloadFromBlob(testLogger(t))
 
 			if tc.wantErr && err == nil {
 				t.Errorf("Expected error for %s, but got none", tc.name)
@@ -554,7 +554,7 @@ func TestDownloadServiceMethods(t *testing.T) {
 
 	kubeClient := newDownloadKubeClient(objects)
 	config := &rest.Config{}
-	service := NewDownloadService(kubeClient, config, "test-namespace")
+	service := NewDownloadService(kubeClient, config, "test-namespace", testLogger(t))
 
 	t.Run("createDownloadPod creates pod correctly", func(t *testing.T) {
 		downloadCmd := &DownloadCmd{
@@ -623,7 +623,7 @@ func TestDownloadServiceErrorHandling(t *testing.T) {
 	ctx := context.Background()
 	kubeClient := newDownloadKubeClient(nil)
 	config := &rest.Config{}
-	service := NewDownloadService(kubeClient, config, "test-namespace")
+	service := NewDownloadService(kubeClient, config, "test-namespace", testLogger(t))
 
 	t.Run("DownloadFile handles unsupported node OS", func(t *testing.T) {
 		// Create a node with unsupported OS
@@ -900,7 +900,7 @@ func TestDownloadCommandFlags(t *testing.T) {
 	// Test all cases with unified approach
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			cmd := NewDownloadSubCommand()
+			cmd := NewDownloadSubCommand(testLogger(t))
 
 			// Parse flags without executing the command
 			err := cmd.ParseFlags(tc.args)

--- a/cli/cmd/capture/test_logger_test.go
+++ b/cli/cmd/capture/test_logger_test.go
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package capture
+
+import (
+	"testing"
+
+	"github.com/microsoft/retina/pkg/log"
+)
+
+func testLogger(t *testing.T) *log.ZapLogger {
+	t.Helper()
+
+	logger, err := log.SetupZapLogger(log.GetDefaultLogOpts())
+	if err != nil {
+		t.Fatalf("failed to set up logger: %v", err)
+	}
+
+	return logger.Named("capture-test")
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -7,11 +7,8 @@ import (
 	"os"
 
 	"github.com/microsoft/retina/pkg/client"
-	"github.com/microsoft/retina/pkg/log"
 	"github.com/spf13/cobra"
 )
-
-var Logger *log.ZapLogger
 
 // RetinaClient for customer consume
 var RetinaClient *client.Retina
@@ -33,9 +30,4 @@ var Retina = &cobra.Command{
 		_ = json.Unmarshal([]byte(file), &config)
 		RetinaClient = client.NewRetinaClient(config.RetinaEndpoint)
 	},
-}
-
-func init() {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
-	Logger = log.Logger().Named("retina-cli")
 }

--- a/cli/main.go
+++ b/cli/main.go
@@ -8,15 +8,22 @@ import (
 
 	"github.com/microsoft/retina/cli/cmd"
 	"github.com/microsoft/retina/cli/cmd/capture"
+	"github.com/microsoft/retina/pkg/log"
 )
 
 func main() {
+	_, err := log.SetupZapLogger(log.GetDefaultLogOpts())
+	if err != nil {
+		fmt.Printf("Failed to initialize logger: %v\n", err)
+		os.Exit(1)
+	}
+
 	kubeClient, err := capture.GetClientset()
 	if err != nil {
 		fmt.Printf("Failed to get Kubernetes client: %v\n", err)
 		os.Exit(1)
 	}
-	cmd.Retina.AddCommand(capture.NewCommand(kubeClient))
+	cmd.Retina.AddCommand(capture.NewCommand(kubeClient, log.Logger().Named("retina-cli")))
 	if err := cmd.Retina.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)


### PR DESCRIPTION
# Description

This pull request removes the CLI capture flow's dependency on the global `retinacmd.Logger` and replaces it with explicit logger injection.

The main changes are:
- initialize the CLI logger in `cli/main.go`
- pass a scoped logger into `capture.NewCommand`
- thread the logger through the capture create, delete, and download command paths
- update download helpers and `DownloadService` to use the injected logger instead of package-global state
- remove the old global CLI logger from `cli/cmd/root.go`
- update tests to construct and pass a test logger explicitly
- add a fail-fast validation for blob URLs without a SAS token so blob validation tests do not hang

This keeps the capture command behavior the same while making the logger usage more explicit and easier to test.

## Related Issue

Related to #585

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Tested locally with:

- `go test -v ./cli/cmd/capture/...`
- `go test -v ./cli/...`
- `go test -run '^$' ./...`
- `go test -v -run 'TestDownloadFromBlobValidation' -count=1 ./cli/cmd/capture`

## Additional Notes

This change is intentionally scoped to the CLI capture flow. It does not attempt to remove logger singletons from the rest of the codebase.

The blob download validation now returns early when the blob URL does not include a SAS token with read/list permissions. This makes the related unit test deterministic in local environments.
