### PR TITLE
ebpf xdp version bump

### DIFF
--- a/.github/workflows/e2e-test-event-writer.yml
+++ b/.github/workflows/e2e-test-event-writer.yml
@@ -45,6 +45,26 @@ jobs:
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Ensure Docker daemon is running
+        shell: pwsh
+        run: |
+          $timeout = 120
+          $timer = [Diagnostics.Stopwatch]::StartNew()
+          while ($timer.Elapsed.TotalSeconds -lt $timeout) {
+            $svc = Get-Service docker -ErrorAction SilentlyContinue
+            if ($svc -and $svc.Status -ne 'Running') {
+              Start-Service docker -ErrorAction SilentlyContinue
+            }
+            $result = docker info 2>&1
+            if ($LASTEXITCODE -eq 0) {
+              Write-Host "Docker daemon is ready"
+              return
+            }
+            Write-Host "Waiting for Docker daemon to start..."
+            Start-Sleep -Seconds 5
+          }
+          throw "Docker daemon failed to start within $timeout seconds"
+
       - name: Docker Login to ghcr.io
         uses: docker/login-action@v3
         if: ${{ env.IS_MERGE_GROUP != 'true' }}

--- a/.github/workflows/e2e-test-event-writer.yml
+++ b/.github/workflows/e2e-test-event-writer.yml
@@ -17,6 +17,8 @@ permissions:
 
 env:
   EVENT_WRITER_PATH: "${{ github.workspace }}/test/e2e/tools/event-writer/"
+  EBPF_VERSION: "1.1.0"
+  XDP_SDK_VERSION: "1.3.0"
 
 jobs:
   retina-win-e2e-bpf-images:
@@ -80,13 +82,13 @@ jobs:
         run: |
           .\export_program_info.exe --clear
           .\export_program_info.exe
-        working-directory: ${{ env.EVENT_WRITER_PATH }}\packages\eBPF-for-Windows.x64.0.21.1\build\native\bin
+        working-directory: ${{ env.EVENT_WRITER_PATH }}\packages\eBPF-for-Windows.x64.${{ env.EBPF_VERSION }}\build\native\bin
 
       - name: Build Event-Writer
         shell: cmd
         run: |
           msbuild /m /t:Clean /p:Configuration=Release /p:Platform=x64 /restore event_writer.sln
-          msbuild /m /p:Configuration=Release /p:Platform=x64 /restore event_writer.sln
+          msbuild /m /p:Configuration=Release /p:Platform=x64 /restore /v:detailed event_writer.sln
         working-directory: ${{ env.EVENT_WRITER_PATH }}
 
       - name: Determine Docker tag

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -12,10 +12,10 @@ FROM mcr.microsoft.com/cbl-mariner/base/core@sha256:8deab931d4af66264253cce66471
 FROM mcr.microsoft.com/cbl-mariner/distroless/minimal@sha256:0b09ee9e988e338f86432484c980c9c334d2b35b3bec6ce14298b754ecb6460b AS mariner-distroless
 
 # mcr.microsoft.com/windows/servercore:ltsc2019
-FROM mcr.microsoft.com/windows/servercore@sha256:1883d9fb02b90ec20783f9376e004e125b28c652a73d821416444aadde6600b0 AS ltsc2019
+FROM mcr.microsoft.com/windows/servercore@sha256:8077f3e5b0987c388735917f0d15a3dd5fc773f8b5699c612ccb539d42644185 AS ltsc2019
 
 # mcr.microsoft.com/windows/servercore:ltsc2022
-FROM mcr.microsoft.com/windows/servercore@sha256:d31ac6a9b0c435679f941677661dd2fc555620348198c506e78e9ba70352e406 AS ltsc2022
+FROM mcr.microsoft.com/windows/servercore@sha256:e000e9a1712065a0218447c20ae19984b447fa741d11cf64696b8a1172fcd7da AS ltsc2022
 
 
 # build stages
