### PR TITLE
fix(helm): use native gRPC probe on relay :4222 and bump default to v1.17.15

### DIFF
--- a/deploy/hubble/manifests/controller/helm/retina/templates/hubble-relay/deployment.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/hubble-relay/deployment.yaml
@@ -191,24 +191,15 @@ spec:
 {{- end }}
 
 {{- define "hubble-relay.probe" }}
-{{- /* This distinction can be removed once we drop support for k8s 1.23 */}}
-{{- if and (semverCompare ">=1.24-0" .Capabilities.KubeVersion.Version) (not .Values.hubble.tls.enabled) -}}
+{{- /*
+Probe the relay's dedicated gRPC health server on :4222. It is always plaintext
+regardless of hubble.tls.enabled (the TLS-enabled listener is the main API on
+listenPort), so the kubelet's native gRPC probe works in both TLS and non-TLS
+deployments. Upstream Cilium removed the grpc_health_probe binary from the
+hubble-relay image (cilium/cilium#37806), so the prior exec-based probe is no
+longer viable on v1.16+ images.
+*/}}
 grpc:
-  port: {{ .Values.hubble.relay.listenPort }}
-{{- else }}
-exec:
-  command:
-  - grpc_health_probe
-  - -addr=localhost:{{ .Values.hubble.relay.listenPort }}
-{{- if .Values.hubble.tls.enabled }}
-  - -tls
-  - -tls-ca-cert=/var/lib/hubble-relay/tls/hubble-server-ca.crt
-  - -tls-client-cert=/var/lib/hubble-relay/tls/client.crt
-  - -tls-client-key=/var/lib/hubble-relay/tls/client.key
-  - -tls-server-name=instance.hubble-relay.cilium.io
-  - -connect-timeout=5s
-  - -rpc-timeout=5s
-{{- end }}
-{{- end }}
+  port: 4222
 timeoutSeconds: 3
 {{- end }}

--- a/deploy/hubble/manifests/controller/helm/retina/values.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/values.yaml
@@ -422,11 +422,18 @@ hubble:
     rollOutPods: false
 
     # -- Hubble-relay container image.
+    # Pinned to the official Cilium registry (quay.io/cilium/hubble-relay) and
+    # to v1.17.15 — the lowest currently-supported minor (1.17) at its latest
+    # patch. This intentionally minimises the major jump from the previous
+    # default (v1.15.0) so users have the smallest supported delta to validate.
+    # See https://github.com/cilium/cilium/releases/tag/v1.17.15 for release
+    # notes and https://quay.io/repository/cilium/hubble-relay?tab=tags for
+    # available tags.
     image:
       override: ~
-      repository: "mcr.microsoft.com/oss/cilium/hubble-relay"
-      tag: "v1.15.0"
-      digest: "sha256:19cd56e7618832257bf88b2f281287cb57f9f7fcb9e04775a6198d4bc4daffae"
+      repository: "quay.io/cilium/hubble-relay"
+      tag: "v1.17.15"
+      digest: "sha256:60dcac76e5841a14d5c4813377cb463822db78568146e8c93ffc5b5cc0e894fb"
       useDigest: false
       pullPolicy: "Always"
 


### PR DESCRIPTION
Closes #2165

> @nddq external contributors can't self-assign on this repo — could you assign #2165 to me, please?

## Summary

1. **`templates/hubble-relay/deployment.yaml`** — replace the conditional `grpc_health_probe` exec / native gRPC probe branching with a single native `grpc:` probe pointed at the relay's dedicated health server on `:4222`. Works regardless of `hubble.tls.enabled` (the health listener is plaintext; only the main API on `listenPort` is TLS-wrapped). Mirrors what upstream Cilium's chart adopted after [cilium/cilium#37806](https://github.com/cilium/cilium/pull/37806).
2. **`values.yaml`** — bump default `hubble.relay.image` from `mcr.microsoft.com/oss/cilium/hubble-relay:v1.15.0` to `quay.io/cilium/hubble-relay:v1.17.15` (lowest currently-supported Cilium minor at its latest patch, smallest jump that lands on a maintained line). Refs: [v1.17.15 release notes](https://github.com/cilium/cilium/releases/tag/v1.17.15), [available tags](https://quay.io/repository/cilium/hubble-relay?tab=tags).

## Why

With the chart's default `hubble.tls.enabled: true`, the probe template selects the `exec grpc_health_probe` branch. Upstream Cilium [removed that binary from the relay image](https://github.com/cilium/cilium/pull/37806) (backported to all supported branches), so any v1.16+ tag fails the startup probe with `executable file not found in $PATH` and the rollout stalls. Reproduced against `v1.17.15`.

Probing `:4222` instead of `listenPort` (`4245`) avoids this without forcing operators to disable TLS or ship a custom relay image — the health server is always plaintext regardless of the main API's TLS state.