### PR TITLE
fix(hubble): bump default hubble-relay image

### DIFF
--- a/deploy/hubble/manifests/controller/helm/retina/templates/hubble-relay/deployment.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/hubble-relay/deployment.yaml
@@ -53,7 +53,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.hubble.relay.image.repository }}:{{ .Values.hubble.relay.image.tag }}"
+          image: {{ include "cilium.image" .Values.hubble.relay.image | quote }}
           imagePullPolicy: {{ .Values.hubble.relay.image.pullPolicy }}
           command:
             - hubble-relay

--- a/deploy/hubble/manifests/controller/helm/retina/values.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/values.yaml
@@ -425,8 +425,8 @@ hubble:
     image:
       override: ~
       repository: "mcr.microsoft.com/oss/cilium/hubble-relay"
-      tag: "v1.15.0"
-      digest: "sha256:19cd56e7618832257bf88b2f281287cb57f9f7fcb9e04775a6198d4bc4daffae"
+      tag: "1.16.1"
+      digest: "sha256:641b13bbe9038d7b0bedd6480e3d704174432e1fd05a25728a4eb27ec47df89a"
       useDigest: false
       pullPolicy: "Always"
 


### PR DESCRIPTION
## Summary
- bump the default `retina-hubble` `hubble-relay` image from `v1.15.0` to `1.16.1`
- align the optional relay digest with the current `1.16.1` MCR manifest
- update the Hubble Relay Deployment to use the shared `cilium.image` helper so `override`, `useDigest`, and `digest` are honored

Fixes #2165.

## Verification
- confirmed MCR exposes `1.16.1` for `oss/cilium/hubble-relay`
- confirmed the `1.16.1` manifest digest is `sha256:641b13bbe9038d7b0bedd6480e3d704174432e1fd05a25728a4eb27ec47df89a`
- verified the Hubble Relay Deployment now renders its image via the shared `cilium.image` helper
