### PR TITLE
fix(grafana): use drop metric for destination pod panel

### DIFF
--- a/deploy/grafana-dashboards/standard-pod-level.json
+++ b/deploy/grafana-dashboards/standard-pod-level.json
@@ -611,7 +611,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by(destination_podname) (irate(networkobservability_adv_forward_count{destination_podname!=\"unknown\", source_podname!=\"unknown\"}[1m]))",
+          "expr": "sum by(destination_podname) (irate(networkobservability_adv_drop_count{destination_podname!=\"unknown\", source_podname!=\"unknown\"}[1m]))",
           "hide": false,
           "legendFormat": "__auto",
           "range": true,


### PR DESCRIPTION
# Description

Fix the Grafana panel query for "Dropped pps per Destination pod".
The panel title indicates dropped packets, but the query was using `networkobservability_adv_forward_count`.

## Related Issue

N/A

## Checklist

- [X] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [X] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

I don't have a live Grafana environment to capture screenshots. 
However, I have verified the fix logically:
- **Observed issue**: The panel titled "Dropped pps" was using `networkobservability_adv_forward_count`, which measures forwarded (successful) traffic.
- **Fix**: Changed the metric to the correct one for dropped packets. 
- The change is a straightforward query update based on the metric definitions.

## Additional Notes

N/A

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
