### PR TITLE
fix(clang-injection): Validate Retina dir header

### DIFF
--- a/pkg/loader/vmlinux.go
+++ b/pkg/loader/vmlinux.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/microsoft/retina/pkg/log"
 	"go.uber.org/zap"
@@ -35,6 +36,28 @@ var (
 func VmlinuxHeaderDir() string {
 	dir := strings.TrimSpace(os.Getenv(VmlinuxHeaderDirEnv))
 	if dir == "" {
+		return DefaultVmlinuxHeaderDir
+	}
+
+	// Security: Prevent argument injection via environment variable
+	// Block any path containing whitespace that could be used to inject
+	// additional clang arguments (e.g., "--config /etc/passwd")
+	// Also block paths starting with dash (would be interpreted as a flag)
+	for _, r := range dir {
+		if unicode.IsSpace(r) {
+			log.Logger().Named("vmlinux").Warn(
+				"RETINA_VMLINUX_HEADER_DIR contains whitespace, using default",
+				zap.String("rejected_value", dir),
+			)
+			return DefaultVmlinuxHeaderDir
+		}
+	}
+
+	if strings.HasPrefix(dir, "-") {
+		log.Logger().Named("vmlinux").Warn(
+			"RETINA_VMLINUX_HEADER_DIR starts with dash (potential flag injection), using default",
+			zap.String("rejected_value", dir),
+		)
 		return DefaultVmlinuxHeaderDir
 	}
 

--- a/pkg/loader/vmlinux_test.go
+++ b/pkg/loader/vmlinux_test.go
@@ -36,3 +36,120 @@ func TestGenerateVmlinuxH(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, string(content), "typedef")
 }
+
+func TestVmlinuxHeaderDir_Security(t *testing.T) {
+	// Initialize logger for test
+	_, err := log.SetupZapLogger(log.GetDefaultLogOpts())
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		envValue string
+		expected string
+		desc     string
+	}{
+		{
+			name:     "default when empty",
+			envValue: "",
+			expected: DefaultVmlinuxHeaderDir,
+			desc:     "Should use default when env var is empty",
+		},
+		{
+			name:     "valid path",
+			envValue: "/custom/path/headers",
+			expected: "/custom/path/headers",
+			desc:     "Should accept valid path without special characters",
+		},
+		{
+			name:     "valid path with dashes",
+			envValue: "/tmp/fake-config",
+			expected: "/tmp/fake-config",
+			desc:     "Should accept valid path with dashes in the middle",
+		},
+		{
+			name:     "valid path with multiple dashes",
+			envValue: "/opt/my-app/retina-headers",
+			expected: "/opt/my-app/retina-headers",
+			desc:     "Should accept valid path with multiple dashes",
+		},
+		{
+			name:     "block space injection",
+			envValue: "/tmp/fake --config /etc/passwd",
+			expected: DefaultVmlinuxHeaderDir,
+			desc:     "Should reject path with spaces (argument injection attempt)",
+		},
+		{
+			name:     "block leading dash (flag injection)",
+			envValue: "--config=/etc/passwd",
+			expected: DefaultVmlinuxHeaderDir,
+			desc:     "Should reject path starting with dash (would be interpreted as flag)",
+		},
+		{
+			name:     "block config flag",
+			envValue: "/tmp/dir --config /etc/shadow",
+			expected: DefaultVmlinuxHeaderDir,
+			desc:     "Should block clang --config file leak attack",
+		},
+		{
+			name:     "block tab injection",
+			envValue: "/tmp/fake\t--config\t/etc/shadow",
+			expected: DefaultVmlinuxHeaderDir,
+			desc:     "Should reject path with tabs",
+		},
+		{
+			name:     "block newline injection",
+			envValue: "/tmp/fake\n--config /etc/passwd",
+			expected: DefaultVmlinuxHeaderDir,
+			desc:     "Should reject path with newlines",
+		},
+		{
+			name:     "trimmed whitespace valid",
+			envValue: "  /custom/path  ",
+			expected: "/custom/path",
+			desc:     "Should trim leading/trailing whitespace from valid paths",
+		},
+		{
+			name:     "block multiple arguments",
+			envValue: "/tmp -I/etc -w /tmp/out.txt",
+			expected: DefaultVmlinuxHeaderDir,
+			desc:     "Should block attempts to inject multiple clang arguments",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set environment variable
+			if tt.envValue != "" {
+				err := os.Setenv(VmlinuxHeaderDirEnv, tt.envValue)
+				require.NoError(t, err)
+				defer os.Unsetenv(VmlinuxHeaderDirEnv)
+			} else {
+				os.Unsetenv(VmlinuxHeaderDirEnv)
+			}
+
+			// Call function and verify result
+			result := VmlinuxHeaderDir()
+			require.Equal(t, tt.expected, result, tt.desc)
+		})
+	}
+}
+
+func TestVmlinuxHeaderDir_PreventArgumentInjection(t *testing.T) {
+	// Initialize logger for test
+	_, err := log.SetupZapLogger(log.GetDefaultLogOpts())
+	require.NoError(t, err)
+
+	// Simulate attack: inject --config flag to leak /etc/passwd
+	maliciousInput := "/tmp/headers --config /etc/passwd"
+	err = os.Setenv(VmlinuxHeaderDirEnv, maliciousInput)
+	require.NoError(t, err)
+	defer os.Unsetenv(VmlinuxHeaderDirEnv)
+
+	// Get the directory (should be sanitized to default)
+	dir := VmlinuxHeaderDir()
+
+	// Verify attack was blocked
+	require.Equal(t, DefaultVmlinuxHeaderDir, dir, "Malicious input should be rejected")
+	require.NotContains(t, dir, "--config", "Result should not contain injected flag")
+	require.NotContains(t, dir, " ", "Result should not contain spaces")
+}


