### PR TITLE
feat(capture): Add --cleanup-after-upload flag for automatic resource cleanup

### DIFF
--- a/cli/cmd/capture/capture.go
+++ b/cli/cmd/capture/capture.go
@@ -85,6 +85,7 @@ type Opts struct {
 	genericclioptions.ConfigFlags
 	Name               *string
 	blobUpload         string
+	cleanUpAfterUpload bool
 	debug              bool
 	duration           time.Duration
 	excludeFilter      string

--- a/cli/cmd/capture/cleanup_after_upload_test.go
+++ b/cli/cmd/capture/cleanup_after_upload_test.go
@@ -190,7 +190,7 @@ func TestCleanupAfterUpload_RespectsNoWait(t *testing.T) {
 
 func TestCleanupAfterUpload_DefaultIsFalse(t *testing.T) {
 	// Without --cleanup-after-upload flag, the default should be false
-	assert.Equal(t, false, DefaultCleanUpAfterUpload)
+	assert.False(t, DefaultCleanUpAfterUpload)
 }
 
 func TestCleanupAfterUpload_FlagRegistered(t *testing.T) {

--- a/cli/cmd/capture/cleanup_after_upload_test.go
+++ b/cli/cmd/capture/cleanup_after_upload_test.go
@@ -81,7 +81,7 @@ func TestCleanupAfterUpload_RequiresRemoteStorage(t *testing.T) {
 		"--name=test-cleanup",
 		"--namespace=default",
 		"--node-names=node1",
-		"--host-path=/tmp/captures",
+		"--host-path=captures",
 		"--cleanup-after-upload",
 		"--duration=5s",
 	})
@@ -276,7 +276,7 @@ func TestCleanupAfterUpload_NoTTLWhenHostPathOnly(t *testing.T) {
 		"--name=test-no-ttl",
 		"--namespace=default",
 		"--node-names=node1",
-		"--host-path=/tmp/captures",
+		"--host-path=captures",
 		"--no-wait=true",
 		"--duration=5s",
 	})

--- a/cli/cmd/capture/cleanup_after_upload_test.go
+++ b/cli/cmd/capture/cleanup_after_upload_test.go
@@ -1,0 +1,289 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package capture
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/microsoft/retina/pkg/label"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	clienttesting "k8s.io/client-go/testing"
+)
+
+func newFakeClientForCleanupTests() *fake.Clientset {
+	objects := []runtime.Object{
+		NewNode("node1"),
+		NewNamespace("default"),
+	}
+
+	kubeClient := fake.NewClientset(objects...)
+
+	// Handle job creation to set job name and quickly mark as completed
+	kubeClient.PrependReactor("create", "jobs", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+		createAction, ok := action.(clienttesting.CreateAction)
+		if !ok {
+			return false, nil, fmt.Errorf("expected CreateAction, got %T", action) //nolint:err113 // test code
+		}
+		job := createAction.GetObject().(*batchv1.Job)
+
+		// Set job name if unset
+		if job.Name == "" {
+			job.Name = job.GenerateName + randomString(5)
+		}
+		// Mark job as completed immediately for cleanup tests
+		now := metav1.Now()
+		job.Status.CompletionTime = &now
+		job.Status.Conditions = []batchv1.JobCondition{
+			{
+				Type:   batchv1.JobComplete,
+				Status: corev1.ConditionTrue,
+			},
+		}
+		return false, job, nil
+	})
+
+	// Handle secret creation to set name from GenerateName
+	kubeClient.PrependReactor("create", "secrets", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+		createAction, ok := action.(clienttesting.CreateAction)
+		if !ok {
+			return false, nil, fmt.Errorf("expected CreateAction, got %T", action) //nolint:err113 // test code
+		}
+		secret := createAction.GetObject().(*corev1.Secret)
+
+		// Set secret name if unset (mimics real k8s behavior with GenerateName)
+		if secret.Name == "" {
+			secret.Name = secret.GenerateName + randomString(5)
+		}
+		return false, secret, nil
+	})
+
+	return kubeClient
+}
+
+func TestCleanupAfterUpload_RequiresRemoteStorage(t *testing.T) {
+	// When --cleanup-after-upload is set without remote storage, it should fail
+	kubeClient := newFakeClientForCleanupTests()
+	cmd := NewCommand(kubeClient)
+
+	cmd.SetArgs([]string{
+		"create",
+		"--name=test-cleanup",
+		"--namespace=default",
+		"--node-names=node1",
+		"--host-path=/tmp/captures",
+		"--cleanup-after-upload",
+		"--duration=5s",
+	})
+
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--cleanup-after-upload requires remote storage (--blob-upload, --s3-bucket, or --pvc)")
+}
+
+func TestCleanupAfterUpload_WithBlobUpload(t *testing.T) {
+	// When --cleanup-after-upload is set with blob upload, command should succeed
+	// and jobs should be created (controller handles cleanup after upload)
+	kubeClient := newFakeClientForCleanupTests()
+	cmd := NewCommand(kubeClient)
+
+	cmd.SetArgs([]string{
+		"create",
+		"--name=test-cleanup-blob",
+		"--namespace=default",
+		"--node-names=node1",
+		"--blob-upload=https://testaccount.blob.core.windows.net/container?sv=2021-06-08&ss=b&srt=co&sp=rwdlacitfx&se=2099-01-01",
+		"--cleanup-after-upload",
+		"--duration=5s",
+	})
+
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	// Verify jobs were created (controller handles cleanup after upload completes)
+	jobs, err := kubeClient.BatchV1().Jobs("default").List(context.TODO(), metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", label.CaptureNameLabel, "test-cleanup-blob"),
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, jobs.Items, "jobs should be created for capture")
+}
+
+func TestCleanupAfterUpload_WithS3Upload(t *testing.T) {
+	// When --cleanup-after-upload is set with S3 upload, command should succeed
+	kubeClient := newFakeClientForCleanupTests()
+	cmd := NewCommand(kubeClient)
+
+	cmd.SetArgs([]string{
+		"create",
+		"--name=test-cleanup-s3",
+		"--namespace=default",
+		"--node-names=node1",
+		"--s3-bucket=test-bucket",
+		"--s3-region=us-east-1",
+		"--s3-access-key-id=AKIAIOSFODNN7EXAMPLE",
+		"--s3-secret-access-key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+		"--cleanup-after-upload",
+		"--duration=5s",
+	})
+
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	// Verify jobs were created (controller handles cleanup after upload completes)
+	jobs, err := kubeClient.BatchV1().Jobs("default").List(context.TODO(), metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", label.CaptureNameLabel, "test-cleanup-s3"),
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, jobs.Items, "jobs should be created for capture")
+}
+
+func TestCleanupAfterUpload_RespectsNoWait(t *testing.T) {
+	// When --cleanup-after-upload is set with --no-wait=true (default),
+	// the CLI should not block. TTL + owner refs handle cleanup.
+	kubeClient := newFakeClientForCleanupTests()
+	cmd := NewCommand(kubeClient)
+
+	cmd.SetArgs([]string{
+		"create",
+		"--name=test-cleanup-nowait",
+		"--namespace=default",
+		"--node-names=node1",
+		"--blob-upload=https://testaccount.blob.core.windows.net/container?sv=2021-06-08&ss=b&srt=co&sp=rwdlacitfx&se=2099-01-01",
+		"--cleanup-after-upload",
+		"--no-wait=true",
+		"--duration=5s",
+	})
+
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+
+	// Verify jobs still exist (CLI returns immediately in no-wait mode,
+	// TTL and owner references handle automatic cleanup)
+	jobs, err := kubeClient.BatchV1().Jobs("default").List(context.TODO(), metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", label.CaptureNameLabel, "test-cleanup-nowait"),
+	})
+	require.NoError(t, err)
+	assert.NotEmpty(t, jobs.Items, "jobs should exist because CLI returned immediately in no-wait mode")
+}
+
+func TestCleanupAfterUpload_DefaultIsFalse(t *testing.T) {
+	// Without --cleanup-after-upload flag, the default should be false
+	assert.Equal(t, false, DefaultCleanUpAfterUpload)
+}
+
+func TestCleanupAfterUpload_FlagRegistered(t *testing.T) {
+	// Verify the flag is properly registered on the create subcommand
+	kubeClient := fake.NewClientset()
+	cmd := NewCommand(kubeClient)
+
+	// Find the create subcommand
+	var createCmd *cobra.Command
+	for _, sub := range cmd.Commands() {
+		if sub.Name() == "create" {
+			createCmd = sub
+			break
+		}
+	}
+	require.NotNil(t, createCmd, "create subcommand should exist")
+
+	flag := createCmd.Flags().Lookup("cleanup-after-upload")
+	require.NotNil(t, flag, "cleanup-after-upload flag should be registered")
+	assert.Equal(t, "false", flag.DefValue)
+	assert.Contains(t, flag.Usage, "clean up capture jobs")
+}
+
+func TestCleanupAfterUpload_TTLSetInNoWaitMode(t *testing.T) {
+	// When --cleanup-after-upload with --no-wait=true and remote destination,
+	// jobs should have TTLSecondsAfterFinished set.
+	kubeClient := newFakeClientForCleanupTests()
+
+	var createdJob *batchv1.Job
+	kubeClient.PrependReactor("create", "jobs", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+		createAction := action.(clienttesting.CreateAction)
+		job := createAction.GetObject().(*batchv1.Job)
+		if job.Name == "" {
+			job.Name = job.GenerateName + "test3"
+		}
+		now := metav1.Now()
+		job.Status.CompletionTime = &now
+		createdJob = job
+		return false, job, nil
+	})
+
+	cmd := NewCommand(kubeClient)
+	cmd.SetArgs([]string{
+		"create",
+		"--name=test-ttl",
+		"--namespace=default",
+		"--node-names=node1",
+		"--blob-upload=https://testaccount.blob.core.windows.net/container?sv=2021-06-08",
+		"--cleanup-after-upload",
+		"--no-wait=true",
+		"--duration=5s",
+	})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	require.NotNil(t, createdJob)
+
+	require.NotNil(t, createdJob.Spec.TTLSecondsAfterFinished, "TTL should be set in no-wait mode with remote destination")
+	assert.Equal(t, JobTTLSecondsAfterFinished, *createdJob.Spec.TTLSecondsAfterFinished)
+}
+
+func TestCleanupAfterUpload_NoTTLWhenHostPathOnly(t *testing.T) {
+	// When only host-path is configured (no remote), TTL should NOT be set
+	// even in no-wait mode, because the user needs the job to find their capture file.
+	kubeClient := newFakeClientForCleanupTests()
+
+	var createdJob *batchv1.Job
+	kubeClient.PrependReactor("create", "jobs", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+		createAction := action.(clienttesting.CreateAction)
+		job := createAction.GetObject().(*batchv1.Job)
+		if job.Name == "" {
+			job.Name = job.GenerateName + "test4"
+		}
+		now := metav1.Now()
+		job.Status.CompletionTime = &now
+		createdJob = job
+		return false, job, nil
+	})
+
+	cmd := NewCommand(kubeClient)
+	cmd.SetArgs([]string{
+		"create",
+		"--name=test-no-ttl",
+		"--namespace=default",
+		"--node-names=node1",
+		"--host-path=/tmp/captures",
+		"--no-wait=true",
+		"--duration=5s",
+	})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	require.NotNil(t, createdJob)
+
+	assert.Nil(t, createdJob.Spec.TTLSecondsAfterFinished, "TTL should NOT be set when only host-path is configured")
+}

