### PR TITLE
feat(e2e): make agent pool VM SKUs configurable via env

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -19,6 +19,21 @@ on:
         required: true
         type: string
         description: The Azure location to use for the E2E tests.
+      azure_agent_linux_sku:
+        required: false
+        default: ''
+        type: string
+        description: VM SKU for the Linux agent pool. Falls back to the in-code default when empty.
+      azure_agent_windows_sku:
+        required: false
+        default: ''
+        type: string
+        description: VM SKU for the Windows agent pool. Falls back to the in-code default when empty.
+      azure_agent_linux_arm_sku:
+        required: false
+        default: ''
+        type: string
+        description: VM SKU for the ARM64 agent pool. Falls back to the in-code default when empty.
       use_existing_infra:
         required: false
         default: false
@@ -61,6 +76,21 @@ on:
         required: false
         type: string
         description: The Azure location to use for the E2E tests.
+      azure_agent_linux_sku:
+        required: false
+        default: ''
+        type: string
+        description: VM SKU for the Linux agent pool. Falls back to the in-code default when empty.
+      azure_agent_windows_sku:
+        required: false
+        default: ''
+        type: string
+        description: VM SKU for the Windows agent pool. Falls back to the in-code default when empty.
+      azure_agent_linux_arm_sku:
+        required: false
+        default: ''
+        type: string
+        description: VM SKU for the ARM64 agent pool. Falls back to the in-code default when empty.
       use_existing_infra:
         required: false
         default: false
@@ -108,6 +138,9 @@ jobs:
         env:
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION }}
           AZURE_LOCATION: ${{ inputs.azure_location }}
+          AZURE_AGENT_LINUX_SKU: ${{ inputs.azure_agent_linux_sku }}
+          AZURE_AGENT_WINDOWS_SKU: ${{ inputs.azure_agent_windows_sku }}
+          AZURE_AGENT_LINUX_ARM_SKU: ${{ inputs.azure_agent_linux_arm_sku }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -422,6 +422,9 @@ jobs:
         env:
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION }}
           AZURE_LOCATION: ${{ vars.AZURE_LOCATION }}
+          AZURE_AGENT_LINUX_SKU: ${{ vars.AZURE_AGENT_LINUX_SKU }}
+          AZURE_AGENT_WINDOWS_SKU: ${{ vars.AZURE_AGENT_WINDOWS_SKU }}
+          AZURE_AGENT_LINUX_ARM_SKU: ${{ vars.AZURE_AGENT_LINUX_ARM_SKU }}
         shell: bash
         run: |
           set -euo pipefail
@@ -446,6 +449,9 @@ jobs:
       image-namespace: ${{ github.repository }}
       retina-mode: basic
       azure-location: ${{ vars.AZURE_LOCATION }}
+      azure-agent-linux-sku: ${{ vars.AZURE_AGENT_LINUX_SKU }}
+      azure-agent-windows-sku: ${{ vars.AZURE_AGENT_WINDOWS_SKU }}
+      azure-agent-linux-arm-sku: ${{ vars.AZURE_AGENT_LINUX_ARM_SKU }}
     secrets:
       azure-subscription: ${{ secrets.AZURE_SUBSCRIPTION }}
       azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -462,6 +468,9 @@ jobs:
       image-namespace: ${{ github.repository }}
       retina-mode: advanced
       azure-location: ${{ vars.AZURE_LOCATION }}
+      azure-agent-linux-sku: ${{ vars.AZURE_AGENT_LINUX_SKU }}
+      azure-agent-windows-sku: ${{ vars.AZURE_AGENT_WINDOWS_SKU }}
+      azure-agent-linux-arm-sku: ${{ vars.AZURE_AGENT_LINUX_ARM_SKU }}
     secrets:
       azure-subscription: ${{ secrets.AZURE_SUBSCRIPTION }}
       azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/perf-manual.yaml
+++ b/.github/workflows/perf-manual.yaml
@@ -35,6 +35,9 @@ jobs:
       image-namespace: ${{ inputs.image-namespace || github.repository }}
       retina-mode: ${{ inputs.retina-mode }}
       azure-location: ${{ vars.AZURE_LOCATION }}
+      azure-agent-linux-sku: ${{ vars.AZURE_AGENT_LINUX_SKU }}
+      azure-agent-windows-sku: ${{ vars.AZURE_AGENT_WINDOWS_SKU }}
+      azure-agent-linux-arm-sku: ${{ vars.AZURE_AGENT_LINUX_ARM_SKU }}
     secrets:
       azure-subscription: ${{ secrets.AZURE_SUBSCRIPTION }}
       azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/perf-schedule.yaml
