### PR TITLE
Fix xdp install in retina test

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,5 +1,5 @@
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24.2-2-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:5341a0010ecff114ee2f11f5eaa4f73b721b54142954041523f3e785d5c4b978 AS builder
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24.4-azurelinux3.0 --format "{{.Name}}@{{.Digest}}"
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.24.4-azurelinux3.0@sha256:250d01e55a37bd79d7014ae83f9f50aa6fa5570ca910e7f19faeff4bb0132ae1 AS builder
 
 ARG VERSION
 ARG APP_INSIGHTS_ID
@@ -20,8 +20,8 @@ RUN --mount=type=cache,target="/root/.cache/go-build" \
     -X "github.com/microsoft/retina/internal/buildinfo.ApplicationInsightsID"="$APP_INSIGHTS_ID"" \
     -a -o kubectl-retina cli/main.go
 
-# mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/cbl-mariner/distroless/minimal@sha256:db87903c5d4d9d6760e86a274914efd6a3bb5914c0b5a6c6b35350ec297fea4f
+# skopeo inspect docker://mcr.microsoft.com/azurelinux/distroless/minimal:3.0 --format "{{.Name}}@{{.Digest}}"
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:5a66f9f16ac675db2a8229dac72d83811b73b502d6ad192d8b374c7f3be498af
 WORKDIR /
 COPY --from=builder /workspace/kubectl-retina .
 

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -2,19 +2,19 @@
 ARG OS_VERSION=ltsc2022
 # pinned base images
 
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24.2-2-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:5341a0010ecff114ee2f11f5eaa4f73b721b54142954041523f3e785d5c4b978 AS golang
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24.4-azurelinux3.0 --format "{{.Name}}@{{.Digest}}"
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.24.4-azurelinux3.0@sha256:250d01e55a37bd79d7014ae83f9f50aa6fa5570ca910e7f19faeff4bb0132ae1 AS golang
 
-# skopeo inspect docker://mcr.microsoft.com/cbl-mariner/base/core:2.0 --format "{{.Name}}@{{.Digest}}"
-FROM mcr.microsoft.com/cbl-mariner/base/core@sha256:8deab931d4af66264253cce66471a04742dc6f8d5d175d4c18e930eda615c0aa AS mariner-core
+# skopeo inspect docker://mcr.microsoft.com/azurelinux/base/core:3.0 --format "{{.Name}}@{{.Digest}}"
+FROM mcr.microsoft.com/azurelinux/base/core:3.0@sha256:35149ae8dd179684f969944f54a337c665a64e702486154eb44253fb39c2505b AS azurelinux-core
 
-# skopeo inspect docker://mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0 --format "{{.Name}}@{{.Digest}}"
-FROM mcr.microsoft.com/cbl-mariner/distroless/minimal@sha256:0b09ee9e988e338f86432484c980c9c334d2b35b3bec6ce14298b754ecb6460b AS mariner-distroless
+# skopeo inspect docker://mcr.microsoft.com/azurelinux/distroless/minimal:3.0 --format "{{.Name}}@{{.Digest}}"
+FROM mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:5a66f9f16ac675db2a8229dac72d83811b73b502d6ad192d8b374c7f3be498af AS azurelinux-distroless
 
-# mcr.microsoft.com/windows/servercore:ltsc2019
+# skopeo inspect docker://mcr.microsoft.com/windows/servercore:ltsc2019  --override-os windows --format "{{.Name}}@{{.Digest}}"
 FROM mcr.microsoft.com/windows/servercore@sha256:8077f3e5b0987c388735917f0d15a3dd5fc773f8b5699c612ccb539d42644185 AS ltsc2019
 
-# mcr.microsoft.com/windows/servercore:ltsc2022
+# skopeo inspect docker://mcr.microsoft.com/windows/servercore:ltsc2022  --override-os windows --format "{{.Name}}@{{.Digest}}"
 FROM mcr.microsoft.com/windows/servercore@sha256:e000e9a1712065a0218447c20ae19984b447fa741d11cf64696b8a1172fcd7da AS ltsc2022
 
 
