### PR TITLE
fix(deps): drop dependabot group-by directive (upstream bug)

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -23,16 +23,12 @@ updates:
     groups:
       golang-base:
         patterns: ["*golang*"]
-        group-by: "dependency-name"
       azurelinux-base:
         patterns: ["*azurelinux*"]
-        group-by: "dependency-name"
       windows-base:
         patterns: ["*windows*", "*nanoserver*", "*servercore*"]
-        group-by: "dependency-name"
       ubuntu-base:
         patterns: ["*ubuntu*"]
-        group-by: "dependency-name"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
# Description

The `group-by: dependency-name` directive added to all four Docker family groups in #2306 turns out to be broken by two open upstream bugs in `dependabot/dependabot-core`:

- [#14780](https://github.com/dependabot/dependabot-core/issues/14780) — PRs created with `group-by: dependency-name` can't be rebased; every `@dependabot rebase` returns "unknown group has been removed from your config" and the PR is permanently stuck.
- [#14286](https://github.com/dependabot/dependabot-core/issues/14286) — `group-by: dependency-name` produces one PR per dependency rather than a single grouped PR, defeating the consolidation goal entirely.

In practice this caused every per-directory Docker bump after #2306 to fail with `unknown_error` (seen in run [25821608265](https://github.com/microsoft/retina/actions/runs/25821608265)) and forced manual closure of ~12 stuck PRs. Drop the directive on all four Docker groups. The `patterns:` definitions stay, so per-directory grouping still applies and per-image PRs continue to land as before #2306.

## Related Issue

Reverts the `group-by` addition from #2306. No closing trailer — #2306's other change (dropping invalid `cooldown.semver-major-days`) is preserved.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`).
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

N/A — config-only change. Behavior reverts to the pre-#2306 baseline, which was already running cleanly.

## Additional Notes

N/A.