### PR TITLE
fix(deps): correct dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -20,16 +20,19 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
-      semver-major-days: 30
     groups:
       golang-base:
         patterns: ["*golang*"]
+        group-by: "dependency-name"
       azurelinux-base:
         patterns: ["*azurelinux*"]
+        group-by: "dependency-name"
       windows-base:
         patterns: ["*windows*", "*nanoserver*", "*servercore*"]
+        group-by: "dependency-name"
       ubuntu-base:
         patterns: ["*ubuntu*"]
+        group-by: "dependency-name"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
@@ -44,7 +47,6 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 3
-      semver-major-days: 14
     groups:
       actions-patch:
         update-types: ["patch"]


### PR DESCRIPTION
# Description

Two fixes to `.github/dependabot.yaml`:

1. **Drop `cooldown.semver-major-days`** from the docker and github-actions blocks. Dependabot rejects the whole config at parse time because `semver-major-days` is only valid for ecosystems with a real semver model (gomod, npm). `default-days` stays.

   <img width="1786" height="535" alt="image" src="https://github.com/user-attachments/assets/bee97983-b8ee-4dee-ae95-121131247e84" />

2. **Group docker base image bumps across directories.** Add `group-by: "dependency-name"` to each Docker family group (`golang-base`, `azurelinux-base`, `windows-base`, `ubuntu-base`) so the same base image bump across `/controller`, `/operator`, `/cli`, `/shell`, `/test/image`, and `/hack/tools/*` lands in a single PR instead of one per Dockerfile. Without it, the family patterns only deduplicate within a single directory job.

## Related Issue

N/A.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (\`git commit -S -s ...\`).
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

N/A — config-only change.

## Additional Notes

N/A.