@@ -28,7 +28,7 @@ ARG GOOS=linux # default to linux
 ENV GOARCH=${GOARCH}
 ENV GOOS=${GOOS}
 RUN if [ "$GOOS" = "linux" ] ; then \
-      tdnf install -y clang16 lld16 bpftool libbpf-devel; \
+      tdnf install -y clang lld bpftool libbpf-devel; \
     fi
 COPY ./pkg/plugin /go/src/github.com/microsoft/retina/pkg/plugin
 WORKDIR /go/src/github.com/microsoft/retina
@@ -80,9 +80,9 @@ RUN --mount=type=cache,target="/root/.cache/go-build" go build -v -o /go/bin/ret
 
 
 # tools image
-FROM mariner-core AS tools
+FROM azurelinux-core AS tools
 RUN tdnf install -y \
-    clang16 \
+    clang \
     iproute \
     iptables \
     tcpdump \
@@ -110,7 +110,7 @@ RUN echo "Hubble version: $HUBBLE_VERSION" && \
     rm hubble-linux-${HUBBLE_ARCH}.tar.gz && rm hubble-linux-${HUBBLE_ARCH}.tar.gz.sha256sum
 
 # init final image
-FROM mariner-distroless AS init
+FROM azurelinux-distroless AS init
 COPY --from=init-bin /go/bin/retina/initretina /retina/initretina
 COPY --from=tools /lib/ /lib
 COPY --from=tools /usr/lib/ /usr/lib
@@ -118,9 +118,9 @@ ENTRYPOINT ["./retina/initretina"]
 
 
 # agent final image
-# mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
-# mcr.microsoft.com/cbl-mariner/distroless/minimal@sha256:63a0a70ceaa1320bc6eb98b81106667d43e46b674731ea8d28e4de1b87e0747f
-FROM mariner-distroless AS agent
+# mcr.microsoft.com/azurelinux/distroless/minimal:3.0
+# mcr.microsoft.com/azurelinux/distroless/minimal@sha256:0801b80a0927309572b9adc99bd1813bc680473175f6e8175cd4124d95dbd50c
+FROM azurelinux-distroless AS agent
 COPY --from=tools /lib/ /lib
 COPY --from=tools /usr/lib/ /usr/lib
 COPY --from=tools /tmp/bin/ /bin

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -45,12 +45,6 @@ RUN if [ "$GOOS" = "linux" ] ; then \
       rm -rf ./pkg/plugin && tar xvf /gen.tar.gz ./pkg/plugin; \
     fi
 
-FROM golang AS eBPFRetinaStage
-WORKDIR /tmp
-RUN tdnf install -y unzip && \
-    curl -L -o eBPFRetina.zip https://www.nuget.org/api/v2/package/Microsoft.Wcn.Observability.eBPF.Retina.x64/1.3.0 && \
-    unzip -d eBPFRetina eBPFRetina.zip || exit 0 && \
-    if [ ! -d "eBPFRetina" ]; then echo "eBPFRetina directory not found after unzip!" && exit 1; fi
 
 # capture binary
 FROM intermediate AS capture-bin
@@ -142,7 +136,6 @@ ENTRYPOINT ["./retina/controller"]
 
 # agent final image for windows
 FROM ${OS_VERSION} AS agent-win
-COPY --from=eBPFRetinaStage /tmp/eBPFRetina/build/native/bin/retinaebpfapi.dll /retinaebpfapi.dll
 COPY --from=controller-bin /go/src/github.com/microsoft/retina/windows/kubeconfigtemplate.yaml kubeconfigtemplate.yaml
 COPY --from=controller-bin /go/src/github.com/microsoft/retina/windows/setkubeconfigpath.ps1 setkubeconfigpath.ps1
 COPY --from=controller-bin /go/bin/retina/controller controller.exe