+++ b/.github/workflows/perf-schedule.yaml
@@ -34,6 +34,9 @@ jobs:
       image-namespace: ${{ github.repository }}
       retina-mode: basic
       azure-location: ${{ vars.AZURE_LOCATION }}
+      azure-agent-linux-sku: ${{ vars.AZURE_AGENT_LINUX_SKU }}
+      azure-agent-windows-sku: ${{ vars.AZURE_AGENT_WINDOWS_SKU }}
+      azure-agent-linux-arm-sku: ${{ vars.AZURE_AGENT_LINUX_ARM_SKU }}
     secrets:
       azure-subscription: ${{ secrets.AZURE_SUBSCRIPTION }}
       azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -49,6 +52,9 @@ jobs:
       image-namespace: ${{ github.repository }}
       retina-mode: advanced
       azure-location: ${{ vars.AZURE_LOCATION }}
+      azure-agent-linux-sku: ${{ vars.AZURE_AGENT_LINUX_SKU }}
+      azure-agent-windows-sku: ${{ vars.AZURE_AGENT_WINDOWS_SKU }}
+      azure-agent-linux-arm-sku: ${{ vars.AZURE_AGENT_LINUX_ARM_SKU }}
     secrets:
       azure-subscription: ${{ secrets.AZURE_SUBSCRIPTION }}
       azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/perf-template.yaml
+++ b/.github/workflows/perf-template.yaml
@@ -24,6 +24,21 @@ on:
         description: 'Azure location for the performance test'
         required: true
         type: string
+      azure-agent-linux-sku:
+        description: 'VM SKU for the Linux agent pool'
+        required: false
+        default: ''
+        type: string
+      azure-agent-windows-sku:
+        description: 'VM SKU for the Windows agent pool'
+        required: false
+        default: ''
+        type: string
+      azure-agent-linux-arm-sku:
+        description: 'VM SKU for the ARM64 agent pool'
+        required: false
+        default: ''
+        type: string
     secrets:
         azure-subscription:
           description: 'Azure subscription ID'
@@ -71,6 +86,9 @@ jobs:
           AZURE_APP_INSIGHTS_KEY: ${{ secrets.azure-app-insights-key }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.azure-subscription }}
           AZURE_LOCATION: ${{ inputs.azure-location }}
+          AZURE_AGENT_LINUX_SKU: ${{ inputs.azure-agent-linux-sku }}
+          AZURE_AGENT_WINDOWS_SKU: ${{ inputs.azure-agent-windows-sku }}
+          AZURE_AGENT_LINUX_ARM_SKU: ${{ inputs.azure-agent-linux-arm-sku }}
         shell: bash
         run: |
           set -euo pipefail

--- a/test/e2e/framework/azure/create-cluster-with-npm.go
+++ b/test/e2e/framework/azure/create-cluster-with-npm.go
@@ -21,7 +21,6 @@ const (
 	clusterTimeout       = 15 * time.Minute
 	clusterCreateTicker  = 30 * time.Second
 	pollFrequency        = 5 * time.Second
-	AgentARMSKU          = "Standard_D4pds_v5"
 	AuxilaryNodeCount    = 1
 	AuxilaryARMNodeCount = 2
 )
@@ -77,7 +76,7 @@ func (c *CreateNPMCluster) Run() error {
 		OSType:             to.Ptr(armcontainerservice.OSTypeLinux),
 		OSSKU:              to.Ptr(armcontainerservice.OSSKUAzureLinux),
 		ScaleDownMode:      to.Ptr(armcontainerservice.ScaleDownModeDelete),
-		VMSize:             to.Ptr(AgentSKU),
+		VMSize:             to.Ptr(AgentLinuxSKU),
 		Name:               to.Ptr("azlinux"),
 		MaxPods:            to.Ptr(int32(MaxPodsPerNode)),
 	})
@@ -90,7 +89,7 @@ func (c *CreateNPMCluster) Run() error {
 		Mode:               to.Ptr(armcontainerservice.AgentPoolModeUser),
 		OSType:             to.Ptr(armcontainerservice.OSTypeLinux),
 		ScaleDownMode:      to.Ptr(armcontainerservice.ScaleDownModeDelete),
-		VMSize:             to.Ptr(AgentARMSKU),
+		VMSize:             to.Ptr(AgentLinuxARMSKU),
 		Name:               to.Ptr("arm64"),
 		MaxPods:            to.Ptr(int32(MaxPodsPerNode)),
 	})

