### PR TITLE
chore(deps): consolidate dependabot config with groups and cooldowns

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,59 +1,15 @@
 version: 2
 updates:
-  # Docker base image tracking - Critical components (daily)
+  # Docker base images across all Dockerfiles
   - package-ecosystem: "docker"
-    directory: "/controller"
-    schedule:
-      interval: "daily"
-    reviewers:
-      - "microsoft/retina"
-    commit-message:
-      prefix: "deps"
-    labels: ["area/infra", "area/dependencies"]
-    open-pull-requests-limit: 5
-  - package-ecosystem: "docker"
-    directory: "/shell"
-    schedule:
-      interval: "daily"
-    reviewers:
-      - "microsoft/retina"
-    commit-message:
-      prefix: "deps"
-    labels: ["area/infra", "area/dependencies"]
-    open-pull-requests-limit: 5
-  - package-ecosystem: "docker"
-    directory: "/cli"
-    schedule:
-      interval: "daily"
-    reviewers:
-      - "microsoft/retina"
-    commit-message:
-      prefix: "deps"
-    labels: ["area/infra", "area/dependencies"]
-    open-pull-requests-limit: 5
-  - package-ecosystem: "docker"
-    directory: "/operator"
-    schedule:
-      interval: "daily"
-    reviewers:
-      - "microsoft/retina"
-    commit-message:
-      prefix: "deps"
-    labels: ["area/infra", "area/dependencies"]
-    open-pull-requests-limit: 5
-  - package-ecosystem: "docker"
-    directory: "/test/image"
-    schedule:
-      interval: "daily"
-    reviewers:
-      - "microsoft/retina"
-    commit-message:
-      prefix: "deps"
-    labels: ["area/infra", "area/dependencies"]
-    open-pull-requests-limit: 3
-  # Docker base image tracking - Tools (weekly)
-  - package-ecosystem: "docker"
-    directory: "/hack/tools/kapinger"
+    directories:
+      - "/controller"
+      - "/shell"
+      - "/cli"
+      - "/operator"
+      - "/test/image"
+      - "/hack/tools/kapinger"
+      - "/hack/tools/toolbox"
     schedule:
       interval: "weekly"
     reviewers:
@@ -61,18 +17,21 @@ updates:
     commit-message:
       prefix: "deps"
     labels: ["area/infra", "area/dependencies"]
-    open-pull-requests-limit: 3
-  - package-ecosystem: "docker"
-    directory: "/hack/tools/toolbox"
-    schedule:
-      interval: "weekly"
-    reviewers:
-      - "microsoft/retina"
-    commit-message:
-      prefix: "deps"
-    labels: ["area/infra", "area/dependencies"]
-    open-pull-requests-limit: 3
-  # GitHub Actions tracking
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+    groups:
+      golang-base:
+        patterns: ["*golang*"]
+      azurelinux-base:
+        patterns: ["*azurelinux*"]
+      windows-base:
+        patterns: ["*windows*", "*nanoserver*", "*servercore*"]
+      ubuntu-base:
+        patterns: ["*ubuntu*"]
+
+  # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -83,7 +42,35 @@ updates:
       prefix: "deps"
     labels: ["area/infra", "area/dependencies"]
     open-pull-requests-limit: 10
-  # Go modules tracking
+    cooldown:
+      default-days: 3
+      semver-major-days: 14
+    groups:
+      actions-patch:
+        update-types: ["patch"]
+
+  # npm (Docusaurus site)
+  - package-ecosystem: "npm"
+    directory: "/site"
+    schedule:
+      interval: "weekly"
+    reviewers:
+      - "microsoft/retina"
+    commit-message:
+      prefix: "deps"
+    labels: ["area/docs", "area/dependencies"]
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+    groups:
+      docusaurus:
+        patterns:
+          - "@docusaurus/*"
+          - "@mdx-js/*"
+        update-types: ["patch"]
+
+  # Go modules
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
@@ -93,6 +80,32 @@ updates:
     commit-message:
       prefix: "deps"
     labels: ["lang/go", "area/dependencies"]
-    ignore:
-      - dependency-name: "github.com/inspektor-gadget/inspektor-gadget"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+    groups:
+      k8s:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
+        exclude-patterns:
+          - "sigs.k8s.io/cloud-provider-azure/*"
+        update-types: ["patch"]
+      cilium:
+        patterns:
+          - "github.com/cilium/*"
+        update-types: ["patch"]
+      aws-sdk:
+        patterns:
+          - "github.com/aws/aws-sdk-go-v2/*"
+        update-types: ["patch"]
+      azure-sdk:
+        patterns:
+          - "github.com/Azure/*"
+          - "sigs.k8s.io/cloud-provider-azure/*"
+        update-types: ["patch"]
+      otel:
+        patterns:
+          - "go.opentelemetry.io/*"
+        update-types: ["patch"]


### PR DESCRIPTION
# Description

Currently the Dependabot config has 7 separate Docker blocks (one per Dockerfile directory) running daily, no dependency grouping for gomod, and no tracking for the `/site` npm packages. This generates ~9 individual PRs/week and misses Docusaurus version updates entirely.

This PR consolidates and optimizes `.github/dependabot.yaml`:

- **Docker**: Collapse 7 blocks into 1 using multi-directory `directories:` syntax, switch from daily to weekly, and group by image family (`golang-base`, `azurelinux-base`, `windows-base`, `ubuntu-base`)
- **Go modules**: Add patch-only groups for `k8s`, `cilium`, `aws-sdk`, `azure-sdk`, and `otel` families — minors and majors remain standalone for review
- **GitHub Actions**: Add `actions-patch` group for patch-only bundling
- **npm**: Add `/site` (Docusaurus) tracking with weekly schedule and `docusaurus` group for `@docusaurus/*` / `@mdx-js/*` patches
- **Cooldowns**: 7d default / 30d major for Docker and gomod; 3d / 14d for actions; 7d / 30d for npm
- **Cleanup**: Remove `inspektor-gadget` ignore (no longer used)

## Related Issue

N/A

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary. (config-only change)
- [ ] I have added tests, if applicable. (config-only change)

## Screenshots (if applicable) or Testing Completed

N/A — config-only change.

## Additional Notes

- `directories:` (plural) requires GitHub-hosted Dependabot (which this repo uses). See [GitHub changelog](https://github.blog/changelog/2024-06-25-simplified-dependabot-yml-configuration-with-multi-directory-key-directories-and-wildcard-glob-support/).
- Security updates bypass cooldown windows automatically — no CVE delay risk.
- Docker groups deliberately don't restrict `update-types` since digest-only re-pins don't reliably classify as "patch" in Dependabot's semver model.