--- a/controller/Dockerfile.gogen
+++ b/controller/Dockerfile.gogen
@@ -1,5 +1,5 @@
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24.2-2-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:5341a0010ecff114ee2f11f5eaa4f73b721b54142954041523f3e785d5c4b978
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24.4-azurelinux3.0 --format "{{.Name}}@{{.Digest}}"
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.24.4-azurelinux3.0@sha256:250d01e55a37bd79d7014ae83f9f50aa6fa5570ca910e7f19faeff4bb0132ae1
 
 # Default linux/architecture.
 ARG GOOS=linux

--- a/controller/Dockerfile.proto
+++ b/controller/Dockerfile.proto
@@ -1,5 +1,5 @@
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24.2-2-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:5341a0010ecff114ee2f11f5eaa4f73b721b54142954041523f3e785d5c4b978
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24.4-azurelinux3.0 --format "{{.Name}}@{{.Digest}}"
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.24.4-azurelinux3.0@sha256:250d01e55a37bd79d7014ae83f9f50aa6fa5570ca910e7f19faeff4bb0132ae1
 
 LABEL Name=retina-builder Version=0.0.1
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/microsoft/retina
 
-go 1.24.2
+go 1.24.3
 
 require (
 	github.com/go-chi/chi/v5 v5.2.1
@@ -260,7 +260,6 @@ require (
 
 require (
 	github.com/Azure/azure-container-networking/zapai v0.0.3
-	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.9.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/containerservice/armcontainerservice/v4 v4.8.0
@@ -351,6 +350,7 @@ require (
 	github.com/Antonboom/errname v1.0.0 // indirect
 	github.com/Antonboom/nilnil v1.0.1 // indirect
 	github.com/Antonboom/testifylint v1.5.2 // indirect
+	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys v0.10.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6 v6.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -478,8 +478,7 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
-github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
+
 github.com/docker/cli v26.0.0+incompatible h1:90BKrx1a1HKYpSnnBFR6AgDq/FqkHxwlUyzJVPxD30I=
 github.com/docker/cli v26.0.0+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.3+incompatible h1:AtKxIZ36LoNK51+Z6RpzLpddBirtxJnzDrHLEKxTAYk=

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,5 +1,5 @@
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24.2-2-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang@sha256:5341a0010ecff114ee2f11f5eaa4f73b721b54142954041523f3e785d5c4b978 AS builder
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24.4-azurelinux3.0 --format "{{.Name}}@{{.Digest}}"
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.24.4-azurelinux3.0@sha256:250d01e55a37bd79d7014ae83f9f50aa6fa5570ca910e7f19faeff4bb0132ae1 AS builder
 
 ARG VERSION
 ARG APP_INSIGHTS_ID
@@ -7,7 +7,6 @@ ARG APP_INSIGHTS_ID
 WORKDIR /workspace
 COPY . .
 
-# Install jq, not sure why this went missing in the 1.24.1-2-cbl-mariner2.0 base go image.
 RUN tdnf install -y jq
 
 # Default linux/architecture.
@@ -25,8 +24,8 @@ RUN --mount=type=cache,target="/root/.cache/go-build" \
 	-a -o retina-operator operator/main.go
 
 ##################### controller #######################
-# mcr.microsoft.com/cbl-mariner/distroless/minimal:2.0
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/cbl-mariner/distroless/minimal@sha256:db87903c5d4d9d6760e86a274914efd6a3bb5914c0b5a6c6b35350ec297fea4f
+# skopeo inspect docker://mcr.microsoft.com/azurelinux/distroless/minimal:3.0 --format "{{.Name}}@{{.Digest}}"
+FROM mcr.microsoft.com/azurelinux/distroless/minimal:3.0@sha256:5a66f9f16ac675db2a8229dac72d83811b73b502d6ad192d8b374c7f3be498af
 WORKDIR /
 COPY --from=builder /lib /lib
 COPY --from=builder /usr/lib/ /usr/lib

--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -1,5 +1,5 @@
 # skopeo inspect docker://mcr.microsoft.com/azurelinux/base/core:3.0 --format "{{.Name}}@{{.Digest}}"
-FROM mcr.microsoft.com/azurelinux/base/core@sha256:9948138108a3d69f1dae62104599ac03132225c3b7a5ac57b85a214629c8567d
+FROM mcr.microsoft.com/azurelinux/base/core:3.0@sha256:35149ae8dd179684f969944f54a337c665a64e702486154eb44253fb39c2505b
 
 RUN tdnf install -y \
 	bind-utils \

--- a/test/e2e/tools/event-writer/install-ebpf-xdp.ps1
+++ b/test/e2e/tools/event-writer/install-ebpf-xdp.ps1
@@ -1,5 +1,12 @@
 #Requires -RunAsAdministrator
 
+# This script performs Windows node setup required for Retina e2e tests.
+
+# Version configuration
+$Script:eBPFVersion = "1.1.0"
+$Script:RetinaEbpfAPIVersion = "1.3.0"
+$Script:XDPRuntimeVersion = "1.3.0"
+
 Function Assert-SoftwareInstalled
 {
    [cmdletbinding(DefaultParameterSetName='Software')]
@@ -355,6 +362,31 @@ Function Assert-WindowsEbpfXdpIsReady
       }
    }
 
+   # Verify VC++ Runtime DLLs
+   $requiredDlls = @("MSVCP140.dll", "VCRUNTIME140.dll", "VCRUNTIME140_1.dll")
+   ForEach($dll in $requiredDlls)
+   {
+      If(-Not (Test-Path "$env:WinDir\System32\$dll"))
+      {
+         $isReady = $false
+         Write-Warning -Message:"`t$dll is not present in System32"
+      }
+   }
+
+   # Verify EbpfApi.dll in System32
+   If(-Not (Test-Path "$env:WinDir\System32\EbpfApi.dll"))
+   {
+      $isReady = $false
+      Write-Warning -Message:"`tEbpfApi.dll is not present in System32"
+   }
+
+   # Verify retinaebpfapi.dll in System32
+   If(-Not (Test-Path "$env:WinDir\System32\retinaebpfapi.dll"))
+   {
+      $isReady = $false
+      Write-Warning -Message:"`tretinaebpfapi.dll is not present in System32"
+   }
+
    Return $isReady
 }
 
@@ -406,10 +438,10 @@ Function Install-eBPF
 
       Write-Host 'Installing extended Berkley Packet Filter for Windows'
       # Download eBPF-for-Windows.
-      $packageEbpfUrl  = "https://github.com/microsoft/ebpf-for-windows/releases/download/Release-v1.0.0-rc2/ebpf-for-windows.x64.1.0.0-rc2.msi"
-      Invoke-WebRequest -Uri $packageEbpfUrl -OutFile "$LocalPath\ebpf-for-windows.x64.1.0.0-rc2.msi"
+      $packageEbpfUrl  = "https://github.com/microsoft/ebpf-for-windows/releases/download/Release-v$Script:eBPFVersion/ebpf-for-windows.x64.$Script:eBPFVersion.msi"
+      Invoke-WebRequest -Uri $packageEbpfUrl -OutFile "$LocalPath\ebpf-for-windows.x64.$Script:eBPFVersion.msi"
 
-      Start-Process -FilePath "$($env:WinDir)\System32\MSIExec.exe" -ArgumentList @("/i", "$LocalPath\ebpf-for-windows.x64.1.0.0-rc2.msi", "/qn", "INSTALLFOLDER=`"$($env:ProgramFiles)\ebpf-for-windows`"", "ADDLOCAL=eBPF_Runtime_Components") -PassThru | Wait-Process
+      Start-Process -FilePath "$($env:WinDir)\System32\MSIExec.exe" -ArgumentList @("/i", "$LocalPath\ebpf-for-windows.x64.$Script:eBPFVersion.msi", "/qn", "INSTALLFOLDER=`"$($env:ProgramFiles)\ebpf-for-windows`"", "ADDLOCAL=eBPF_Runtime_Components") -PassThru | Wait-Process
       If(-Not (Assert-SoftwareInstalled -ServiceName:'eBPFCore' -Silent) -Or
          -Not (Assert-SoftwareInstalled -ServiceName:'NetEbpfExt' -Silent))
       {
@@ -418,12 +450,151 @@ Function Install-eBPF
       }
 
       $isSuccess = Assert-SoftwareInstalled -ServiceName:"eBPFCore"
+
+      # TODO : Remove this once retinaebpfapi.dll can find EbpfApi.dll from the install location.
+      # Copy EbpfApi.dll to System32 so dependent DLLs can find it
+      $ebpfApiSource = "$($env:ProgramFiles)\ebpf-for-windows\EbpfApi.dll"
+      $ebpfApiDest = "$env:WinDir\System32\EbpfApi.dll"
+      If((Test-Path $ebpfApiSource) -And -Not (Test-Path $ebpfApiDest))
+      {
+         Copy-Item -Path $ebpfApiSource -Destination $ebpfApiDest -Force
+         Write-Host "EbpfApi.dll copied to $ebpfApiDest"
+      }
    }
    Catch
    {
       $isSuccess = $false
       Write-Host "EBPF install failed : $_"
       Uninstall-eBPF
+   }
+
+   Return $isSuccess
+}
+
+<#
+ .Name
+   Install-VCRuntime
+
+ .Synopsis
+   Installs the Visual C++ Runtime redistributable.
+
+ .Description
+   Downloads and installs the Microsoft Visual C++ Redistributable (x64) which provides
+   MSVCP140.dll, VCRUNTIME140.dll, and VCRUNTIME140_1.dll in C:\Windows\System32. retinaebpfapi.dll
+   depends on these DLLs. Returns TRUE if successful, otherwise FALSE.
+#>
+Function Install-VCRuntime
+{
+   [Boolean] $isSuccess = $true
+
+   Try
+   {
+      $requiredDlls = @("MSVCP140.dll", "VCRUNTIME140.dll", "VCRUNTIME140_1.dll")
+      $allPresent = $true
+
+      ForEach($dll in $requiredDlls)
+      {
+         If(-Not (Test-Path "$env:WinDir\System32\$dll"))
+         {
+            $allPresent = $false
+            Break
+         }
+      }
+
+      If($allPresent)
+      {
+         Write-Host 'Visual C++ Runtime DLLs are already installed'
+         return $isSuccess
+      }
+
+      Write-Host 'Installing Visual C++ Redistributable (x64)'
+
+      $vcRedistUrl = "https://aka.ms/vs/17/release/vc_redist.x64.exe"
+      $vcRedistPath = "$env:TEMP\vc_redist.x64.exe"
+
+      Invoke-WebRequest -Uri $vcRedistUrl -OutFile $vcRedistPath
+      Start-Process -FilePath $vcRedistPath -ArgumentList @("/install", "/quiet", "/norestart") -Wait
+
+      # Verify installation
+      ForEach($dll in $requiredDlls)
+      {
+         If(-Not (Test-Path "$env:WinDir\System32\$dll"))
+         {
+            Write-Error "$dll not found after VC++ Redistributable install"
+            Throw
+         }
+      }
+
+      Write-Host 'Visual C++ Runtime DLLs installed successfully'
+   }
+   Catch
+   {
+      $isSuccess = $false
+      Write-Host "Visual C++ Runtime install failed: $_"
+   }
+   Finally
+   {
+      Remove-Item -Path "$env:TEMP\vc_redist.x64.exe" -Force -ErrorAction SilentlyContinue
+   }
+
+   Return $isSuccess
+}
+
+<#
+ .Name
+   Install-RetinaEbpfAPI
+
+ .Synopsis
+   Downloads and installs retinaebpfapi.dll from the NuGet gallery.
+
+ .Description
+   Downloads the Microsoft.Wcn.Observability.eBPF.Retina.x64 NuGet package and
+   copies retinaebpfapi.dll to C:\Windows\System32.
+   Returns TRUE if successful, otherwise FALSE.
+#>
+Function Install-RetinaEbpfAPI
+{
+   [Boolean] $isSuccess = $true
+
+   Try
+   {
+      $dllDest = "$env:WinDir\System32\retinaebpfapi.dll"
+
+      If(Test-Path $dllDest)
+      {
+         Write-Host 'retinaebpfapi.dll is already installed'
+         return $isSuccess
+      }
+
+      Write-Host 'Installing retinaebpfapi.dll from NuGet'
+
+      $nugetUrl = "https://www.nuget.org/api/v2/package/Microsoft.Wcn.Observability.eBPF.Retina.x64/$Script:RetinaEbpfAPIVersion"
+      $zipPath = "$env:TEMP\eBPFRetina.zip"
+      $extractPath = "$env:TEMP\eBPFRetina"
+
+      Invoke-WebRequest -Uri $nugetUrl -OutFile $zipPath
+      Expand-Archive -Path $zipPath -DestinationPath $extractPath -Force
+
+      $dllSource = "$extractPath\build\native\bin\retinaebpfapi.dll"
+      If(-Not (Test-Path $dllSource))
+      {
+         Write-Error "retinaebpfapi.dll not found in NuGet package at $dllSource"
+         Throw
+      }
+
+      Copy-Item -Path $dllSource -Destination $dllDest -Force
+      Write-Host "retinaebpfapi.dll installed to $dllDest"
+   }
+   Catch
+   {
+      $isSuccess = $false
+      Write-Host "retinaebpfapi.dll install failed: $_"
+   }
+   Finally
+   {
+      # Cleanup
+      Remove-Item -Path "$env:TEMP\eBPFRetina.zip" -Force -ErrorAction SilentlyContinue
+      Remove-Item -Path "$env:TEMP\eBPFRetina" -Recurse -Force -ErrorAction SilentlyContinue
    }
 
    Return $isSuccess
@@ -470,19 +641,37 @@ Function Install-XDP
 
       # Download and extract the XDP runtime NuGet package.
       Write-Host 'Installing eXpress Data Path for Windows'
-      $xdpRuntimeVersion = "1.3.0"
+      $xdpRuntimeVersion = $Script:XDPRuntimeVersion
       $xdpNupkgUrl = "https://www.nuget.org/api/v2/package/Microsoft.XDP-for-Windows.Runtime.x64/$xdpRuntimeVersion"
-      $xdpNupkgPath = "$LocalPath\Microsoft.XDP-for-Windows.Runtime.x64.$xdpRuntimeVersion.nupkg"
+      $xdpZipPath = "$LocalPath\Microsoft.XDP-for-Windows.Runtime.x64.$xdpRuntimeVersion.zip"
       $xdpExtractPath = "$LocalPath\xdp-runtime"
 
-      Invoke-WebRequest -Uri $xdpNupkgUrl -OutFile $xdpNupkgPath
-      Expand-Archive -Path $xdpNupkgPath -DestinationPath $xdpExtractPath -Force
+      Invoke-WebRequest -Uri $xdpNupkgUrl -OutFile $xdpZipPath
+      Expand-Archive -Path $xdpZipPath -DestinationPath $xdpExtractPath -Force
+      Remove-Item -Path $xdpZipPath -Force
 
       # Install XDP using xdp-setup.ps1 from the runtime package
       $xdpSetupScript = Get-ChildItem -Path $xdpExtractPath -Recurse -Filter "xdp-setup.ps1" | Select-Object -First 1
       If($null -eq $xdpSetupScript) {
          Write-Error -Message:"xdp-setup.ps1 not found in the runtime package"
          Throw
+      }
+
+      # Trust the certificate from xdp.sys so Windows allows the driver to load
+      $xdpSys = Get-ChildItem -Path $xdpExtractPath -Recurse -Filter "xdp.sys" | Select-Object -First 1
+      If($null -ne $xdpSys) {
+         $xdpCert = (Get-AuthenticodeSignature $xdpSys.FullName).SignerCertificate
+         If($null -ne $xdpCert) {
+            $xdpCertPath = "$LocalPath\xdp.cer"
+            Export-Certificate -Cert $xdpCert -FilePath $xdpCertPath -Type CERT -Force
+            certutil -f -addstore Root $xdpCertPath
+            certutil -f -addstore TrustedPublisher $xdpCertPath
+            Remove-Item -Path $xdpCertPath -Force
+         } Else {
+            Write-Warning "xdp.sys is not signed, skipping certificate trust"
+         }
+      } Else {
+         Write-Warning "xdp.sys not found in the runtime package, skipping certificate trust"
       }
 
       & $xdpSetupScript.FullName -Install xdp
@@ -560,6 +749,10 @@ Function Install-EbpfXdp
       If(-Not (Install-eBPF)) {Throw}
 
       If(-Not (Install-XDP)) {Throw}
+
+      If(-Not (Install-VCRuntime)) {Throw}
+
+      If(-Not (Install-RetinaEbpfAPI)) {Throw}
 
       Write-Host 'eBPF and XDP for Windows is installed successfully'
       write-Host 'Create the probe ready file'
@@ -648,7 +841,7 @@ Function Uninstall-eBPF
             }
          }
 