--- a/test/e2e/framework/azure/create-cluster.go
+++ b/test/e2e/framework/azure/create-cluster.go
@@ -14,8 +14,6 @@ import (
 const (
 	MaxNumberOfNodes = 3
 	MaxPodsPerNode   = 250
-	AgentSKU         = "Standard_D4ds_v4"
-	AgentWindowsSKU  = "Standard_D4ds_v4"
 )
 
 var defaultClusterCreateTimeout = 30 * time.Minute
@@ -117,7 +115,7 @@ func GetStarterClusterTemplate(location string) armcontainerservice.ManagedClust
 					Mode:               to.Ptr(armcontainerservice.AgentPoolModeSystem),
 					OSType:             to.Ptr(armcontainerservice.OSTypeLinux),
 					ScaleDownMode:      to.Ptr(armcontainerservice.ScaleDownModeDelete),
-					VMSize:             to.Ptr(AgentSKU),
+					VMSize:             to.Ptr(AgentLinuxSKU),
 					Name:               to.Ptr("nodepool1"),
 					MaxPods:            to.Ptr(int32(MaxPodsPerNode)),
 				},

--- a/test/e2e/framework/azure/skus.go
+++ b/test/e2e/framework/azure/skus.go
@@ -1,0 +1,16 @@
+package azure
+
+import "os"
+
+var (
+	AgentLinuxSKU    = skuFromEnv("AZURE_AGENT_LINUX_SKU", "Standard_D4ds_v4")
+	AgentLinuxARMSKU = skuFromEnv("AZURE_AGENT_LINUX_ARM_SKU", "Standard_D4pds_v5")
+	AgentWindowsSKU  = skuFromEnv("AZURE_AGENT_WINDOWS_SKU", "Standard_D4ds_v4")
+)
+
+func skuFromEnv(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}

--- a/test/e2e/jobs/scale.go
+++ b/test/e2e/jobs/scale.go
@@ -62,7 +62,7 @@ func GetScaleTestInfra(subID, rg, clusterName, location, kubeConfigFilePath stri
 			Nodes:       nodes,
 		}).
 			SetPodCidr("100.64.0.0/10").
-			SetVMSize("Standard_D4ds_v4").
+			SetVMSize(azure.AgentLinuxSKU).
 			SetNetworkPluginMode("overlay"), nil)
 
 		job.AddStep(&azure.GetAKSKubeConfig{


### PR DESCRIPTION
# Description

Agent pool VM SKUs are hardcoded today (`Standard_D4ds_v4` for Linux and Windows, `Standard_D4pds_v5` for Linux ARM). When a SKU is suddenly made unavailable in a region without prior notice, the workflow has no escape hatch short of a code change. This PR mirrors the existing `AZURE_LOCATION` pattern: three env vars override the in-code defaults, plumbed through the workflows as optional inputs and repo variables.

| OS / arch | Env var | Default |
|---|---|---|
| Linux x86 | `AZURE_AGENT_LINUX_SKU` | `Standard_D4ds_v4` |
| Linux ARM64 | `AZURE_AGENT_LINUX_ARM_SKU` | `Standard_D4pds_v5` |
| Windows | `AZURE_AGENT_WINDOWS_SKU` | `Standard_D4ds_v4` |

When an env var is unset or empty, the Go code falls back to the in-code default — so this is a no-op until a repo variable (e.g. `vars.AZURE_AGENT_LINUX_SKU`) is set.

## Changes

- **Go**: new `test/e2e/framework/azure/skus.go` declares `AgentLinuxSKU`, `AgentLinuxARMSKU`, `AgentWindowsSKU` as env-overridable vars. Callers in `create-cluster.go`, `create-cluster-with-npm.go`, and `scale.go` now reference them instead of the previous constants and one hardcoded string.
- **Workflows**: `perf-template.yaml`, `perf-manual.yaml`, `perf-schedule.yaml`, `images.yaml`, and `e2e.yaml` get three optional inputs each plus env wiring. Caller workflows pass `vars.AZURE_AGENT_LINUX_SKU` etc.

## Related Issue

N/A.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`).
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

`go build ./test/e2e/...`, `go vet ./test/e2e/...`, and YAML parse all clean on the touched files.

## Additional Notes

N/A.