### PR DESCRIPTION
# Security Fix: Prevent Clang Argument Injection via RETINA_VMLINUX_HEADER_DIR

## Summary
Fixes a **High severity** information disclosure vulnerability where the `RETINA_VMLINUX_HEADER_DIR` environment variable could be exploited to inject clang arguments, enabling arbitrary file reads through clang's `--config` flag.

This fix implements:
1. **Input Validation**: Block dangerous characters at the source
2. **Safe Default**: Always fall back to known-good value
3. **Security Logging**: Warn when suspicious input is detected
4. **No Breaking Changes**: Default behavior unchanged

## Vulnerability Details

**Attack Vector**: Argument injection during eBPF compilation  
**Impact**: Information disclosure - leak sensitive files (passwords, tokens, keys)  
**Prerequisites**: Ability to modify Retina agent DaemonSet configuration  

The `RETINA_VMLINUX_HEADER_DIR` environment variable is read without validation and directly incorporated into clang command-line arguments via the `-I` flag:

```go
// Before (vulnerable)
runtimeIncludeDir := "-I" + loader.VmlinuxHeaderDir()
// If RETINA_VMLINUX_HEADER_DIR="/tmp/fake --config /etc/shadow"
// becomes: -I/tmp/fake --config /etc/shadow
```

Clang interprets this as two separate arguments:
1. `-I/tmp/fake` (include directory)
2. `--config /etc/shadow` (read config from file)

File contents leak via clang error messages in pod logs.

**Example Attack**:
```yaml
# Malicious DaemonSet modification
env:
  - name: RETINA_VMLINUX_HEADER_DIR
    value: "/tmp/fake --config /etc/shadow"
```

**Files at Risk**:
- `/etc/shadow` - Password hashes
- `/etc/passwd` - User information
- `/var/run/secrets/kubernetes.io/serviceaccount/token` - K8s service account token
- `/root/.ssh/id_rsa` - SSH private keys
- Application secrets, certificates, configuration files

### Validation Rules

- Reject spaces (prevents multi-argument injection)
- Reject tabs/newlines (prevents hidden arguments)  
- Reject dashes (prevents flag injection like `--config`)
- Fall back to safe default `/tmp/retina/include`
- Log warning for security monitoring

## Testing

### Unit Tests

Added 9 test cases in `pkg/loader/vmlinux_test.go`:
**All tests passing**: `go test -v ./pkg/loader/... -run TestVmlinux`

### Manual Validation
```
# Deploy with malicious env var
kubectl set env daemonset/retina-agent -n kube-system \
  RETINA_VMLINUX_HEADER_DIR="/tmp/headers --config /etc/shadow"
```

Pre Fix:
<img width="1861" height="116" alt="image" src="https://github.com/user-attachments/assets/eef4768d-a8ec-42e7-bb5c-2d2619807413" />

Post Fix:
<img width="1886" height="152" alt="image" src="https://github.com/user-attachments/assets/380c9bd2-bef0-41f4-8169-73bccf858157" />


## Impact Assessment

### No Impact on Existing Behavior

- Environment variable is not set  in deployments 
- Default path `/tmp/retina/include` is always used
- Variable only configurable via Helm values in standard deployment:
  ```yaml
  daemonset:
    container:
      retina:
        env: []  # Empty by default
  ```
- Hubble deployment has no provision for custom env vars