-         Start-Process -FilePath:"$($env:WinDir)\System32\MSIExec.exe" -ArgumentList @("/x $($LocalPath)\ebpf-for-windows.x64.1.0.0-rc2.msi", '/qn') -PassThru | Wait-Process
+         Start-Process -FilePath:"$($env:WinDir)\System32\MSIExec.exe" -ArgumentList @("/x $($LocalPath)\ebpf-for-windows.x64.$Script:eBPFVersion.msi", '/qn') -PassThru | Wait-Process
       }
 
       If((Assert-SoftwareInstalled -ServiceName:'eBPFCore' -Silent) -or

--- a/test/image/Dockerfile
+++ b/test/image/Dockerfile
@@ -1,10 +1,10 @@
 # build stage
-# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24.2-2-cbl-mariner2.0 --format "{{.Name}}@{{.Digest}}"
-FROM mcr.microsoft.com/oss/go/microsoft/golang@sha256:5341a0010ecff114ee2f11f5eaa4f73b721b54142954041523f3e785d5c4b978 AS builder
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.24.4-azurelinux3.0 --format "{{.Name}}@{{.Digest}}"
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.24.4-azurelinux3.0@sha256:250d01e55a37bd79d7014ae83f9f50aa6fa5570ca910e7f19faeff4bb0132ae1 AS builder
 ENV CGO_ENABLED=0
 COPY . /go/src/github.com/microsoft/retina 
 WORKDIR /go/src/github.com/microsoft/retina
-RUN tdnf install -y clang16 lld16 bpftool libbpf-devel make git jq
+RUN tdnf install -y clang lld bpftool libbpf-devel make git jq
 RUN go generate /go/src/github.com/microsoft/retina/pkg/plugin/...
 # RUN go mod edit -module retina
 # RUN make all generate


### PR DESCRIPTION
# Description

Made the following fixes to the install-ebpf-xdp.ps1 script which is used to setup node for e2e tests.
- Add xdp cert to cert store to resolve installation errors.
- Download and install retinaebpfapi on the node since it is no longer packaged with retina image
- Install vc++ runtime needed for retinaebpfapi.dll
- Copy ebpfapi.dll to the dir where retinaebpfapi.dll is (this can be updated when retinaebpfapi can find the dll from path)


## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [X] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
