### PR TITLE
build: add empty-bpf-objects target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,9 @@ generate-bpf-go: ## generate ebpf wrappers for plugins for all archs
 FMT_PKG  ?= .
 LINT_PKG ?= .
 
+empty-bpf-objects: ## truncate all tracked .o files to 0 bytes
+	git ls-files '*.o' | xargs truncate -s 0
+
 fmt: ## run gofumpt on $FMT_PKG (default "retina").
 	$(GOFUMPT) -w $(FMT_PKG)
 


### PR DESCRIPTION
# Description

Adds the missing 'empty-bpf-objects' target mentioned in CI error messages. This allows developers to truncate eBPF .o files to 0-byte stubs after local generation, satisfying the repo policy and fixing GHA 'Generate Check' failures.

## Related Issue

Fixes #2291 

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

- Ran `make generate-bpf-go` to ensure .o files contained binary data, ran the new `make empty-bpf-objects` target, confirmed the .o files returned to their original 0-byte state, resulting in a clean git status.
- Verified make help
```
Utils 
  empty-bpf-objects  truncate all tracked .o files to 0 bytes
```
## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