@@ -48,7 +48,7 @@ RUN if [ "$GOOS" = "linux" ] ; then \
 FROM golang AS eBPFRetinaStage
 WORKDIR /tmp
 RUN tdnf install -y unzip && \
-    curl -L -o eBPFRetina.zip https://www.nuget.org/api/v2/package/Microsoft.Wcn.Observability.eBPF.Retina.x64/0.1.0-prerelease.11 && \
+    curl -L -o eBPFRetina.zip https://www.nuget.org/api/v2/package/Microsoft.Wcn.Observability.eBPF.Retina.x64/1.3.0 && \
     unzip -d eBPFRetina eBPFRetina.zip || exit 0 && \
     if [ ! -d "eBPFRetina" ]; then echo "eBPFRetina directory not found after unzip!" && exit 1; fi
 

--- a/controller/Dockerfile.windows-native
+++ b/controller/Dockerfile.windows-native
@@ -27,7 +27,7 @@ FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:
 FROM golang AS eBPFRetinaStage
 WORKDIR /tmp
 RUN tdnf install -y unzip && \
-    curl -L -o eBPFRetina.zip https://www.nuget.org/api/v2/package/Microsoft.Wcn.Observability.eBPF.Retina.x64/0.1.0-prerelease.11 && \
+    curl -L -o eBPFRetina.zip https://www.nuget.org/api/v2/package/Microsoft.Wcn.Observability.eBPF.Retina.x64/1.3.0 && \
     unzip -d eBPFRetina eBPFRetina.zip || exit 0 && \
     if [ ! -d "eBPFRetina" ]; then echo "eBPFRetina directory not found after unzip!" && exit 1; fi
 

--- a/controller/Dockerfile.windows-native
+++ b/controller/Dockerfile.windows-native
@@ -23,18 +23,9 @@ RUN go build -v -o captureworkload.exe -ldflags="-X github.com/microsoft/retina/
 FROM --platform=windows/amd64 ${BUILDER_IMAGE} as pktmon-builder
 WORKDIR C:\\retina
 
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:5341a0010ecff114ee2f11f5eaa4f73b721b54142954041523f3e785d5c4b978 AS golang
-FROM golang AS eBPFRetinaStage
-WORKDIR /tmp
-RUN tdnf install -y unzip && \
-    curl -L -o eBPFRetina.zip https://www.nuget.org/api/v2/package/Microsoft.Wcn.Observability.eBPF.Retina.x64/1.3.0 && \
-    unzip -d eBPFRetina eBPFRetina.zip || exit 0 && \
-    if [ ! -d "eBPFRetina" ]; then echo "eBPFRetina directory not found after unzip!" && exit 1; fi
-
 FROM --platform=windows/amd64 mcr.microsoft.com/windows/nanoserver:ltsc2022 AS final
 ADD https://github.com/microsoft/etl2pcapng/releases/download/v1.10.0/etl2pcapng.exe /etl2pcapng.exe
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'Continue';"]
-COPY --from=eBPFRetinaStage /tmp/eBPFRetina/build/native/bin/retinaebpfapi.dll /retinaebpfapi.dll
 COPY --from=builder C:\\retina\\windows\\kubeconfigtemplate.yaml kubeconfigtemplate.yaml
 COPY --from=builder C:\\retina\\windows\\setkubeconfigpath.ps1 setkubeconfigpath.ps1
 COPY --from=builder C:\\retina\\controller.exe controller.exe

--- a/controller/Dockerfile.windows-retina-oss-build
+++ b/controller/Dockerfile.windows-retina-oss-build
@@ -2,11 +2,12 @@
 ARG OS_VERSION=ltsc2022
 # pinned base images
 
