### PR TITLE
fix(devcontainer): bump go feature to 1.3.4 for golangci-lint fix

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2.16.1": {},
     "ghcr.io/devcontainers/features/github-cli:1.1.0": {},
-    "ghcr.io/devcontainers/features/go:1.3.3": {
+    "ghcr.io/devcontainers/features/go:1.3.4": {
       "version": "1.24.11"
     },
     "ghcr.io/devcontainers/features/kubectl-helm-minikube:1.3.1": {},


### PR DESCRIPTION
# Description

The DevContainer workflow has been failing on every run since 2026-04-30 because the `ghcr.io/devcontainers/features/go:1.3.3` install script downloads `golangci-lint` v2.12.1+, which now ships an SBOM asset (`…tar.gz.sbom.json`). The deprecated `master/install.sh` greps `checksums.txt` by tarball basename, the SBOM filename matches as a prefix, and the multi-line result fails `hash_sha256_verify` — even though the actual tarball hash is correct.

The fix is upstream: [devcontainers/features#1636](https://github.com/devcontainers/features/pull/1636) (merged 2026-05-05) switched the Go feature's install URL to the supported `golangci-lint.run/install.sh` and bumped the feature to **`1.3.4`**. This PR bumps our pin so the next devcontainer build picks it up.

Related upstream issues: [golangci/golangci-lint#6572](https://github.com/golangci/golangci-lint/issues/6572), [devcontainers/features#1635](https://github.com/devcontainers/features/issues/1635).

## Related Issue

N/A.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`).
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

N/A — version-pin bump only. Will validate once the DevContainer workflow runs on this PR.

## Additional Notes

N/A.