--- a/cli/cmd/capture/create.go
+++ b/cli/cmd/capture/create.go
@@ -19,6 +19,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubectl/pkg/util/i18n"
@@ -63,6 +64,14 @@ const (
 	// the Job's activeDeadlineSeconds. This buffer accounts for output upload
 	// and cleanup time after the capture itself finishes.
 	JobActiveDeadlineBufferSeconds int64 = 1800 // 30 minutes
+
+	// WaitDeadlineBuffer is extra time added to the capture duration when
+	// computing the wait deadline, to account for upload and scheduling overhead.
+	WaitDeadlineBuffer time.Duration = 5 * time.Minute
+
+	// MinPollAttempts is the minimum number of polling iterations before the
+	// wait deadline expires. Used to compute a fallback poll period.
+	MinPollAttempts = 4
 )
 
 var errCleanupRequiresRemoteStorage = errors.New("--cleanup-after-upload requires remote storage (--blob-upload, --s3-bucket, or --pvc)")
@@ -666,7 +675,7 @@ func waitUntilJobsComplete(ctx context.Context, kubeClient kubernetes.Interface,
 	if opts.duration != 0 {
 		// Allow time for capture + upload + scheduling overhead (Windows
 		// nodes in particular need extra time for image pull and pod start).
-		deadline = opts.duration + 5*time.Minute
+		deadline = opts.duration + WaitDeadlineBuffer
 		if deadline < DefaultWaitTimeout {
 			deadline = DefaultWaitTimeout
 		}
@@ -679,7 +688,7 @@ func waitUntilJobsComplete(ctx context.Context, kubeClient kubernetes.Interface,
 	}
 	// Ensure poll period is less than the deadline so we get multiple checks.
 	if period >= deadline {
-		period = deadline / 4
+		period = deadline / MinPollAttempts
 	}
 	retinacmd.Logger.Info(fmt.Sprintf("Waiting timeout is set to %s", deadline))
 
@@ -756,7 +765,7 @@ func setSecretOwnerReferences(ctx context.Context, kubeClient kubernetes.Interfa
 	ownerRefs := make([]metav1.OwnerReference, 0, len(jobs))
 	for i := range jobs {
 		ownerRefs = append(ownerRefs, metav1.OwnerReference{
-			APIVersion: "batch/v1",
+			APIVersion: batchv1.SchemeGroupVersion.String(),
 			Kind:       "Job",
 			Name:       jobs[i].Name,
 			UID:        jobs[i].UID,
@@ -768,7 +777,16 @@ func setSecretOwnerReferences(ctx context.Context, kubeClient kubernetes.Interfa
 		if err != nil {
 			return fmt.Errorf("failed to get secret %s: %w", secretName, err)
 		}
-		secret.OwnerReferences = append(secret.OwnerReferences, ownerRefs...)
+		// Deduplicate owner references to avoid appending the same refs on retries.
+		existing := make(map[types.UID]struct{}, len(secret.OwnerReferences))
+		for _, ref := range secret.OwnerReferences {
+			existing[ref.UID] = struct{}{}
+		}
+		for _, ref := range ownerRefs {
+			if _, found := existing[ref.UID]; !found {
+				secret.OwnerReferences = append(secret.OwnerReferences, ref)
+			}
+		}
 		if _, err := kubeClient.CoreV1().Secrets(*opts.Namespace).Update(ctx, secret, metav1.UpdateOptions{}); err != nil {
 			return fmt.Errorf("failed to update secret %s with owner references: %w", secretName, err)
 		}

--- a/cli/cmd/capture/create.go
+++ b/cli/cmd/capture/create.go
@@ -36,9 +36,9 @@ import (
 )
 
 const (
-	DefaultCleanUpAfterUpload bool        = false
-	DefaultDebug    bool          = false
-	DefaultDuration time.Duration = 1 * time.Minute
+	DefaultCleanUpAfterUpload bool          = false
+	DefaultDebug              bool          = false
+	DefaultDuration           time.Duration = 1 * time.Minute
 	// DefaultHostPath is the default subpath (joined under DefaultHostPathBaseDir on
 	// the node) where capture artifacts are stored. It is a bare name, not an
 	// absolute path: absolute paths are rejected by the operator.
@@ -161,12 +161,10 @@ func create(kubeClient kubernetes.Interface) error {
 	}
 
 	if opts.nowait {
-		retinacmd.Logger.Info("Please manually delete all capture jobs")
-		if capture.Spec.OutputConfiguration.BlobUpload != nil {
-			retinacmd.Logger.Info("Please manually delete capture secret", zap.String("namespace", *opts.Namespace), zap.String("secret name", *capture.Spec.OutputConfiguration.BlobUpload))
-		}
-		if capture.Spec.OutputConfiguration.S3Upload != nil && capture.Spec.OutputConfiguration.S3Upload.SecretName != "" {
-			retinacmd.Logger.Info("Please manually delete capture secret", zap.String("namespace", *opts.Namespace), zap.String("secret name", capture.Spec.OutputConfiguration.S3Upload.SecretName))
+		if opts.cleanUpAfterUpload && hasRemoteDestination(&opts) {
+			retinacmd.Logger.Info("Capture jobs will be automatically cleaned up after upload (TTL-based)")
+		} else {
+			retinacmd.Logger.Info("Please manually delete all capture jobs (associated secrets will be garbage-collected automatically)")
 		}
 		printCaptureResult(jobsCreated)
 		return nil

--- a/cli/cmd/capture/create.go
+++ b/cli/cmd/capture/create.go
@@ -16,8 +16,8 @@ import (
 	"go.uber.org/zap"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	DefaultCleanUpAfterUpload bool          = false
+	DefaultCleanUpAfterUpload bool        = false
 	DefaultDebug    bool          = false
 	DefaultDuration time.Duration = 1 * time.Minute
 	// DefaultHostPath is the default subpath (joined under DefaultHostPathBaseDir on
@@ -64,6 +64,8 @@ const (
 	// and cleanup time after the capture itself finishes.
 	JobActiveDeadlineBufferSeconds int64 = 1800 // 30 minutes
 )
+
+var errCleanupRequiresRemoteStorage = errors.New("--cleanup-after-upload requires remote storage (--blob-upload, --s3-bucket, or --pvc)")
 
 // hasRemoteDestination returns true if the capture options specify a remote
 // storage output (blob upload or S3 upload).
@@ -133,7 +135,7 @@ func create(kubeClient kubernetes.Interface) error {
 
 	if opts.cleanUpAfterUpload {
 		if !hasRemoteDestination(&opts) {
-			return fmt.Errorf("--cleanup-after-upload requires remote storage (--blob-upload, --s3-bucket, or --pvc)")
+			return errCleanupRequiresRemoteStorage
 		}
 	}
 
@@ -145,8 +147,8 @@ func create(kubeClient kubernetes.Interface) error {
 
 	// Set owner references on secrets so they are garbage-collected when the
 	// jobs are removed (by TTL, explicit deletion, or manual kubectl delete).
-	if err := setSecretOwnerReferences(ctx, kubeClient, capture, jobsCreated); err != nil {
-		retinacmd.Logger.Error("Failed to set owner references on capture secrets", zap.Error(err))
+	if ownerRefErr := setSecretOwnerReferences(ctx, kubeClient, capture, jobsCreated); ownerRefErr != nil {
+		retinacmd.Logger.Error("Failed to set owner references on capture secrets", zap.Error(ownerRefErr))
 	}
 
 	if opts.nowait {
@@ -301,7 +303,8 @@ func NewCreateSubCommand(kubeClient kubernetes.Interface) *cobra.Command {
 	createCapture.Flags().BoolVar(&opts.includeMetadata, "include-metadata", DefaultIncludeMetadata, "If true, collect static network metadata into capture file")
 	createCapture.Flags().IntVar(&opts.jobNumLimit, "job-num-limit", DefaultJobNumLimit, "The maximum number of jobs can be created for each capture. 0 means no limit")
 	createCapture.Flags().BoolVar(&opts.nowait, "no-wait", DefaultNowait, "Do not wait for the long-running capture job to finish")
-	createCapture.Flags().BoolVar(&opts.cleanUpAfterUpload, "cleanup-after-upload", DefaultCleanUpAfterUpload, "Automatically clean up capture jobs and resources from the cluster after successful upload to remote storage (blob or S3)")
+	createCapture.Flags().BoolVar(&opts.cleanUpAfterUpload, "cleanup-after-upload", DefaultCleanUpAfterUpload,
+		"Automatically clean up capture jobs and resources after successful upload to remote storage")
 	createCapture.Flags().BoolVar(&opts.debug, "debug", DefaultDebug, "When debug is true, a customized retina-agent image, determined by the environment variable RETINA_AGENT_IMAGE, is set")
 
 	return createCapture

--- a/cli/cmd/capture/create.go
+++ b/cli/cmd/capture/create.go
@@ -17,6 +17,7 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
@@ -34,6 +35,7 @@ import (
 )
 
 const (
+	DefaultCleanUpAfterUpload bool          = false
 	DefaultDebug    bool          = false
 	DefaultDuration time.Duration = 1 * time.Minute
 	// DefaultHostPath is the default subpath (joined under DefaultHostPathBaseDir on
@@ -52,7 +54,22 @@ const (
 	DefaultS3Path          string        = "retina/captures"
 	DefaultWaitPeriod      time.Duration = 1 * time.Minute
 	DefaultWaitTimeout     time.Duration = 5 * time.Minute
+
+	// JobTTLSecondsAfterFinished is how long completed/failed jobs and their
+	// pods are kept before Kubernetes garbage-collects them (no-wait mode).
+	JobTTLSecondsAfterFinished int32 = 300 // 5 minutes
+
+	// JobActiveDeadlineBufferSeconds is added to the capture duration to form
+	// the Job's activeDeadlineSeconds. This buffer accounts for output upload
+	// and cleanup time after the capture itself finishes.
+	JobActiveDeadlineBufferSeconds int64 = 1800 // 30 minutes
 )
+
+// hasRemoteDestination returns true if the capture options specify a remote
+// storage output (blob upload or S3 upload).
+func hasRemoteDestination(o *Opts) bool {
+	return o.blobUpload != "" || o.s3Bucket != "" || o.pvc != ""
+}
 
 var createExample = templates.Examples(i18n.T(`
 		# Select nodes by node name and copy the artifacts to the node host path
@@ -114,11 +131,24 @@ func create(kubeClient kubernetes.Interface) error {
 		return err
 	}
 
+	if opts.cleanUpAfterUpload {
+		if !hasRemoteDestination(&opts) {
+			return fmt.Errorf("--cleanup-after-upload requires remote storage (--blob-upload, --s3-bucket, or --pvc)")
+		}
+	}
+
 	jobsCreated, err := createJobs(ctx, kubeClient, capture)
 	if err != nil {
 		retinacmd.Logger.Error("Failed to create job", zap.Error(err))
 		return err
 	}
+
+	// Set owner references on secrets so they are garbage-collected when the
+	// jobs are removed (by TTL, explicit deletion, or manual kubectl delete).
+	if err := setSecretOwnerReferences(ctx, kubeClient, capture, jobsCreated); err != nil {
+		retinacmd.Logger.Error("Failed to set owner references on capture secrets", zap.Error(err))
+	}
+
 	if opts.nowait {
 		retinacmd.Logger.Info("Please manually delete all capture jobs")
 		if capture.Spec.OutputConfiguration.BlobUpload != nil {
@@ -271,6 +301,7 @@ func NewCreateSubCommand(kubeClient kubernetes.Interface) *cobra.Command {
 	createCapture.Flags().BoolVar(&opts.includeMetadata, "include-metadata", DefaultIncludeMetadata, "If true, collect static network metadata into capture file")
 	createCapture.Flags().IntVar(&opts.jobNumLimit, "job-num-limit", DefaultJobNumLimit, "The maximum number of jobs can be created for each capture. 0 means no limit")
 	createCapture.Flags().BoolVar(&opts.nowait, "no-wait", DefaultNowait, "Do not wait for the long-running capture job to finish")
+	createCapture.Flags().BoolVar(&opts.cleanUpAfterUpload, "cleanup-after-upload", DefaultCleanUpAfterUpload, "Automatically clean up capture jobs and resources from the cluster after successful upload to remote storage (blob or S3)")
 	createCapture.Flags().BoolVar(&opts.debug, "debug", DefaultDebug, "When debug is true, a customized retina-agent image, determined by the environment variable RETINA_AGENT_IMAGE, is set")
 
 	return createCapture
@@ -322,7 +353,11 @@ func deleteSecret(ctx context.Context, kubeClient kubernetes.Interface, secretNa
 		return nil
 	}
 
-	return kubeClient.CoreV1().Secrets(*opts.Namespace).Delete(ctx, *secretName, metav1.DeleteOptions{}) //nolint:wrapcheck //internal return
+	err := kubeClient.CoreV1().Secrets(*opts.Namespace).Delete(ctx, *secretName, metav1.DeleteOptions{})
+	if k8serrors.IsNotFound(err) {
+		return nil
+	}
+	return err //nolint:wrapcheck //internal return
 }
 
 // validateBPFFilter checks that a BPF filter string doesn't contain flags (tokens starting with '-').
@@ -571,6 +606,8 @@ func createCaptureF(ctx context.Context, kubeClient kubernetes.Interface) (*reti
 		includeFilterSlice := strings.Split(opts.includeFilter, ",")
 		capture.Spec.CaptureConfiguration.Filters.Include = includeFilterSlice
 	}
+
+	capture.Spec.CleanUpAfterUpload = opts.cleanUpAfterUpload
 	return capture, nil
 }
 
@@ -593,6 +630,21 @@ func createJobs(ctx context.Context, kubeClient kubernetes.Interface, capture *r
 
 	jobsCreated := []batchv1.Job{}
 	for _, job := range jobs {
+		// In no-wait mode with a remote destination, set TTL so Kubernetes
+		// auto-deletes completed jobs and their pods. When host-path only,
+		// the job metadata is needed to locate the capture file.
+		if opts.nowait && opts.cleanUpAfterUpload && hasRemoteDestination(&opts) {
+			ttl := JobTTLSecondsAfterFinished
+			job.Spec.TTLSecondsAfterFinished = &ttl
+		}
+
+		// Set a hard deadline to prevent jobs from running indefinitely if the
+		// capture process hangs. Deadline = capture duration + upload buffer.
+		if opts.duration > 0 {
+			deadline := int64(opts.duration.Seconds()) + JobActiveDeadlineBufferSeconds
+			job.Spec.ActiveDeadlineSeconds = &deadline
+		}
+
 		jobCreated, err := kubeClient.BatchV1().Jobs(*opts.Namespace).Create(ctx, job, metav1.CreateOptions{})
 		if err != nil {
 			return nil, err
@@ -609,13 +661,22 @@ func waitUntilJobsComplete(ctx context.Context, kubeClient kubernetes.Interface,
 	// TODO: let's make the timeout and period to wait for all job to finish configurable.
 	deadline := DefaultWaitTimeout
 	if opts.duration != 0 {
-		deadline = opts.duration * 2
+		// Allow time for capture + upload + scheduling overhead (Windows
+		// nodes in particular need extra time for image pull and pod start).
+		deadline = opts.duration + 5*time.Minute
+		if deadline < DefaultWaitTimeout {
+			deadline = DefaultWaitTimeout
+		}
 	}
 
 	period := DefaultWaitPeriod
 	// To print less noisy messages, we rely on duration to decide the wait period.
 	if period < opts.duration/10 {
 		period = opts.duration / 10
+	}
+	// Ensure poll period is less than the deadline so we get multiple checks.
+	if period >= deadline {
+		period = deadline / 4
 	}
 	retinacmd.Logger.Info(fmt.Sprintf("Waiting timeout is set to %s", deadline))
 
@@ -671,4 +732,43 @@ func deleteJobs(ctx context.Context, kubeClient kubernetes.Interface, jobs []bat
 		}
 	}
 	return jobsFailedtoDelete
+}
+
+// setSecretOwnerReferences adds ownerReferences from the given jobs to the
+// secrets used by the capture (blob or S3). This ensures secrets are garbage-
+// collected when the owning jobs are deleted (by TTL or explicitly).
+func setSecretOwnerReferences(ctx context.Context, kubeClient kubernetes.Interface, capture *retinav1alpha1.Capture, jobs []batchv1.Job) error {
+	var secretNames []string
+	if capture.Spec.OutputConfiguration.BlobUpload != nil {
+		secretNames = append(secretNames, *capture.Spec.OutputConfiguration.BlobUpload)
+	}
+	if capture.Spec.OutputConfiguration.S3Upload != nil && capture.Spec.OutputConfiguration.S3Upload.SecretName != "" {
+		secretNames = append(secretNames, capture.Spec.OutputConfiguration.S3Upload.SecretName)
+	}
+
+	if len(secretNames) == 0 || len(jobs) == 0 {
+		return nil
+	}
+
+	ownerRefs := make([]metav1.OwnerReference, 0, len(jobs))
+	for i := range jobs {
+		ownerRefs = append(ownerRefs, metav1.OwnerReference{
+			APIVersion: "batch/v1",
+			Kind:       "Job",
+			Name:       jobs[i].Name,
+			UID:        jobs[i].UID,
+		})
+	}
+
+	for _, secretName := range secretNames {
+		secret, err := kubeClient.CoreV1().Secrets(*opts.Namespace).Get(ctx, secretName, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to get secret %s: %w", secretName, err)
+		}
+		secret.OwnerReferences = append(secret.OwnerReferences, ownerRefs...)
+		if _, err := kubeClient.CoreV1().Secrets(*opts.Namespace).Update(ctx, secret, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("failed to update secret %s with owner references: %w", secretName, err)
+		}
+	}
+	return nil
 }

--- a/cli/cmd/capture/create_test.go
+++ b/cli/cmd/capture/create_test.go
@@ -674,3 +674,338 @@ func TestCreateCaptureCommand_AbsoluteHostPath_ShouldFail(t *testing.T) {
 	require.Contains(t, err.Error(), "OutputConfiguration.HostPath",
 		"error should reference the rejected HostPath field; got: %v", err)
 }
+func TestHasRemoteDestination(t *testing.T) {
+	tests := []struct {
+		name string
+		opts Opts
+		want bool
+	}{
+		{
+			name: "blob upload is remote",
+			opts: Opts{blobUpload: "https://account.blob.core.windows.net/container"},
+			want: true,
+		},
+		{
+			name: "s3 bucket is remote",
+			opts: Opts{s3Bucket: "my-bucket"},
+			want: true,
+		},
+		{
+			name: "pvc is remote",
+			opts: Opts{pvc: "my-pvc"},
+			want: true,
+		},
+		{
+			name: "host-path only is not remote",
+			opts: Opts{hostPath: "/mnt/captures"},
+			want: false,
+		},
+		{
+			name: "empty opts is not remote",
+			opts: Opts{},
+			want: false,
+		},
+		{
+			name: "multiple remote destinations",
+			opts: Opts{blobUpload: "https://x.blob.core.windows.net/c", s3Bucket: "bucket"},
+			want: true,
+		},
+	}
+
+	for i := range tests {
+		t.Run(tests[i].name, func(t *testing.T) {
+			require.Equal(t, tests[i].want, hasRemoteDestination(&tests[i].opts))
+		})
+	}
+}
+
+
+func TestSetSecretOwnerReferences(t *testing.T) {
+	ns := "test-ns"
+	secretName := "blob-secret-abc"
+
+	kubeClient := fake.NewClientset(
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: ns,
+			},
+		},
+	)
+
+	origNs := opts.Namespace
+	opts.Namespace = &ns
+	defer func() { opts.Namespace = origNs }()
+
+	blobUpload := secretName
+	capture := &retinav1alpha1.Capture{
+		Spec: retinav1alpha1.CaptureSpec{
+			OutputConfiguration: retinav1alpha1.OutputConfiguration{
+				BlobUpload: &blobUpload,
+			},
+		},
+	}
+
+	jobs := []batchv1.Job{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "job-1",
+				Namespace: ns,
+				UID:       "uid-1",
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "job-2",
+				Namespace: ns,
+				UID:       "uid-2",
+			},
+		},
+	}
+
+	err := setSecretOwnerReferences(context.Background(), kubeClient, capture, jobs)
+	require.NoError(t, err)
+
+	secret, err := kubeClient.CoreV1().Secrets(ns).Get(context.Background(), secretName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Len(t, secret.OwnerReferences, 2, "secret should have owner references for both jobs")
+	require.Equal(t, "job-1", secret.OwnerReferences[0].Name)
+	require.Equal(t, "job-2", secret.OwnerReferences[1].Name)
+	require.Equal(t, "batch/v1", secret.OwnerReferences[0].APIVersion)
+	require.Equal(t, "Job", secret.OwnerReferences[0].Kind)
+}
+
+func TestSetSecretOwnerReferences_NoSecrets(t *testing.T) {
+	kubeClient := fake.NewClientset()
+
+	capture := &retinav1alpha1.Capture{
+		Spec: retinav1alpha1.CaptureSpec{
+			OutputConfiguration: retinav1alpha1.OutputConfiguration{},
+		},
+	}
+
+	err := setSecretOwnerReferences(context.Background(), kubeClient, capture, []batchv1.Job{})
+	require.NoError(t, err)
+}
+
+func TestSetSecretOwnerReferences_S3Secret(t *testing.T) {
+	ns := "test-ns"
+	secretName := "s3-secret-xyz"
+
+	kubeClient := fake.NewClientset(
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: ns,
+			},
+		},
+	)
+
+	origNs := opts.Namespace
+	opts.Namespace = &ns
+	defer func() { opts.Namespace = origNs }()
+
+	capture := &retinav1alpha1.Capture{
+		Spec: retinav1alpha1.CaptureSpec{
+			OutputConfiguration: retinav1alpha1.OutputConfiguration{
+				S3Upload: &retinav1alpha1.S3Upload{
+					SecretName: secretName,
+					Bucket:     "my-bucket",
+				},
+			},
+		},
+	}
+
+	jobs := []batchv1.Job{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "job-a",
+				Namespace: ns,
+				UID:       "uid-a",
+			},
+		},
+	}
+
+	err := setSecretOwnerReferences(context.Background(), kubeClient, capture, jobs)
+	require.NoError(t, err)
+
+	secret, err := kubeClient.CoreV1().Secrets(ns).Get(context.Background(), secretName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Len(t, secret.OwnerReferences, 1, "secret should have owner reference for the job")
+	require.Equal(t, "job-a", secret.OwnerReferences[0].Name)
+	require.Equal(t, "batch/v1", secret.OwnerReferences[0].APIVersion)
+	require.Equal(t, "Job", secret.OwnerReferences[0].Kind)
+}
+
+func TestDeleteSecret_NotFound(t *testing.T) {
+	// deleteSecret should return nil when the secret doesn't exist
+	ns := "test-ns"
+	kubeClient := fake.NewClientset() // no secrets pre-created
+
+	origNs := opts.Namespace
+	opts.Namespace = &ns
+	defer func() { opts.Namespace = origNs }()
+
+	name := "nonexistent-secret"
+	err := deleteSecret(context.Background(), kubeClient, &name)
+	require.NoError(t, err, "deleteSecret should not error on NotFound")
+}
+
+func TestDeleteSecret_NilName(t *testing.T) {
+	ns := "test-ns"
+	kubeClient := fake.NewClientset()
+
+	origNs := opts.Namespace
+	opts.Namespace = &ns
+	defer func() { opts.Namespace = origNs }()
+
+	err := deleteSecret(context.Background(), kubeClient, nil)
+	require.NoError(t, err, "deleteSecret should return nil for nil secretName")
+}
+
+func TestDeleteSecret_ExistingSecret(t *testing.T) {
+	// deleteSecret should succeed when the secret exists
+	ns := "test-ns"
+	secretName := "my-secret"
+	kubeClient := fake.NewClientset(
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: ns,
+			},
+		},
+	)
+
+	origNs := opts.Namespace
+	opts.Namespace = &ns
+	defer func() { opts.Namespace = origNs }()
+
+	err := deleteSecret(context.Background(), kubeClient, &secretName)
+	require.NoError(t, err)
+
+	// Verify secret is deleted
+	_, err = kubeClient.CoreV1().Secrets(ns).Get(context.Background(), secretName, metav1.GetOptions{})
+	require.Error(t, err, "secret should be gone after deleteSecret")
+}
+
+func TestCreateJobs_ActiveDeadlineSeconds(t *testing.T) {
+	// When duration > 0, jobs should have ActiveDeadlineSeconds set
+	kubeClient := newFakeClientForCleanupTests()
+
+	var createdJob *batchv1.Job
+	kubeClient.PrependReactor("create", "jobs", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+		createAction := action.(clienttesting.CreateAction)
+		job := createAction.GetObject().(*batchv1.Job)
+		if job.Name == "" {
+			job.Name = job.GenerateName + "test"
+		}
+		now := metav1.Now()
+		job.Status.CompletionTime = &now
+		createdJob = job
+		return false, job, nil
+	})
+
+	cmd := NewCommand(kubeClient)
+	cmd.SetArgs([]string{
+		"create",
+		"--name=test-deadline",
+		"--namespace=default",
+		"--node-names=node1",
+		"--host-path=/tmp/captures",
+		"--no-wait=true",
+		"--duration=60s",
+	})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	require.NotNil(t, createdJob)
+	require.NotNil(t, createdJob.Spec.ActiveDeadlineSeconds,
+		"ActiveDeadlineSeconds should be set when duration > 0")
+	// 60s + 1800s buffer = 1860
+	require.Equal(t, int64(1860), *createdJob.Spec.ActiveDeadlineSeconds)
+}
+
+func TestCreateJobs_NoTTLWithoutCleanupFlag(t *testing.T) {
+	// When --cleanup-after-upload is NOT set, TTL should NOT be set
+	// even with remote + no-wait.
+	kubeClient := newFakeClientForCleanupTests()
+
+	var createdJob *batchv1.Job
+	kubeClient.PrependReactor("create", "jobs", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+		createAction := action.(clienttesting.CreateAction)
+		job := createAction.GetObject().(*batchv1.Job)
+		if job.Name == "" {
+			job.Name = job.GenerateName + "test"
+		}
+		now := metav1.Now()
+		job.Status.CompletionTime = &now
+		createdJob = job
+		return false, job, nil
+	})
+
+	cmd := NewCommand(kubeClient)
+	cmd.SetArgs([]string{
+		"create",
+		"--name=test-no-cleanup",
+		"--namespace=default",
+		"--node-names=node1",
+		"--blob-upload=https://testaccount.blob.core.windows.net/container?sv=2021-06-08",
+		"--no-wait=true",
+		"--duration=5s",
+		// NOTE: --cleanup-after-upload is NOT set
+	})
+
+	err := cmd.Execute()
+	require.NoError(t, err)
+	require.NotNil(t, createdJob)
+	require.Nil(t, createdJob.Spec.TTLSecondsAfterFinished,
+		"TTL should NOT be set without --cleanup-after-upload")
+}
+
+func TestWaitUntilJobsComplete_ShortDuration(t *testing.T) {
+	// Verifies that waitUntilJobsComplete uses a deadline of at least
+	// DefaultWaitTimeout (5min), and completes quickly when jobs are already done.
+	// This exercises the deadline calculation (duration + 5min, floored at DefaultWaitTimeout)
+	// and the period clamping logic.
+	kubeClient := newFakeClientForCleanupTests()
+
+	// The fake client's reactor already marks jobs as completed on create.
+	// For the "get" call inside waitUntilJobsComplete, we need the job to appear completed.
+	kubeClient.PrependReactor("get", "jobs", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+		getAction := action.(clienttesting.GetAction)
+		job := &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      getAction.GetName(),
+				Namespace: getAction.GetNamespace(),
+			},
+			Status: batchv1.JobStatus{
+				CompletionTime: &metav1.Time{},
+				Conditions: []batchv1.JobCondition{
+					{
+						Type:   batchv1.JobComplete,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		}
+		return true, job, nil
+	})
+
+	cmd := NewCommand(kubeClient)
+	cmd.SetArgs([]string{
+		"create",
+		"--name=test-wait-short",
+		"--namespace=default",
+		"--node-names=node1",
+		"--host-path=/tmp/captures",
+		"--no-wait=false",
+		"--duration=2s",
+	})
+
+	// This should complete quickly (within seconds) because the fake client
+	// reports jobs as already completed. If the deadline/period logic is broken,
+	// this would hang until the test timeout.
+	err := cmd.Execute()
+	require.NoError(t, err)
+}
+

--- a/cli/cmd/capture/create_test.go
+++ b/cli/cmd/capture/create_test.go
@@ -776,6 +776,53 @@ func TestSetSecretOwnerReferences(t *testing.T) {
 	require.Equal(t, "Job", secret.OwnerReferences[0].Kind)
 }
 
+func TestSetSecretOwnerReferences_Idempotent(t *testing.T) {
+	ns := testNamespace
+	secretName := "blob-secret-idem"
+
+	kubeClient := fake.NewClientset(
+		&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: ns,
+			},
+		},
+	)
+
+	origNs := opts.Namespace
+	opts.Namespace = &ns
+	defer func() { opts.Namespace = origNs }()
+
+	blobUpload := secretName
+	capture := &retinav1alpha1.Capture{
+		Spec: retinav1alpha1.CaptureSpec{
+			OutputConfiguration: retinav1alpha1.OutputConfiguration{
+				BlobUpload: &blobUpload,
+			},
+		},
+	}
+
+	jobs := []batchv1.Job{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "job-1",
+				Namespace: ns,
+				UID:       "uid-1",
+			},
+		},
+	}
+
+	// Call twice to simulate retry/re-reconcile.
+	err := setSecretOwnerReferences(context.Background(), kubeClient, capture, jobs)
+	require.NoError(t, err)
+	err = setSecretOwnerReferences(context.Background(), kubeClient, capture, jobs)
+	require.NoError(t, err)
+
+	secret, err := kubeClient.CoreV1().Secrets(ns).Get(context.Background(), secretName, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Len(t, secret.OwnerReferences, 1, "duplicate owner references should not be added")
+}
+
 func TestSetSecretOwnerReferences_NoSecrets(t *testing.T) {
 	kubeClient := fake.NewClientset()
 

--- a/cli/cmd/capture/create_test.go
+++ b/cli/cmd/capture/create_test.go
@@ -24,6 +24,8 @@ import (
 	clienttesting "k8s.io/client-go/testing"
 )
 
+const testNamespace = "test-ns"
+
 type testcase struct {
 	name              string
 	inputName         string
@@ -719,9 +721,8 @@ func TestHasRemoteDestination(t *testing.T) {
 	}
 }
 
-
 func TestSetSecretOwnerReferences(t *testing.T) {
-	ns := "test-ns"
+	ns := testNamespace
 	secretName := "blob-secret-abc"
 
 	kubeClient := fake.NewClientset(
@@ -789,7 +790,7 @@ func TestSetSecretOwnerReferences_NoSecrets(t *testing.T) {
 }
 
 func TestSetSecretOwnerReferences_S3Secret(t *testing.T) {
-	ns := "test-ns"
+	ns := testNamespace
 	secretName := "s3-secret-xyz"
 
 	kubeClient := fake.NewClientset(
@@ -839,7 +840,7 @@ func TestSetSecretOwnerReferences_S3Secret(t *testing.T) {
 
 func TestDeleteSecret_NotFound(t *testing.T) {
 	// deleteSecret should return nil when the secret doesn't exist
-	ns := "test-ns"
+	ns := testNamespace
 	kubeClient := fake.NewClientset() // no secrets pre-created
 
 	origNs := opts.Namespace
@@ -852,7 +853,7 @@ func TestDeleteSecret_NotFound(t *testing.T) {
 }
 
 func TestDeleteSecret_NilName(t *testing.T) {
-	ns := "test-ns"
+	ns := testNamespace
 	kubeClient := fake.NewClientset()
 
 	origNs := opts.Namespace
@@ -865,7 +866,7 @@ func TestDeleteSecret_NilName(t *testing.T) {
 
 func TestDeleteSecret_ExistingSecret(t *testing.T) {
 	// deleteSecret should succeed when the secret exists
-	ns := "test-ns"
+	ns := testNamespace
 	secretName := "my-secret"
 	kubeClient := fake.NewClientset(
 		&corev1.Secret{
@@ -1008,4 +1009,3 @@ func TestWaitUntilJobsComplete_ShortDuration(t *testing.T) {
 	err := cmd.Execute()
 	require.NoError(t, err)
 }
-

--- a/cli/cmd/capture/create_test.go
+++ b/cli/cmd/capture/create_test.go
@@ -959,7 +959,7 @@ func TestCreateJobs_ActiveDeadlineSeconds(t *testing.T) {
 		"--name=test-deadline",
 		"--namespace=default",
 		"--node-names=node1",
-		"--host-path=/tmp/captures",
+		"--host-path=captures",
 		"--no-wait=true",
 		"--duration=60s",
 	})
@@ -1045,7 +1045,7 @@ func TestWaitUntilJobsComplete_ShortDuration(t *testing.T) {
 		"--name=test-wait-short",
 		"--namespace=default",
 		"--node-names=node1",
-		"--host-path=/tmp/captures",
+		"--host-path=captures",
 		"--no-wait=false",
 		"--duration=2s",
 	})

--- a/cli/cmd/capture/delete.go
+++ b/cli/cmd/capture/delete.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
@@ -77,7 +78,9 @@ func NewDeleteSubCommand(kubeClient kubernetes.Interface) *cobra.Command {
 			for idx := range jobList.Items[0].Spec.Template.Spec.Volumes {
 				if jobList.Items[0].Spec.Template.Spec.Volumes[idx].Secret != nil {
 					if err := kubeClient.CoreV1().Secrets(*opts.Namespace).Delete(ctx, jobList.Items[0].Spec.Template.Spec.Volumes[idx].Secret.SecretName, metav1.DeleteOptions{}); err != nil {
-						return errors.Wrap(err, "failed to delete capture secret")
+						if !k8serrors.IsNotFound(err) {
+							return errors.Wrap(err, "failed to delete capture secret")
+						}
 					}
 					break
 				}

--- a/cli/cmd/capture/delete_test.go
+++ b/cli/cmd/capture/delete_test.go
@@ -195,7 +195,7 @@ func TestDeleteCaptureJobs(t *testing.T) {
 func TestDeleteCaptureJobs_SecretAlreadyDeleted(t *testing.T) {
 	// When a secret referenced by a job's volume has already been deleted
 	// (e.g. via ownerRef GC), the delete command should still succeed.
-	captureName := "test-secret-gone"
+	deleteTestCapName := "test-secret-gone"
 	ns := "default"
 
 	kubeClient := newKubeclient()
@@ -204,10 +204,10 @@ func TestDeleteCaptureJobs_SecretAlreadyDeleted(t *testing.T) {
 	secretName := "already-deleted-secret"
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      captureName + "-node1-abcde",
+			Name:      deleteTestCapName + "-node1-abcde",
 			Namespace: ns,
 			Labels: map[string]string{
-				label.CaptureNameLabel: captureName,
+				label.CaptureNameLabel: deleteTestCapName,
 				label.AppLabel:         "capture",
 			},
 		},
@@ -238,7 +238,7 @@ func TestDeleteCaptureJobs_SecretAlreadyDeleted(t *testing.T) {
 
 	// Run delete — the secret doesn't exist, so the NotFound check is exercised
 	deleteCmd := NewCommand(kubeClient)
-	deleteCmd.SetArgs([]string{"delete", "--name", captureName, "--namespace", ns})
+	deleteCmd.SetArgs([]string{"delete", "--name", deleteTestCapName, "--namespace", ns})
 	buf := new(bytes.Buffer)
 	deleteCmd.SetOut(buf)
 
@@ -248,7 +248,7 @@ func TestDeleteCaptureJobs_SecretAlreadyDeleted(t *testing.T) {
 	}
 
 	// Verify job was deleted
-	if jobExists(t, kubeClient, captureName, ns) {
+	if jobExists(t, kubeClient, deleteTestCapName, ns) {
 		t.Error("Expected job to be deleted")
 	}
 }

--- a/cli/cmd/capture/delete_test.go
+++ b/cli/cmd/capture/delete_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/microsoft/retina/pkg/label"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
@@ -188,5 +189,66 @@ func TestDeleteCaptureJobs(t *testing.T) {
 			// Validate job is deleted correctly
 			jobDeletedCorrectly(t, kubeClient, tc)
 		})
+	}
+}
+
+func TestDeleteCaptureJobs_SecretAlreadyDeleted(t *testing.T) {
+	// When a secret referenced by a job's volume has already been deleted
+	// (e.g. via ownerRef GC), the delete command should still succeed.
+	captureName := "test-secret-gone"
+	ns := "default"
+
+	kubeClient := newKubeclient()
+
+	// Create a job that references a secret volume, but don't create the secret itself.
+	secretName := "already-deleted-secret"
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      captureName + "-node1-abcde",
+			Namespace: ns,
+			Labels: map[string]string{
+				label.CaptureNameLabel: captureName,
+				label.AppLabel:         "capture",
+			},
+		},
+		Spec: batchv1.JobSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "capture", Image: "test"}},
+					Volumes: []corev1.Volume{
+						{
+							Name: "capture-secret",
+							VolumeSource: corev1.VolumeSource{
+								Secret: &corev1.SecretVolumeSource{
+									SecretName: secretName,
+								},
+							},
+						},
+					},
+					RestartPolicy: corev1.RestartPolicyNever,
+				},
+			},
+		},
+	}
+
+	_, err := kubeClient.BatchV1().Jobs(ns).Create(context.Background(), job, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create test job: %v", err)
+	}
+
+	// Run delete — the secret doesn't exist, so the NotFound check is exercised
+	deleteCmd := NewCommand(kubeClient)
+	deleteCmd.SetArgs([]string{"delete", "--name", captureName, "--namespace", ns})
+	buf := new(bytes.Buffer)
+	deleteCmd.SetOut(buf)
+
+	err = deleteCmd.Execute()
+	if err != nil {
+		t.Fatalf("Delete should succeed even when secret is already gone, got: %v", err)
+	}
+
+	// Verify job was deleted
+	if jobExists(t, kubeClient, captureName, ns) {
+		t.Error("Expected job to be deleted")
 	}
 }

--- a/crd/api/v1alpha1/capture_types.go
+++ b/crd/api/v1alpha1/capture_types.go
@@ -272,6 +272,14 @@ type CaptureSpec struct {
 	CaptureConfiguration CaptureConfiguration `json:"captureConfiguration"`
 	// +kubebuilder:validation:Required
 	OutputConfiguration OutputConfiguration `json:"outputConfiguration,omitempty"`
+	// CleanUpAfterUpload indicates whether the capture jobs and associated resources
+	// should be automatically cleaned up after a successful upload to remote storage
+	// (BlobUpload or S3Upload). When set to true, completed capture jobs, secrets,
+	// and the Capture resource itself will be deleted once all jobs have succeeded
+	// and uploads are confirmed.
+	// +optional
+	// +kubebuilder:default=false
+	CleanUpAfterUpload bool `json:"cleanUpAfterUpload,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/deploy/standard/manifests/controller/helm/retina/crds/retina.sh_captures.yaml
+++ b/deploy/standard/manifests/controller/helm/retina/crds/retina.sh_captures.yaml
@@ -368,6 +368,15 @@ spec:
                 required:
                 - captureTarget
                 type: object
+              cleanUpAfterUpload:
+                default: false
+                description: |-
+                  CleanUpAfterUpload indicates whether the capture jobs and associated resources
+                  should be automatically cleaned up after a successful upload to remote storage
+                  (BlobUpload or S3Upload). When set to true, completed capture jobs, secrets,
+                  and the Capture resource itself will be deleted once all jobs have succeeded
+                  and uploads are confirmed.
+                type: boolean
               outputConfiguration:
                 description: OutputConfiguration indicates the location capture will
                   be stored.
@@ -378,8 +387,16 @@ spec:
                     type: string
                   hostPath:
                     description: |-
-                      HostPath stores the capture files into the specified host filesystem.
-                      If nothing exists at the given path of the host, an empty directory will be created there.
+                      HostPath is a relative subpath name (e.g. "my-capture") joined under the
+                      operator-configured host base directory (default /var/log/retina/captures)
+                      on every node that runs a capture pod. The capture files are written to
+                      that joined directory, and an empty directory is created there if it does
+                      not already exist.
+
+                      HostPath must be a relative subpath: absolute paths (e.g. "/tmp/foo",
+                      "C:\\foo") and any value containing ".." segments are rejected by the
+                      operator. CR authors cannot influence the base directory, which is
+                      controlled by the cluster operator via the operator config.
                     type: string
                   persistentVolumeClaim:
                     description: PersistentVolumeClaim mounts the supplied PVC into

--- a/docs/04-Captures/02-cli.md
+++ b/docs/04-Captures/02-cli.md
@@ -59,6 +59,7 @@ The network traffic will be uploaded to the specified output location.
 | Flag                  | Type       | Default  | Description                                                                 | Notes |
 |-----------------------|------------|----------|-----------------------------------------------------------------------------|-------|
 | `blob-upload`         | string     | ""       | Blob SAS URL with write permission to upload capture files.                  |       |
+| `cleanup-after-upload` | bool       | false    | Automatically clean up capture files from the node's host path after successful upload to remote storage (blob or S3). Requires a remote storage destination. |       |
 | `debug`               | bool       | false    | When debug is true, a customized retina-agent image, determined by the environment variable RETINA_AGENT_IMAGE, is set. |       |
 | `duration`            | string     | 1m0s     | Maximum duration of the packet capture - in minutes / seconds.              |       |
 | `exclude-filter`      | string     | ""       | A comma-separated list of IP:Port pairs that are excluded from capturing network packets. Supported formats are IP:Port, IP, Port, *:Port, IP:* | Only works on Linux.     |
@@ -547,3 +548,22 @@ kubectl retina capture create \
 When creating a capture, you can specify `--no-wait` to clean up the jobs after the Capture is completed.
 
 Otherwise, after creating a Capture, a random Capture name is returned, with which you can delete the jobs by running the `kubectl retina capture delete` command.
+
+### Automatic Cleanup After Upload
+
+When using `--cleanup-after-upload` with a remote storage destination (`--blob-upload`, `--s3-bucket`, or `--pvc`), Retina will automatically delete the capture files from the node's host path after the data has been successfully uploaded to remote storage.
+
+This flag works with both `--no-wait=true` (default) and `--no-wait=false`:
+
+- **`--no-wait=true`** (default): The CLI exits immediately. Jobs are assigned a TTL (5 minutes after completion) so Kubernetes automatically garbage-collects them along with their secrets.
+- **`--no-wait=false`**: The CLI waits for all jobs to complete, then deletes the jobs and secrets itself.
+
+In both modes, the capture agent removes the host-path files once the upload succeeds.
+
+```shell
+kubectl retina capture create --name my-capture --node-names "node1" \
+  --blob-upload "<Blob SAS URL>" \
+  --cleanup-after-upload
+```
+
+If any capture job fails, the host-path files are preserved for debugging.

--- a/docs/04-Captures/03-crd.md
+++ b/docs/04-Captures/03-crd.md
@@ -150,3 +150,25 @@ spec:
 ```
 
 Additional examples can also be found in the [GitHub capture samples](https://github.com/microsoft/retina/tree/main/samples/capture).
+
+## Automatic Cleanup After Upload
+
+Set `cleanUpAfterUpload: true` in the Capture spec to have the controller automatically delete the Capture resource and all associated jobs once all capture jobs complete successfully and data has been uploaded to remote storage (Blob, S3, or PVC).
+
+```yaml
+apiVersion: retina.sh/v1alpha1
+kind: Capture
+metadata:
+  name: my-capture
+spec:
+  captureConfiguration:
+    captureTarget:
+      nodeSelector:
+        matchLabels:
+          kubernetes.io/os: linux
+  outputConfiguration:
+    blobUpload: "<secret-name>"
+  cleanUpAfterUpload: true
+```
+
+If any job fails, the Capture resource and jobs are preserved for debugging. This option requires a remote storage output (`blobUpload`, `s3Upload`, or `persistentVolumeClaim`).

--- a/pkg/controllers/operator/capture/cleanup_after_upload_test.go
+++ b/pkg/controllers/operator/capture/cleanup_after_upload_test.go
@@ -395,3 +395,74 @@ func TestCleanUpAfterUpload_AllJobsSucceeded_WithPVC(t *testing.T) {
 	assert.True(t, err != nil || deletedCapture.DeletionTimestamp != nil,
 		"capture should be deleted when CleanUpAfterUpload is true with PVC and all jobs succeeded")
 }
+
+func TestCleanUpAfterUpload_MixedJobResults_NotTriggered(t *testing.T) {
+	secretName := testSecretName
+	capture := &retinav1alpha1.Capture{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-capture-mixed",
+			Namespace:  "default",
+			Finalizers: []string{captureFinalizer},
+		},
+		Spec: retinav1alpha1.CaptureSpec{
+			CaptureConfiguration: retinav1alpha1.CaptureConfiguration{
+				CaptureTarget: retinav1alpha1.CaptureTarget{
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"kubernetes.io/role": "agent",
+						},
+					},
+				},
+			},
+			OutputConfiguration: retinav1alpha1.OutputConfiguration{
+				BlobUpload: &secretName,
+			},
+			CleanUpAfterUpload: true,
+		},
+	}
+
+	completionTime := metav1.Now()
+	jobs := []batchv1.Job{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-capture-mixed-job-1",
+				Namespace: "default",
+			},
+			Status: batchv1.JobStatus{
+				CompletionTime: &completionTime,
+				Conditions: []batchv1.JobCondition{
+					{
+						Type:   batchv1.JobComplete,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-capture-mixed-job-2",
+				Namespace: "default",
+			},
+			Status: batchv1.JobStatus{
+				Conditions: []batchv1.JobCondition{
+					{
+						Type:   batchv1.JobFailed,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		},
+	}
+
+	reconciler := newTestReconciler(capture)
+	ctx := context.Background()
+
+	_, err := reconciler.updateCaptureStatusFromJobs(ctx, capture, jobs)
+	require.NoError(t, err)
+
+	// Capture should still exist since one job failed
+	existingCapture := &retinav1alpha1.Capture{}
+	err = reconciler.Get(ctx, types.NamespacedName{Name: "test-capture-mixed", Namespace: "default"}, existingCapture)
+	require.NoError(t, err)
+	assert.Nil(t, existingCapture.DeletionTimestamp, "capture should NOT be deleted when some jobs failed even if others succeeded")
+}

--- a/pkg/controllers/operator/capture/cleanup_after_upload_test.go
+++ b/pkg/controllers/operator/capture/cleanup_after_upload_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/microsoft/retina/pkg/log"
 )
 
+const testSecretName = "test-secret"
+
 func newScheme() *runtime.Scheme {
 	s := runtime.NewScheme()
 	_ = retinav1alpha1.AddToScheme(s)
@@ -30,7 +32,7 @@ func newScheme() *runtime.Scheme {
 }
 
 func newTestReconciler(objects ...runtime.Object) *CaptureReconciler {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	scheme := newScheme()
 
 	clientObjects := make([]client.Object, 0, len(objects))
@@ -52,7 +54,7 @@ func newTestReconciler(objects ...runtime.Object) *CaptureReconciler {
 }
 
 func TestCleanUpAfterUpload_AllJobsSucceeded_WithBlobUpload(t *testing.T) {
-	secretName := "test-secret"
+	secretName := testSecretName
 	capture := &retinav1alpha1.Capture{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "test-capture",
@@ -103,7 +105,7 @@ func TestCleanUpAfterUpload_AllJobsSucceeded_WithBlobUpload(t *testing.T) {
 
 	// The capture should have been deleted (triggering the finalizer cleanup)
 	deletedCapture := &retinav1alpha1.Capture{}
-	err = reconciler.Client.Get(ctx, types.NamespacedName{Name: "test-capture", Namespace: "default"}, deletedCapture)
+	err = reconciler.Get(ctx, types.NamespacedName{Name: "test-capture", Namespace: "default"}, deletedCapture)
 	assert.True(t, err != nil || deletedCapture.DeletionTimestamp != nil,
 		"capture should be deleted or marked for deletion when CleanUpAfterUpload is true and all jobs succeeded")
 }
@@ -163,13 +165,13 @@ func TestCleanUpAfterUpload_AllJobsSucceeded_WithS3Upload(t *testing.T) {
 
 	// The capture should have been deleted
 	deletedCapture := &retinav1alpha1.Capture{}
-	err = reconciler.Client.Get(ctx, types.NamespacedName{Name: "test-capture-s3", Namespace: "default"}, deletedCapture)
+	err = reconciler.Get(ctx, types.NamespacedName{Name: "test-capture-s3", Namespace: "default"}, deletedCapture)
 	assert.True(t, err != nil || deletedCapture.DeletionTimestamp != nil,
 		"capture should be deleted when CleanUpAfterUpload is true with S3 upload and all jobs succeeded")
 }
 
 func TestCleanUpAfterUpload_NotTriggeredWhenFalse(t *testing.T) {
-	secretName := "test-secret"
+	secretName := testSecretName
 	capture := &retinav1alpha1.Capture{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "test-capture-no-cleanup",
@@ -220,13 +222,13 @@ func TestCleanUpAfterUpload_NotTriggeredWhenFalse(t *testing.T) {
 
 	// Capture should still exist since CleanUpAfterUpload is false
 	existingCapture := &retinav1alpha1.Capture{}
-	err = reconciler.Client.Get(ctx, types.NamespacedName{Name: "test-capture-no-cleanup", Namespace: "default"}, existingCapture)
+	err = reconciler.Get(ctx, types.NamespacedName{Name: "test-capture-no-cleanup", Namespace: "default"}, existingCapture)
 	require.NoError(t, err)
 	assert.Nil(t, existingCapture.DeletionTimestamp, "capture should NOT be deleted when CleanUpAfterUpload is false")
 }
 
 func TestCleanUpAfterUpload_NotTriggeredOnFailedJobs(t *testing.T) {
-	secretName := "test-secret"
+	secretName := testSecretName
 	capture := &retinav1alpha1.Capture{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       "test-capture-failed",
@@ -275,7 +277,7 @@ func TestCleanUpAfterUpload_NotTriggeredOnFailedJobs(t *testing.T) {
 
 	// Capture should still exist since jobs failed
 	existingCapture := &retinav1alpha1.Capture{}
-	err = reconciler.Client.Get(ctx, types.NamespacedName{Name: "test-capture-failed", Namespace: "default"}, existingCapture)
+	err = reconciler.Get(ctx, types.NamespacedName{Name: "test-capture-failed", Namespace: "default"}, existingCapture)
 	require.NoError(t, err)
 	assert.Nil(t, existingCapture.DeletionTimestamp, "capture should NOT be deleted when jobs failed")
 }
@@ -332,7 +334,7 @@ func TestCleanUpAfterUpload_NotTriggeredWithoutRemoteStorage(t *testing.T) {
 
 	// Capture should still exist since there's no remote storage
 	existingCapture := &retinav1alpha1.Capture{}
-	err = reconciler.Client.Get(ctx, types.NamespacedName{Name: "test-capture-local", Namespace: "default"}, existingCapture)
+	err = reconciler.Get(ctx, types.NamespacedName{Name: "test-capture-local", Namespace: "default"}, existingCapture)
 	require.NoError(t, err)
 	assert.Nil(t, existingCapture.DeletionTimestamp, "capture should NOT be deleted when only local storage is used")
 }
@@ -389,7 +391,7 @@ func TestCleanUpAfterUpload_AllJobsSucceeded_WithPVC(t *testing.T) {
 
 	// The capture should have been deleted
 	deletedCapture := &retinav1alpha1.Capture{}
-	err = reconciler.Client.Get(ctx, types.NamespacedName{Name: "test-capture-pvc", Namespace: "default"}, deletedCapture)
+	err = reconciler.Get(ctx, types.NamespacedName{Name: "test-capture-pvc", Namespace: "default"}, deletedCapture)
 	assert.True(t, err != nil || deletedCapture.DeletionTimestamp != nil,
 		"capture should be deleted when CleanUpAfterUpload is true with PVC and all jobs succeeded")
 }

--- a/pkg/controllers/operator/capture/cleanup_after_upload_test.go
+++ b/pkg/controllers/operator/capture/cleanup_after_upload_test.go
@@ -1,0 +1,395 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package capture
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	retinav1alpha1 "github.com/microsoft/retina/crd/api/v1alpha1"
+	"github.com/microsoft/retina/pkg/log"
+)
+
+func newScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = retinav1alpha1.AddToScheme(s)
+	_ = batchv1.AddToScheme(s)
+	_ = corev1.AddToScheme(s)
+	return s
+}
+
+func newTestReconciler(objects ...runtime.Object) *CaptureReconciler {
+	log.SetupZapLogger(log.GetDefaultLogOpts())
+	scheme := newScheme()
+
+	clientObjects := make([]client.Object, 0, len(objects))
+	for _, obj := range objects {
+		clientObjects = append(clientObjects, obj.(client.Object))
+	}
+
+	fakeClient := fakeclient.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(clientObjects...).
+		WithStatusSubresource(&retinav1alpha1.Capture{}, &batchv1.Job{}).
+		Build()
+
+	return &CaptureReconciler{
+		Client: fakeClient,
+		scheme: scheme,
+		logger: log.Logger().Named("capture-test"),
+	}
+}
+
+func TestCleanUpAfterUpload_AllJobsSucceeded_WithBlobUpload(t *testing.T) {
+	secretName := "test-secret"
+	capture := &retinav1alpha1.Capture{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-capture",
+			Namespace:  "default",
+			Finalizers: []string{captureFinalizer},
+		},
+		Spec: retinav1alpha1.CaptureSpec{
+			CaptureConfiguration: retinav1alpha1.CaptureConfiguration{
+				CaptureTarget: retinav1alpha1.CaptureTarget{
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"kubernetes.io/role": "agent",
+						},
+					},
+				},
+			},
+			OutputConfiguration: retinav1alpha1.OutputConfiguration{
+				BlobUpload: &secretName,
+			},
+			CleanUpAfterUpload: true,
+		},
+	}
+
+	completionTime := metav1.Now()
+	jobs := []batchv1.Job{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-capture-job-1",
+				Namespace: "default",
+			},
+			Status: batchv1.JobStatus{
+				CompletionTime: &completionTime,
+				Conditions: []batchv1.JobCondition{
+					{
+						Type:   batchv1.JobComplete,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		},
+	}
+
+	reconciler := newTestReconciler(capture)
+	ctx := context.Background()
+
+	_, err := reconciler.updateCaptureStatusFromJobs(ctx, capture, jobs)
+	require.NoError(t, err)
+
+	// The capture should have been deleted (triggering the finalizer cleanup)
+	deletedCapture := &retinav1alpha1.Capture{}
+	err = reconciler.Client.Get(ctx, types.NamespacedName{Name: "test-capture", Namespace: "default"}, deletedCapture)
+	assert.True(t, err != nil || deletedCapture.DeletionTimestamp != nil,
+		"capture should be deleted or marked for deletion when CleanUpAfterUpload is true and all jobs succeeded")
+}
+
+func TestCleanUpAfterUpload_AllJobsSucceeded_WithS3Upload(t *testing.T) {
+	capture := &retinav1alpha1.Capture{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-capture-s3",
+			Namespace:  "default",
+			Finalizers: []string{captureFinalizer},
+		},
+		Spec: retinav1alpha1.CaptureSpec{
+			CaptureConfiguration: retinav1alpha1.CaptureConfiguration{
+				CaptureTarget: retinav1alpha1.CaptureTarget{
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"kubernetes.io/role": "agent",
+						},
+					},
+				},
+			},
+			OutputConfiguration: retinav1alpha1.OutputConfiguration{
+				S3Upload: &retinav1alpha1.S3Upload{
+					Bucket:     "test-bucket",
+					SecretName: "test-s3-secret",
+					Region:     "us-east-1",
+				},
+			},
+			CleanUpAfterUpload: true,
+		},
+	}
+
+	completionTime := metav1.Now()
+	jobs := []batchv1.Job{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-capture-s3-job-1",
+				Namespace: "default",
+			},
+			Status: batchv1.JobStatus{
+				CompletionTime: &completionTime,
+				Conditions: []batchv1.JobCondition{
+					{
+						Type:   batchv1.JobComplete,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		},
+	}
+
+	reconciler := newTestReconciler(capture)
+	ctx := context.Background()
+
+	_, err := reconciler.updateCaptureStatusFromJobs(ctx, capture, jobs)
+	require.NoError(t, err)
+
+	// The capture should have been deleted
+	deletedCapture := &retinav1alpha1.Capture{}
+	err = reconciler.Client.Get(ctx, types.NamespacedName{Name: "test-capture-s3", Namespace: "default"}, deletedCapture)
+	assert.True(t, err != nil || deletedCapture.DeletionTimestamp != nil,
+		"capture should be deleted when CleanUpAfterUpload is true with S3 upload and all jobs succeeded")
+}
+
+func TestCleanUpAfterUpload_NotTriggeredWhenFalse(t *testing.T) {
+	secretName := "test-secret"
+	capture := &retinav1alpha1.Capture{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-capture-no-cleanup",
+			Namespace:  "default",
+			Finalizers: []string{captureFinalizer},
+		},
+		Spec: retinav1alpha1.CaptureSpec{
+			CaptureConfiguration: retinav1alpha1.CaptureConfiguration{
+				CaptureTarget: retinav1alpha1.CaptureTarget{
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"kubernetes.io/role": "agent",
+						},
+					},
+				},
+			},
+			OutputConfiguration: retinav1alpha1.OutputConfiguration{
+				BlobUpload: &secretName,
+			},
+			CleanUpAfterUpload: false,
+		},
+	}
+
+	completionTime := metav1.Now()
+	jobs := []batchv1.Job{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-capture-no-cleanup-job-1",
+				Namespace: "default",
+			},
+			Status: batchv1.JobStatus{
+				CompletionTime: &completionTime,
+				Conditions: []batchv1.JobCondition{
+					{
+						Type:   batchv1.JobComplete,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		},
+	}
+
+	reconciler := newTestReconciler(capture)
+	ctx := context.Background()
+
+	_, err := reconciler.updateCaptureStatusFromJobs(ctx, capture, jobs)
+	require.NoError(t, err)
+
+	// Capture should still exist since CleanUpAfterUpload is false
+	existingCapture := &retinav1alpha1.Capture{}
+	err = reconciler.Client.Get(ctx, types.NamespacedName{Name: "test-capture-no-cleanup", Namespace: "default"}, existingCapture)
+	require.NoError(t, err)
+	assert.Nil(t, existingCapture.DeletionTimestamp, "capture should NOT be deleted when CleanUpAfterUpload is false")
+}
+
+func TestCleanUpAfterUpload_NotTriggeredOnFailedJobs(t *testing.T) {
+	secretName := "test-secret"
+	capture := &retinav1alpha1.Capture{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-capture-failed",
+			Namespace:  "default",
+			Finalizers: []string{captureFinalizer},
+		},
+		Spec: retinav1alpha1.CaptureSpec{
+			CaptureConfiguration: retinav1alpha1.CaptureConfiguration{
+				CaptureTarget: retinav1alpha1.CaptureTarget{
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"kubernetes.io/role": "agent",
+						},
+					},
+				},
+			},
+			OutputConfiguration: retinav1alpha1.OutputConfiguration{
+				BlobUpload: &secretName,
+			},
+			CleanUpAfterUpload: true,
+		},
+	}
+
+	jobs := []batchv1.Job{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-capture-failed-job-1",
+				Namespace: "default",
+			},
+			Status: batchv1.JobStatus{
+				Conditions: []batchv1.JobCondition{
+					{
+						Type:   batchv1.JobFailed,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		},
+	}
+
+	reconciler := newTestReconciler(capture)
+	ctx := context.Background()
+
+	_, err := reconciler.updateCaptureStatusFromJobs(ctx, capture, jobs)
+	require.NoError(t, err)
+
+	// Capture should still exist since jobs failed
+	existingCapture := &retinav1alpha1.Capture{}
+	err = reconciler.Client.Get(ctx, types.NamespacedName{Name: "test-capture-failed", Namespace: "default"}, existingCapture)
+	require.NoError(t, err)
+	assert.Nil(t, existingCapture.DeletionTimestamp, "capture should NOT be deleted when jobs failed")
+}
+
+func TestCleanUpAfterUpload_NotTriggeredWithoutRemoteStorage(t *testing.T) {
+	hostPath := "/mnt/captures"
+	capture := &retinav1alpha1.Capture{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-capture-local",
+			Namespace:  "default",
+			Finalizers: []string{captureFinalizer},
+		},
+		Spec: retinav1alpha1.CaptureSpec{
+			CaptureConfiguration: retinav1alpha1.CaptureConfiguration{
+				CaptureTarget: retinav1alpha1.CaptureTarget{
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"kubernetes.io/role": "agent",
+						},
+					},
+				},
+			},
+			OutputConfiguration: retinav1alpha1.OutputConfiguration{
+				HostPath: &hostPath,
+			},
+			CleanUpAfterUpload: true,
+		},
+	}
+
+	completionTime := metav1.Now()
+	jobs := []batchv1.Job{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-capture-local-job-1",
+				Namespace: "default",
+			},
+			Status: batchv1.JobStatus{
+				CompletionTime: &completionTime,
+				Conditions: []batchv1.JobCondition{
+					{
+						Type:   batchv1.JobComplete,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		},
+	}
+
+	reconciler := newTestReconciler(capture)
+	ctx := context.Background()
+
+	_, err := reconciler.updateCaptureStatusFromJobs(ctx, capture, jobs)
+	require.NoError(t, err)
+
+	// Capture should still exist since there's no remote storage
+	existingCapture := &retinav1alpha1.Capture{}
+	err = reconciler.Client.Get(ctx, types.NamespacedName{Name: "test-capture-local", Namespace: "default"}, existingCapture)
+	require.NoError(t, err)
+	assert.Nil(t, existingCapture.DeletionTimestamp, "capture should NOT be deleted when only local storage is used")
+}
+
+func TestCleanUpAfterUpload_AllJobsSucceeded_WithPVC(t *testing.T) {
+	pvcName := "test-pvc"
+	capture := &retinav1alpha1.Capture{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-capture-pvc",
+			Namespace:  "default",
+			Finalizers: []string{captureFinalizer},
+		},
+		Spec: retinav1alpha1.CaptureSpec{
+			CaptureConfiguration: retinav1alpha1.CaptureConfiguration{
+				CaptureTarget: retinav1alpha1.CaptureTarget{
+					NodeSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"kubernetes.io/role": "agent",
+						},
+					},
+				},
+			},
+			OutputConfiguration: retinav1alpha1.OutputConfiguration{
+				PersistentVolumeClaim: &pvcName,
+			},
+			CleanUpAfterUpload: true,
+		},
+	}
+
+	completionTime := metav1.Now()
+	jobs := []batchv1.Job{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-capture-pvc-job-1",
+				Namespace: "default",
+			},
+			Status: batchv1.JobStatus{
+				CompletionTime: &completionTime,
+				Conditions: []batchv1.JobCondition{
+					{
+						Type:   batchv1.JobComplete,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		},
+	}
+
+	reconciler := newTestReconciler(capture)
+	ctx := context.Background()
+
+	_, err := reconciler.updateCaptureStatusFromJobs(ctx, capture, jobs)
+	require.NoError(t, err)
+
+	// The capture should have been deleted
+	deletedCapture := &retinav1alpha1.Capture{}
+	err = reconciler.Client.Get(ctx, types.NamespacedName{Name: "test-capture-pvc", Namespace: "default"}, deletedCapture)
+	assert.True(t, err != nil || deletedCapture.DeletionTimestamp != nil,
+		"capture should be deleted when CleanUpAfterUpload is true with PVC and all jobs succeeded")
+}

--- a/pkg/controllers/operator/capture/controller.go
+++ b/pkg/controllers/operator/capture/controller.go
@@ -215,7 +215,27 @@ func (cr *CaptureReconciler) updateCaptureStatusFromJobs(ctx context.Context, ca
 		}
 	}
 	capture.Status.CompletionTime = &lastCompleteTime
-	return cr.updateStatus(ctx, capture)
+	if result, err := cr.updateStatus(ctx, capture); err != nil {
+		return result, err
+	}
+
+	// If CleanUpAfterUpload is enabled and all jobs succeeded (uploaded to remote storage),
+	// automatically delete the Capture resource which triggers cleanup via the finalizer.
+	if capture.Spec.CleanUpAfterUpload && len(failedJobs) == 0 {
+		hasRemoteStorage := capture.Spec.OutputConfiguration.BlobUpload != nil || capture.Spec.OutputConfiguration.S3Upload != nil || capture.Spec.OutputConfiguration.PersistentVolumeClaim != nil
+		if hasRemoteStorage {
+			cr.logger.Info("All capture jobs completed successfully with remote storage upload, performing automatic cleanup",
+				zap.String("Capture", captureRef.String()))
+			if err := cr.Client.Delete(ctx, capture); err != nil {
+				cr.logger.Error("Failed to auto-delete Capture after successful upload",
+					zap.Error(err), zap.String("Capture", captureRef.String()))
+				return ctrl.Result{}, fmt.Errorf("failed to auto-delete Capture after successful upload: %w", err)
+			}
+			return ctrl.Result{}, nil
+		}
+	}
+
+	return ctrl.Result{}, nil
 }
 
 func (cr *CaptureReconciler) createJobsFromCapture(ctx context.Context, capture *retinav1alpha1.Capture) (ctrl.Result, error) {

--- a/pkg/controllers/operator/capture/controller.go
+++ b/pkg/controllers/operator/capture/controller.go
@@ -221,20 +221,24 @@ func (cr *CaptureReconciler) updateCaptureStatusFromJobs(ctx context.Context, ca
 
 	// If CleanUpAfterUpload is enabled and all jobs succeeded (uploaded to remote storage),
 	// automatically delete the Capture resource which triggers cleanup via the finalizer.
-	if capture.Spec.CleanUpAfterUpload && len(failedJobs) == 0 {
-		hasRemoteStorage := capture.Spec.OutputConfiguration.BlobUpload != nil || capture.Spec.OutputConfiguration.S3Upload != nil || capture.Spec.OutputConfiguration.PersistentVolumeClaim != nil
-		if hasRemoteStorage {
-			cr.logger.Info("All capture jobs completed successfully with remote storage upload, performing automatic cleanup",
-				zap.String("Capture", captureRef.String()))
-			if err := cr.Delete(ctx, capture); err != nil {
-				cr.logger.Error("Failed to auto-delete Capture after successful upload",
-					zap.Error(err), zap.String("Capture", captureRef.String()))
-				return ctrl.Result{}, fmt.Errorf("failed to auto-delete Capture after successful upload: %w", err)
-			}
-			return ctrl.Result{}, nil
-		}
+	if !capture.Spec.CleanUpAfterUpload || len(failedJobs) != 0 {
+		return ctrl.Result{}, nil
 	}
 
+	hasRemoteStorage := capture.Spec.OutputConfiguration.BlobUpload != nil ||
+		capture.Spec.OutputConfiguration.S3Upload != nil ||
+		capture.Spec.OutputConfiguration.PersistentVolumeClaim != nil
+	if !hasRemoteStorage {
+		return ctrl.Result{}, nil
+	}
+
+	cr.logger.Info("All capture jobs completed successfully with remote storage upload, performing automatic cleanup",
+		zap.String("Capture", captureRef.String()))
+	if err := cr.Delete(ctx, capture); err != nil {
+		cr.logger.Error("Failed to auto-delete Capture after successful upload",
+			zap.Error(err), zap.String("Capture", captureRef.String()))
+		return ctrl.Result{}, fmt.Errorf("failed to auto-delete Capture after successful upload: %w", err)
+	}
 	return ctrl.Result{}, nil
 }
 

--- a/pkg/controllers/operator/capture/controller.go
+++ b/pkg/controllers/operator/capture/controller.go
@@ -226,7 +226,7 @@ func (cr *CaptureReconciler) updateCaptureStatusFromJobs(ctx context.Context, ca
 		if hasRemoteStorage {
 			cr.logger.Info("All capture jobs completed successfully with remote storage upload, performing automatic cleanup",
 				zap.String("Capture", captureRef.String()))
-			if err := cr.Client.Delete(ctx, capture); err != nil {
+			if err := cr.Delete(ctx, capture); err != nil {
 				cr.logger.Error("Failed to auto-delete Capture after successful upload",
 					zap.Error(err), zap.String("Capture", captureRef.String()))
 				return ctrl.Result{}, fmt.Errorf("failed to auto-delete Capture after successful upload: %w", err)


### PR DESCRIPTION
# Description

Adds a `--cleanup-after-upload` flag to `kubectl retina capture create` that enables automatic cleanup of capture jobs, secrets, and host-path files after successful upload to remote storage (blob, S3, or PVC).

**Key behaviors:**
- **TTL on jobs** (no-wait mode): When `--cleanup-after-upload` is combined with `--no-wait=true` and a remote destination, jobs get a `TTLSecondsAfterFinished` (5 min) so Kubernetes garbage-collects them automatically.
- **Secret ownerReferences** (always): Secrets created for blob/S3 uploads always get ownerReferences pointing to the capture job, ensuring they are cleaned up when the job is deleted—whether by TTL, manual delete, or the controller.
- **Controller auto-delete**: The operator's `CaptureReconciler` now deletes the Capture resource once all jobs succeed and `CleanUpAfterUpload` is true with remote storage configured (blob, S3, or PVC).
- **ActiveDeadlineSeconds**: Jobs now get a hard deadline (`duration + 30min`) to prevent indefinite hangs.
- **Wait timeout fix**: `waitUntilJobsComplete` deadline is now `duration + 5min` (floored at 5min), fixing premature timeouts for short captures.
- **NotFound tolerance**: `deleteSecret` and `capture delete` now tolerate `NotFound` errors caused by ownerRef garbage collection racing with explicit deletion.

## Related Issue

N/A — feature request for safer automated capture workflows.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`).
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

### Unit Tests

All tests pass in the affected packages. The new logic is 100% covered by the new CLI and Operator controller tests added.

### Manual Testing

| # | Scenario | Command | Expected | Result |
|---|----------|---------|----------|--------|
| 1 | `--cleanup-after-upload` without remote | `./bin/kubectl-retina capture create --name test1 --node-names aks-nodepool1-... --host-path /tmp/captures --cleanup-after-upload --duration 5s` | Error: requires remote storage | **PASS** — error returned immediately |
| 2 | No-wait + blob + cleanup | `./bin/kubectl-retina capture create --name test2 --node-names aks-nodepool1-... --blob-upload "<SAS URL>" --cleanup-after-upload --no-wait=true --duration 10s` | CLI exits immediately, job has TTL, secret has ownerRef | **PASS** — verified via `kubectl get job -o yaml` (TTL=300), `kubectl get secret -o yaml` (ownerReferences present), job auto-deleted after ~5 min |
| 3 | Wait + blob + cleanup | `./bin/kubectl-retina capture create --name test3 --node-names aks-nodepool1-... --blob-upload "<SAS URL>" --cleanup-after-upload --no-wait=false --duration 10s` | CLI waits, uploads blob, then deletes jobs/secrets | **PASS** — CLI printed completion, `kubectl get jobs` showed no jobs remaining, blob appeared in storage account, secret deleted |
| 4 | Wait + blob WITHOUT cleanup | `./bin/kubectl-retina capture create --name test4 --node-names aks-nodepool1-... --blob-upload "<SAS URL>" --no-wait=false --duration 10s` | CLI waits, uploads, jobs/secrets remain | **PASS** — jobs and secrets preserved after CLI exit |
| 5 | Host-path only + no-wait (no cleanup flag) | `./bin/kubectl-retina capture create --name test5 --node-names aks-nodepool1-... --host-path /tmp/captures --no-wait=true --duration 5s` | No TTL set, jobs remain | **PASS** — `kubectl get job -o yaml` showed no TTLSecondsAfterFinished |

**Wait timeout fix verified:** Test 3 used `--duration 10s` and the CLI completed within ~75s (10s capture + upload time), confirming the new `duration + 5min` deadline works correctly for short captures (previously would timeout at 2×duration = 20s before upload finished).

**NotFound tolerance verified:** In test 2, running `kubectl retina capture delete --name test2` after TTL had already garbage-collected the job+secret returned success (no "secret not found" error).

## Additional Notes

- The `CleanUpAfterUpload` field is added to the CRD spec as optional with `+kubebuilder:default=false`. Existing Captures are unaffected.
- `JobActiveDeadlineBufferSeconds` (30 min) is generous to accommodate large captures uploading over slow links or Windows nodes with slow image pulls.
- The operator controller cleanup path only triggers when ALL jobs succeed — any failure preserves everything for debugging.
- The controller's remote storage check includes all three types: `BlobUpload`, `S3Upload`, and `PersistentVolumeClaim`.