-# mcr.microsoft.com/windows/servercore:ltsc2019 
-FROM mcr.microsoft.com/windows/servercore@sha256:1883d9fb02b90ec20783f9376e004e125b28c652a73d821416444aadde6600b0 AS ltsc2019
+# mcr.microsoft.com/windows/servercore:ltsc2019
+FROM mcr.microsoft.com/windows/servercore@sha256:8077f3e5b0987c388735917f0d15a3dd5fc773f8b5699c612ccb539d42644185 AS ltsc2019
 
 # mcr.microsoft.com/windows/servercore:ltsc2022
-FROM mcr.microsoft.com/windows/servercore@sha256:d31ac6a9b0c435679f941677661dd2fc555620348198c506e78e9ba70352e406 AS ltsc2022
+FROM mcr.microsoft.com/windows/servercore@sha256:e000e9a1712065a0218447c20ae19984b447fa741d11cf64696b8a1172fcd7da    AS ltsc2022
+
 
 FROM ${OS_VERSION} AS agent-win
 ARG GOARCH=amd64 # default to amd64

--- a/pkg/plugin/ebpfwindows/metricsmap_windows.go
+++ b/pkg/plugin/ebpfwindows/metricsmap_windows.go
@@ -53,8 +53,8 @@ type MetricsMap interface {
 type metricsMap struct{}
 
 var (
-	// Load the retinaebpfapi.dll
-	retinaEbpfAPI = windows.NewLazyDLL("retinaebpfapi.dll")
+	// Load retinaebpfapi.dll from the system directory
+	retinaEbpfAPI = windows.NewLazyDLL(`C:\Windows\system32\retinaebpfapi.dll`)
 	// Load the RetinaEnumerateMetrics function
 	enumMetricsMap = retinaEbpfAPI.NewProc("RetinaEnumerateMetrics")
 	// Load the RetinaGetLostEventsCount function

--- a/test/e2e/tools/event-writer/event_writer.vcxproj
+++ b/test/e2e/tools/event-writer/event_writer.vcxproj
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="packages\XDP-for-Windows.1.1.0\build\native\xdp-for-windows.props" Condition="Exists('packages\XDP-for-Windows.1.1.0\build\native\xdp-for-windows.props')" />
+  <PropertyGroup Label="PackageVersions">
+    <EbpfVersion>1.1.0</EbpfVersion>
+    <XdpSdkVersion>1.3.0</XdpSdkVersion>
+  </PropertyGroup>
+  <Import Project="packages\Microsoft.XDP-for-Windows.Sdk.$(XdpSdkVersion)\build\native\Microsoft.XDP-for-Windows.Sdk.props" Condition="Exists('packages\Microsoft.XDP-for-Windows.Sdk.$(XdpSdkVersion)\build\native\Microsoft.XDP-for-Windows.Sdk.props')" />
   <Import Project="packages\Microsoft.Windows.WDK.x64.10.0.26100.2454\build\native\Microsoft.Windows.WDK.x64.props" Condition="Exists('packages\Microsoft.Windows.WDK.x64.10.0.26100.2454\build\native\Microsoft.Windows.WDK.x64.props')" />
   <Import Project="packages\Microsoft.Windows.SDK.CPP.x64.10.0.26100.2454\build\native\Microsoft.Windows.SDK.cpp.x64.props" Condition="Exists('packages\Microsoft.Windows.SDK.CPP.x64.10.0.26100.2454\build\native\Microsoft.Windows.SDK.cpp.x64.props')" />
   <Import Project="packages\Microsoft.Windows.SDK.CPP.10.0.26100.2454\build\native\Microsoft.Windows.SDK.cpp.props" Condition="Exists('packages\Microsoft.Windows.SDK.CPP.10.0.26100.2454\build\native\Microsoft.Windows.SDK.cpp.props')" />
-  <Import Project="packages\eBPF-for-Windows.x64.0.21.1\build\native\ebpf-for-windows.x64.props" Condition="Exists('packages\eBPF-for-Windows.x64.0.21.1\build\native\ebpf-for-windows.x64.props')" />
+  <Import Project="packages\eBPF-for-Windows.x64.$(EbpfVersion)\build\native\ebpf-for-windows.x64.props" Condition="Exists('packages\eBPF-for-Windows.x64.$(EbpfVersion)\build\native\ebpf-for-windows.x64.props')" />
   <PropertyGroup>
     <WDKVersion>10.0.26100.2454</WDKVersion>
   </PropertyGroup>
@@ -20,8 +24,8 @@
     <ProjectGuid>{A12E2603-25A2-4A9C-9B9D-9156C9520789}</ProjectGuid>
     <RootNamespace>event_writer</RootNamespace>
     <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
-    <EbpfPackagePath>$(SolutionDir)packages\eBPF-for-Windows.x64.0.21.1\build\native\</EbpfPackagePath>
-    <XdpPackagePath>$(SolutionDir)packages\XDP-for-Windows.1.1.0\build\native\</XdpPackagePath>
+    <EbpfPackagePath>$(SolutionDir)packages\eBPF-for-Windows.x64.$(EbpfVersion)\build\native\</EbpfPackagePath>
+    <XdpPackagePath>$(SolutionDir)packages\Microsoft.XDP-for-Windows.Sdk.$(XdpSdkVersion)\build\native\</XdpPackagePath>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
@@ -51,7 +55,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.10.0.26100.2454\c\Include\10.0.26100.0\um;$(SolutionDir)packages\eBPF-for-Windows.x64.0.21.1\build\native\include;$(SolutionDir)packages\XDP-for-Windows.1.1.0\build\native\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.10.0.26100.2454\c\Include\10.0.26100.0\um;$(SolutionDir)packages\eBPF-for-Windows.x64.$(EbpfVersion)\build\native\include;$(SolutionDir)packages\Microsoft.XDP-for-Windows.Sdk.$(XdpSdkVersion)\build\native\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
@@ -60,7 +64,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalLibraryDirectories>$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.x64.10.0.26100.2454\c\um\x64;$(SolutionDir)packages\eBPF-for-Windows.x64.0.21.1\build\native\lib;$(SolutionDir)packages\XDP-for-Windows.1.1.0\build\native\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(SolutionDir)packages\Microsoft.Windows.SDK.CPP.x64.10.0.26100.2454\c\um\x64;$(SolutionDir)packages\eBPF-for-Windows.x64.$(EbpfVersion)\build\native\lib;$(SolutionDir)packages\Microsoft.XDP-for-Windows.Sdk.$(XdpSdkVersion)\build\native\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>ebpfapi.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
@@ -74,11 +78,12 @@
     <CustomBuild Include="bpf_event_writer.c">
       <Outputs>$(Platform)\$(Configuration)\bpf_event_writer.sys</Outputs>
       <Command>
+        set PATH=$(EbpfPackagePath)bin;%PATH%
         $(XdpPackagePath)bin\$(Platform)\xdpbpfexport.exe --clear
         $(XdpPackagePath)bin\$(Platform)\xdpbpfexport.exe
         clang -g -target bpf -O2 -Werror -I$(EbpfPackagePath)include -I$(XdpPackagePath)include -c bpf_event_writer.c -o $(Platform)\$(Configuration)\bpf_event_writer.o
         pushd $(OutDir)
-        powershell -NonInteractive -ExecutionPolicy Unrestricted $(EbpfPackagePath)bin\Convert-BpfToNative.ps1 -FileName bpf_event_writer -IncludeDir $(EbpfPackagePath)include -Platform $(Platform) -Packages $(SolutionDir)packages -Configuration $(Configuration) -KernelMode $true
+        powershell -NonInteractive -ExecutionPolicy Unrestricted $(EbpfPackagePath)bin\Convert-BpfToNative.ps1 -FileName bpf_event_writer -IncludeDir $(EbpfPackagePath)include -Platform $(Platform) -Configuration $(Configuration) -KernelMode $true
         popd
       </Command>
     </CustomBuild>
@@ -98,11 +103,11 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('packages\eBPF-for-Windows.x64.0.21.1\build\native\ebpf-for-windows.x64.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\eBPF-for-Windows.x64.0.21.1\build\native\ebpf-for-windows.x64.props'))" />
+    <Error Condition="!Exists('packages\eBPF-for-Windows.x64.$(EbpfVersion)\build\native\ebpf-for-windows.x64.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\eBPF-for-Windows.x64.$(EbpfVersion)\build\native\ebpf-for-windows.x64.props'))" />
     <Error Condition="!Exists('packages\Microsoft.Windows.SDK.CPP.10.0.26100.2454\build\native\Microsoft.Windows.SDK.cpp.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Windows.SDK.CPP.10.0.26100.2454\build\native\Microsoft.Windows.SDK.cpp.props'))" />
     <Error Condition="!Exists('packages\Microsoft.Windows.SDK.CPP.10.0.26100.2454\build\native\Microsoft.Windows.SDK.cpp.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Windows.SDK.CPP.10.0.26100.2454\build\native\Microsoft.Windows.SDK.cpp.targets'))" />
     <Error Condition="!Exists('packages\Microsoft.Windows.SDK.CPP.x64.10.0.26100.2454\build\native\Microsoft.Windows.SDK.cpp.x64.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Windows.SDK.CPP.x64.10.0.26100.2454\build\native\Microsoft.Windows.SDK.cpp.x64.props'))" />
     <Error Condition="!Exists('packages\Microsoft.Windows.WDK.x64.10.0.26100.2454\build\native\Microsoft.Windows.WDK.x64.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Windows.WDK.x64.10.0.26100.2454\build\native\Microsoft.Windows.WDK.x64.props'))" />
-    <Error Condition="!Exists('packages\XDP-for-Windows.1.1.0\build\native\xdp-for-windows.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\XDP-for-Windows.1.1.0\build\native\xdp-for-windows.props'))" />
+    <Error Condition="!Exists('packages\Microsoft.XDP-for-Windows.Sdk.$(XdpSdkVersion)\build\native\Microsoft.XDP-for-Windows.Sdk.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.XDP-for-Windows.Sdk.$(XdpSdkVersion)\build\native\Microsoft.XDP-for-Windows.Sdk.props'))" />
   </Target>
 </Project>

--- a/test/e2e/tools/event-writer/install-ebpf-xdp.ps1
+++ b/test/e2e/tools/event-writer/install-ebpf-xdp.ps1
@@ -406,10 +406,10 @@ Function Install-eBPF
 
       Write-Host 'Installing extended Berkley Packet Filter for Windows'
       # Download eBPF-for-Windows.
-      $packageEbpfUrl  = "https://github.com/microsoft/ebpf-for-windows/releases/download/Release-v0.21.1/ebpf-for-windows.x64.0.21.1.msi"
-      Invoke-WebRequest -Uri $packageEbpfUrl -OutFile "$LocalPath\ebpf-for-windows.x64.0.21.1.msi"
+      $packageEbpfUrl  = "https://github.com/microsoft/ebpf-for-windows/releases/download/Release-v1.0.0-rc2/ebpf-for-windows.x64.1.0.0-rc2.msi"
+      Invoke-WebRequest -Uri $packageEbpfUrl -OutFile "$LocalPath\ebpf-for-windows.x64.1.0.0-rc2.msi"
 
-      Start-Process -FilePath "$($env:WinDir)\System32\MSIExec.exe" -ArgumentList @("/i", "$LocalPath\ebpf-for-windows.x64.0.21.1.msi", "/qn", "INSTALLFOLDER=`"$($env:ProgramFiles)\ebpf-for-windows`"", "ADDLOCAL=eBPF_Runtime_Components") -PassThru | Wait-Process
+      Start-Process -FilePath "$($env:WinDir)\System32\MSIExec.exe" -ArgumentList @("/i", "$LocalPath\ebpf-for-windows.x64.1.0.0-rc2.msi", "/qn", "INSTALLFOLDER=`"$($env:ProgramFiles)\ebpf-for-windows`"", "ADDLOCAL=eBPF_Runtime_Components") -PassThru | Wait-Process
       If(-Not (Assert-SoftwareInstalled -ServiceName:'eBPFCore' -Silent) -Or
          -Not (Assert-SoftwareInstalled -ServiceName:'NetEbpfExt' -Silent))
       {
@@ -462,28 +462,37 @@ Function Install-XDP
 
    Try
    {
-      If(Assert-SoftwareInstalled -SoftwareName:'XDP for Windows' -Silent)
+      If(Assert-SoftwareInstalled -ServiceName:'XDP' -Silent)
       {
          Write-Host 'XDP for Windows is already installed'
          return $isSuccess
       }
 
-      # Download XDP-for-Windows.
+      # Download and extract the XDP runtime NuGet package.
       Write-Host 'Installing eXpress Data Path for Windows'
-      CertUtil.exe -addstore Root "$LocalPath\xdp.cer"
-      CertUtil.exe -addstore TrustedPublisher "$LocalPath\xdp.cer"
-      Invoke-WebRequest -Uri "https://github.com/microsoft/xdp-for-windows/releases/download/v1.2.0-prerelease-793dc2a0/xdp-for-windows.x64.1.2.0-prerelease-793dc2a0.msi" -OutFile "$LocalPath\xdp-for-windows.msi"
-      $certFileName = 'xdp.cer'
-      Get-AuthenticodeSignature "$LocalPath\xdp-for-windows.msi" | Select-Object -ExpandProperty SignerCertificate | Export-Certificate -Type CERT -FilePath $certFileName
-      Import-Certificate -FilePath $certFileName -CertStoreLocation 'cert:\localmachine\root'
-      Import-Certificate -FilePath $certFileName -CertStoreLocation 'cert:\localmachine\trustedpublisher'
-      Start-Process -FilePath:"$($env:WinDir)\System32\MSIExec.exe" -ArgumentList @("/i $LocalPath\xdp-for-windows.msi", '/qn') -PassThru | Wait-Process
-      sc.exe query xdp
+      $xdpRuntimeVersion = "1.3.0"
+      $xdpNupkgUrl = "https://www.nuget.org/api/v2/package/Microsoft.XDP-for-Windows.Runtime.x64/$xdpRuntimeVersion"
+      $xdpNupkgPath = "$LocalPath\Microsoft.XDP-for-Windows.Runtime.x64.$xdpRuntimeVersion.nupkg"
+      $xdpExtractPath = "$LocalPath\xdp-runtime"
+
+      Invoke-WebRequest -Uri $xdpNupkgUrl -OutFile $xdpNupkgPath
+      Expand-Archive -Path $xdpNupkgPath -DestinationPath $xdpExtractPath -Force
+
+      # Install XDP using xdp-setup.ps1 from the runtime package
+      $xdpSetupScript = Get-ChildItem -Path $xdpExtractPath -Recurse -Filter "xdp-setup.ps1" | Select-Object -First 1
+      If($null -eq $xdpSetupScript) {
+         Write-Error -Message:"xdp-setup.ps1 not found in the runtime package"
+         Throw
+      }
+
+      & $xdpSetupScript.FullName -Install xdp
+      & $xdpSetupScript.FullName -Install xdpebpf
+
       reg.exe add "HKLM\SYSTEM\CurrentControlSet\Services\xdp\Parameters" /v XdpEbpfEnabled /d 1 /t REG_DWORD /f
       net.exe stop xdp
       net.exe start xdp
 
-      If(-Not (Assert-SoftwareInstalled -SoftwareName:'XDP for Windows' -Silent)) {
+      If(-Not (Assert-SoftwareInstalled -ServiceName:'XDP' -Silent)) {
          Throw
       }
 
@@ -639,7 +648,7 @@ Function Uninstall-eBPF
             }
          }
 
-         Start-Process -FilePath:"$($env:WinDir)\System32\MSIExec.exe" -ArgumentList @("/x $($LocalPath)\ebpf-for-windows.x64.0.21.1.msi", '/qn') -PassThru | Wait-Process
+         Start-Process -FilePath:"$($env:WinDir)\System32\MSIExec.exe" -ArgumentList @("/x $($LocalPath)\ebpf-for-windows.x64.1.0.0-rc2.msi", '/qn') -PassThru | Wait-Process
       }
 
       If((Assert-SoftwareInstalled -ServiceName:'eBPFCore' -Silent) -or
@@ -726,15 +735,16 @@ Function Uninstall-XDP
             $state = Get-Service -Name:'XDP'
          }
 
-         $regValue = New-ItemProperty -Path:'HKLM:\SYSTEM\CurrentControlSet\Services\xdp\Parameters' -Name:'xdpEbpfEnabled' -PropertyType:'DWORD' -Value:0 -Force
-         If($regValue.xdpEbpfEnabled -IEQ 0)
-         {
-            Start-Process -FilePath:"$($env:WinDir)\System32\MSIExec.exe" -ArgumentList @("/x $($LocalPath)\xdp-for-windows.msi", '/qn') -PassThru | Wait-Process
+         # Uninstall using xdp-setup.ps1 from the extracted runtime package
+         $xdpExtractPath = "$LocalPath\xdp-runtime"
+         $xdpSetupScript = Get-ChildItem -Path $xdpExtractPath -Recurse -Filter "xdp-setup.ps1" -ErrorAction SilentlyContinue | Select-Object -First 1
+         If($null -ne $xdpSetupScript) {
+            & $xdpSetupScript.FullName -Uninstall xdpebpf
+            & $xdpSetupScript.FullName -Uninstall xdp
          }
       }
 
-      If((Assert-SoftwareInstalled -ServiceName:'XDP' -Silent) -or
-         (Assert-SoftwareInstalled -SoftwareName:'XDP for Windows' -Silent))
+      If((Assert-SoftwareInstalled -ServiceName:'XDP' -Silent))
       {
          Write-Error -Message:"XDP for Windows is still installed"
 

--- a/test/e2e/tools/event-writer/packages.config
+++ b/test/e2e/tools/event-writer/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="eBPF-for-Windows.ARM64" version="0.21.0" targetFramework="native" />
-  <package id="eBPF-for-Windows.x64" version="0.21.1" targetFramework="native" />
+  <package id="eBPF-for-Windows.ARM64" version="1.1.0" targetFramework="native" />
+  <package id="eBPF-for-Windows.x64" version="1.1.0" targetFramework="native" />
   <package id="Microsoft.Windows.SDK.CPP" version="10.0.26100.2454" targetFramework="native" />
   <package id="Microsoft.Windows.SDK.CPP.x64" version="10.0.26100.2454" targetFramework="native" />
   <package id="Microsoft.Windows.WDK.x64" version="10.0.26100.2454" targetFramework="native" />
-  <package id="XDP-for-Windows" version="1.1.0" targetFramework="native" />
+  <package id="Microsoft.XDP-for-Windows.Sdk" version="1.3.0" targetFramework="native" />
 </packages>


### PR DESCRIPTION
# Description
Remove retinaebpfapi.dll from retina image. 

Bumped the version of following:
ebpf 0.21.0 -> 1.1.0
xdp  1.1.0 -> 1.3.0
Microsoft.Wcn.Observability.eBPF.Retina (retinaebpfapi.dll) 0.1.0-prerelease.11 -> 1.3.0
servercore base images


## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
