### PR TITLE
fix(cve-operator): Remove unused EnablePProf function exposing pprof on all interfaces

### DIFF
--- a/operator/cmd/standard/deployment.go
+++ b/operator/cmd/standard/deployment.go
@@ -6,8 +6,6 @@ package standard
 import (
 	"context"
 	"fmt"
-	"net/http"
-	"net/http/pprof"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -241,20 +239,6 @@ func (o *Operator) Start() error {
 	}
 
 	return nil
-}
-
-func EnablePProf() {
-	pprofmux := http.NewServeMux()
-	pprofmux.HandleFunc("/debug/pprof/", pprof.Index)
-	pprofmux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-	pprofmux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-	pprofmux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-	pprofmux.HandleFunc("/debug/pprof/trace", pprof.Trace)
-	pprofmux.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
-
-	if err := http.ListenAndServe(":8082", pprofmux); err != nil { //nolint:gosec // TODO replace with secure server that supports timeout
-		panic(err)
-	}
 }
 
 func initLogging(cfg *config.OperatorConfig, applicationInsightsID string) (*log.ZapLogger, error) {


### PR DESCRIPTION
# Summary
Remove the dead EnablePProf() function from the operator's standard deployment code. This function bound Go's pprof debug endpoints to :8082 (all network interfaces), which was flagged as a medium-severity vulnerability (OWASP A05 — Security Misconfiguration).

## Changes
Removed EnablePProf() from deployment.go as this function was never called
Removed now-unused `net/http` and `net/http/pprof` imports

## Screenshots (if applicable) or Testing Completed

- go build retina. passes
- go test retina. passes

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
