### PR TITLE
Security: HTTP response body not properly handled

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -32,8 +32,12 @@ func (c *Retina) StartTrace(operationID, filter string) error {
 	if err != nil {
 		return err
 	}
+	defer response.Body.Close()
 
-	response.Body.Close()
+	if response.StatusCode >= 400 {
+		return fmt.Errorf("unexpected status code: %d", response.StatusCode)
+	}
+
 	return nil
 }
 
@@ -43,7 +47,11 @@ func (c *Retina) GetTrace(operationID string) error {
 	if err != nil {
 		return err
 	}
+	defer response.Body.Close()
 
-	response.Body.Close()
+	if response.StatusCode >= 400 {
+		return fmt.Errorf("unexpected status code: %d", response.StatusCode)
+	}
+
 	return nil
 }


### PR DESCRIPTION
## Summary

Security: HTTP response body not properly handled

## Problem

**Severity**: `Medium` | **File**: `pkg/client/client.go:L35`

In pkg/client/client.go, the HTTP responses are closed without checking the status code. If the server returns an error status (4xx, 5xx), the error is silently ignored, potentially leading to silent failures.

## Solution

Check the response status code before closing the body and handle error responses appropriately.

## Changes

- `pkg/client/client.go` (modified)