### PR TITLE
fix(test): resolve goroutine races causing flaky coverage diffs

### DIFF
--- a/pkg/controllers/daemon/namespace/namespace_controller_test.go
+++ b/pkg/controllers/daemon/namespace/namespace_controller_test.go
@@ -198,7 +198,12 @@ func TestStart(t *testing.T) {
 	r := New(client, cache, mm)
 	// add multiple reocncile calls to the channel to confirm reconcile is only called once
 	ctx, cancel := context.WithCancel(context.Background())
-	go r.Start(ctx)
+	done := make(chan struct{})
+	go func() {
+		r.Start(ctx)
+		close(done)
+	}()
 	time.Sleep(15 * time.Second)
 	cancel()
+	<-done
 }

--- a/pkg/controllers/operator/retinaendpoint/retinaendpoint_controller_test.go
+++ b/pkg/controllers/operator/retinaendpoint/retinaendpoint_controller_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -208,37 +207,19 @@ func TestRetinaEndpointReconciler_ReconcilePod(t *testing.T) {
 			client := fake.NewClientBuilder().WithScheme(fakescheme).WithObjects(tt.fields.existingObjects...).Build()
 			podchannel := make(chan cache.PodCacheObject, 10)
 			r := New(client, podchannel)
-			ctx, cancel := context.WithCancel(context.Background())
-			go r.ReconcilePod(ctx)
+			ctx, cancel := context.WithTimeout(context.Background(), REQUEST_TIMEOUT)
 			defer cancel()
 
+			err := r.reconcileRetinaEndpointFromPod(ctx, tt.fields.newlyCachedPod)
+			require.NoError(t, err)
+
 			got := retinav1alpha1.RetinaEndpoint{}
+			err = client.Get(context.Background(), tt.fields.newlyCachedPod.Key, &got)
 
-			podchannel <- tt.fields.newlyCachedPod
-
-			// Nil wantedRetinaEndpoint indicates no RetinaEndpoint is created from the newlyCachedPod.
 			if tt.wantedRetinaEndpoint == nil {
-				// No retinaEndpoint should be created consistently within timeout.
-				require.Eventually(t, func() bool {
-					err := client.Get(context.Background(), tt.fields.newlyCachedPod.Key, &got)
-					return apierrors.IsNotFound(err)
-				}, 5*time.Second, 1*time.Second, "RetinaEndpoint should not exist")
+				require.True(t, apierrors.IsNotFound(err), "RetinaEndpoint should not exist")
 			} else {
-				// Wait for the RetinaEndpoint to be created/updated with the expected values
-				require.Eventually(t, func() bool {
-					err := client.Get(context.Background(), tt.fields.newlyCachedPod.Key, &got)
-					if apierrors.IsNotFound(err) {
-						return false
-					}
-					// Check that the spec matches what we expect (indicating create/update completed)
-					return got.Spec.PodIP == tt.wantedRetinaEndpoint.Spec.PodIP
-				}, 5*time.Second, 100*time.Millisecond, "RetinaEndpoint should be created/updated with expected PodIP")
-
-				// Re-fetch to get the latest state
-				err := client.Get(context.Background(), tt.fields.newlyCachedPod.Key, &got)
 				require.NoError(t, err)
-
-				// Compare the spec (ignore TypeMeta/ResourceVersion since fake client doesn't populate them)
 				require.Equal(t, tt.wantedRetinaEndpoint.Spec, got.Spec)
 				require.Equal(t, tt.wantedRetinaEndpoint.Name, got.Name)
 				require.Equal(t, tt.wantedRetinaEndpoint.Namespace, got.Namespace)


### PR DESCRIPTION
# Description

Two controller unit tests started background goroutines without waiting for them to finish, so whether specific branches were executed before `go test` wrote the coverage profile depended on Go's scheduling. The same line ranges flipped covered/uncovered across runs of the same `main` branch, and `scripts/coverage/compare_cov.py` then reported ~1–2% file-level coverage shifts on unrelated PRs.

The two line ranges doing the flapping:

| File | Lines | Code |
|---|---|---|
| `pkg/controllers/operator/retinaendpoint/retinaendpoint_controller.go` | 130-133 | `if pod.Pod.Status.Phase != corev1.PodRunning { return nil }` |
| `pkg/controllers/daemon/namespace/namespace_controller.go` | 80-81 | `case <-ctx.Done(): return` |

## retinaendpoint_controller_test.go — race in `TestRetinaEndpointReconciler_ReconcilePod`

`ReconcilePod` was run in a goroutine, fed via a channel, and the test then waited with `require.Eventually(IsNotFound)` for the "non-running pod" / "nil pod" cases. `IsNotFound` was true immediately after the fake client was built, so `Eventually` returned on its first poll — usually before the goroutine had even read from the channel. Whether the `Phase != PodRunning` branch executed before the test exited was a coin toss.

**Fix:** Call the unexported `reconcileRetinaEndpointFromPod` directly (test is in the same package). The channel + goroutine plumbing is not what the test asserts on, and the synchronous call makes every case reach its assertion deterministically.

## namespace_controller_test.go — `TestStart` doesn't wait for the goroutine

`TestStart` did `go r.Start(ctx); time.Sleep(15s); cancel()` and returned. After `cancel()`, the goroutine still had to run its `select` and hit `case <-ctx.Done(): return`, but the test exited first.

**Fix:** Wait for `Start` to actually return via a `done` channel before the test function returns.

## Related Issue

N/A

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Ran the two affected packages multiple times to confirm the flaky line ranges are now deterministically covered:

```bash
$ for i in 1 2 3 4 5; do
    go test -tags=unit,dashboard ./pkg/controllers/operator/retinaendpoint/ \
      -coverprofile=/tmp/cov$i.out -count=1 >/dev/null
    grep 'retinaendpoint_controller.go:130.47,133.3' /tmp/cov$i.out
  done
# 5/5 runs: ... 130.47,133.3 2 1   (was flapping 0/1 on main)

$ for i in 1 2 3; do
    go test -tags=unit,dashboard ./pkg/controllers/daemon/namespace/ \
      -coverprofile=/tmp/nscov$i.out -count=1 >/dev/null
    grep 'namespace_controller.go:80.21,81.10' /tmp/nscov$i.out
  done
# 3/3 runs: ... 80.21,81.10 1 1   (was flapping 0/1 on main)
```

## Additional Notes

The 1–2% file-level shifts come partly from `scripts/coverage/compare_cov.py:getAvgPerFile` averaging per-function coverage percentages unweighted. A separate PR will replace the custom script with Codecov, which uses statement-weighted math and tracks history.
