### PR TITLE
fix: add BPF capability to default values in Helm deploy

### DIFF
--- a/deploy/standard/manifests/controller/helm/retina/values.yaml
+++ b/deploy/standard/manifests/controller/helm/retina/values.yaml
@@ -145,6 +145,7 @@ securityContext:
       - NET_ADMIN # for packetparser plugin
       - IPC_LOCK # for mmap() calls made by NewReader(), ref: https://man7.org/linux/man-pages/man2/mmap.2.html
       - SYS_RESOURCE # for setting rlimit
+      - BPF # for linuxutil and packetforward plugins
   windowsOptions:
     runAsUserName: "NT AUTHORITY\\SYSTEM"
 


### PR DESCRIPTION
# Description

Adds the BPF capability for the Retina agent pod, since the linuxutil and packetforward plugins require it.

## Related Issue

#2236 

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

```shell
$ k get pods/retina-agent-7dltc -n kube-system -o yaml | grep -A6 capabilities
      capabilities:
        add:
        - SYS_ADMIN
        - NET_ADMIN
        - IPC_LOCK
        - SYS_RESOURCE
        - BPF
```

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
