### PR TITLE
deps: bump hubble CLI to v1.19.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ PLATFORM		?= $(OS)/$(ARCH)
 PLATFORMS		?= linux/amd64 linux/arm64 windows/amd64
 OS_VERSION		?= ltsc2022
 
-HUBBLE_VERSION ?= v1.18.6
+HUBBLE_VERSION ?= v1.19.3
 
 CONTAINER_BUILDER ?= docker
 CONTAINER_RUNTIME ?= docker

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -90,7 +90,7 @@ RUN cp $(which bpftool) /tmp/init-bin
 ARG GOARCH=amd64
 ENV HUBBLE_ARCH=${GOARCH}
 # ARG HUBBLE_VERSION may be modified via the update-hubble GitHub Action
-ARG HUBBLE_VERSION=v1.18.6
+ARG HUBBLE_VERSION=v1.19.3
 ENV HUBBLE_VERSION=${HUBBLE_VERSION}
 RUN echo "Hubble version: $HUBBLE_VERSION" && \
     wget --no-check-certificate https://github.com/cilium/hubble/releases/download/$HUBBLE_VERSION/hubble-linux-${HUBBLE_ARCH}.tar.gz && \


### PR DESCRIPTION
# Description

Bumps the Hubble CLI binary baked into the `retina-agent` image from `v1.18.6` → `v1.19.3` (current upstream stable, released 2026-04-22). This brings the in-image CLI into alignment with `go.mod`, which already pins `github.com/cilium/cilium v1.19.3`.

## Related Issue

N/A.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`).
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

N/A — version-pin bump only.

## Additional Notes

N/A.