### PR TITLE
fix(ci): prevent template injection in e2e and perf workflows

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -141,16 +141,27 @@ jobs:
           AZURE_AGENT_LINUX_SKU: ${{ inputs.azure_agent_linux_sku }}
           AZURE_AGENT_WINDOWS_SKU: ${{ inputs.azure_agent_windows_sku }}
           AZURE_AGENT_LINUX_ARM_SKU: ${{ inputs.azure_agent_linux_arm_sku }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
+          IMAGE_REGISTRY: ${{ inputs.image_registry }}
+          IMAGE_NAMESPACE: ${{ inputs.image_namespace }}
+          USE_EXISTING_INFRA: ${{ inputs.use_existing_infra }}
+          INPUT_CLUSTER_NAME: ${{ inputs.cluster_name }}
+          INPUT_RESOURCE_GROUP: ${{ inputs.resource_group }}
         shell: bash
         run: |
           set -euo pipefail
 
-          if [ "${{ inputs.use_existing_infra }}" = "true" ]; then
-            export CLUSTER_NAME=${{ inputs.cluster_name }}
-            export AZURE_RESOURCE_GROUP=${{ inputs.resource_group }}
+          if [ "$USE_EXISTING_INFRA" = "true" ]; then
+            export CLUSTER_NAME="$INPUT_CLUSTER_NAME"
+            export AZURE_RESOURCE_GROUP="$INPUT_RESOURCE_GROUP"
+            CREATE_INFRA=false
+            DELETE_INFRA=false
+          else
+            CREATE_INFRA=true
+            DELETE_INFRA=true
           fi
 
-          go test -v ./test/e2e/. -timeout 60m -tags=e2e -count=1  -args -image-tag=${{ inputs.image_tag }} -image-registry=${{ inputs.image_registry }} -image-namespace=${{ inputs.image_namespace }} -create-infra=${{ !inputs.use_existing_infra }} -delete-infra=${{ !inputs.use_existing_infra }}
+          go test -v ./test/e2e/. -timeout 60m -tags=e2e -count=1  -args -image-tag="$IMAGE_TAG" -image-registry="$IMAGE_REGISTRY" -image-namespace="$IMAGE_NAMESPACE" -create-infra="$CREATE_INFRA" -delete-infra="$DELETE_INFRA"
 
       - name: Cleanup resource group
         if: always()

--- a/.github/workflows/perf-template.yaml
+++ b/.github/workflows/perf-template.yaml
@@ -89,17 +89,16 @@ jobs:
           AZURE_AGENT_LINUX_SKU: ${{ inputs.azure-agent-linux-sku }}
           AZURE_AGENT_WINDOWS_SKU: ${{ inputs.azure-agent-windows-sku }}
           AZURE_AGENT_LINUX_ARM_SKU: ${{ inputs.azure-agent-linux-arm-sku }}
+          TAG: ${{ inputs.tag }}
+          REGISTRY: ${{ inputs.image-registry }}
+          NAMESPACE: ${{ inputs.image-namespace }}
+          MODE: ${{ inputs.retina-mode }}
         shell: bash
         run: |
           set -euo pipefail
 
-          TAG="${{ inputs.tag }}"
-          REGISTRY="${{ inputs.image-registry }}"
-          NAMESPACE="${{ inputs.image-namespace }}"
-          MODE="${{ inputs.retina-mode }}"
-
           echo "Running in $MODE mode..."
-          go test -v ./test/e2e/. -timeout 2h -tags=perf -count=1 -args -image-tag=$TAG -image-registry=$REGISTRY -image-namespace=$NAMESPACE -retina-mode=$MODE
+          go test -v ./test/e2e/. -timeout 2h -tags=perf -count=1 -args -image-tag="$TAG" -image-registry="$REGISTRY" -image-namespace="$NAMESPACE" -retina-mode="$MODE"
 
       - name: Cleanup resource group
         if: always()


### PR DESCRIPTION
## Summary

Routes `${{ inputs.* }}` values through step-level `env:` and references them as quoted shell variables (`"$VAR"`) in the `Run E2E` and `Run performance measurement for Retina` steps, eliminating GitHub Actions template-injection sinks in the `run:` blocks.

## Motivation

`e2e.yaml` and `perf-template.yaml` interpolated workflow inputs directly into shell scripts. Although both workflows are gated to `workflow_call` / `workflow_dispatch` (caller already has repo write), this still:
- Violates the pattern already used elsewhere in this repo (see `commit-message.yaml`, which passes `github.event.pull_request.title`  via `env: TITLE` and references `"$TITLE"`).

## Changes

- `.github/workflows/e2e.yaml` — `Run E2E` step: added `IMAGE_TAG`, `IMAGE_REGISTRY`, `IMAGE_NAMESPACE`, `USE_EXISTING_INFRA`, `INPUT_CLUSTER_NAME`, `INPUT_RESOURCE_GROUP` to `env:`. The `${{ !inputs.use_existing_infra }}` negation is now computed in bash as `CREATE_INFRA` / `DELETE_INFRA`.
- `.github/workflows/perf-template.yaml` — `Run performance measurement for Retina` step: added `TAG`, `REGISTRY`, `NAMESPACE`, `MODE` to `env:`; removed the redundant local-variable reassignment block; quoted all expansions in the `go test` invocation.

## Compatibility

No interface changes — workflow inputs, secrets, and resulting `go test` command lines are identical to before. No callers need to be updated.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Pipeline runs with change:
- https://github.com/microsoft/retina/actions/runs/25907691013
- https://github.com/microsoft/retina/actions/runs/25868604325

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
