### PR TITLE
fix(capture): Fix Windows capture stop ctx.

### DIFF
--- a/pkg/capture/provider/network_capture_win.go
+++ b/pkg/capture/provider/network_capture_win.go
@@ -84,7 +84,7 @@ func (ncp *NetworkCaptureProvider) CaptureNetworkPacket(ctx context.Context, fil
 	}
 	if stopTrace {
 		ncp.l.Info("Stopping netsh trace session before starting a new one")
-		_ = ncp.stopNetworkCapture(ctx)
+		_ = ncp.stopNetworkCapture()
 	}
 
 	captureFileName := ncp.Filename.String() + ".etl"
@@ -164,7 +164,7 @@ func (ncp *NetworkCaptureProvider) CaptureNetworkPacket(ctx context.Context, fil
 	}
 
 	ncp.l.Info("Stop netsh")
-	if err := ncp.stopNetworkCapture(ctx); err != nil {
+	if err := ncp.stopNetworkCapture(); err != nil {
 		ncp.l.Error("Failed to stop netsh trace by 'netsh trace stop', will kill the process", zap.Error(err))
 		_ = captureStartCmd.Process.Kill()
 		return fmt.Errorf("netsh stop failed: Output: %s", err)
@@ -204,10 +204,15 @@ func (ncp *NetworkCaptureProvider) needToStopTraceSession(ctx context.Context) (
 	return false, fmt.Errorf("cannot stop trace session because it's not created by Retina capture")
 }
 
-func (ncp *NetworkCaptureProvider) stopNetworkCapture(ctx context.Context) error {
+func (ncp *NetworkCaptureProvider) stopNetworkCapture() error {
 	ncp.l.Info("Stopping netsh trace session")
 
-	command := exec.CommandContext(ctx, "netsh", "trace", "stop")
+	// Create independent context for cleanup.
+	// netsh trace stop completes in ~1s; 30s timeout provides ample safety margin.
+	stopCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	command := exec.CommandContext(stopCtx, "netsh", "trace", "stop")
 	output, err := command.CombinedOutput()
 	// ignore the error when stop the trace when no live trace session exists.
 	if strings.Contains(string(output), "There is no trace session currently in progress") {

--- a/pkg/capture/provider/network_capture_win.go
+++ b/pkg/capture/provider/network_capture_win.go
@@ -84,7 +84,7 @@ func (ncp *NetworkCaptureProvider) CaptureNetworkPacket(ctx context.Context, fil
 	}
 	if stopTrace {
 		ncp.l.Info("Stopping netsh trace session before starting a new one")
-		_ = ncp.stopNetworkCapture()
+		_ = ncp.stopNetworkCapture() //nolint:contextcheck // stopNetworkCapture creates its own context
 	}
 
 	captureFileName := ncp.Filename.String() + ".etl"
@@ -164,7 +164,8 @@ func (ncp *NetworkCaptureProvider) CaptureNetworkPacket(ctx context.Context, fil
 	}
 
 	ncp.l.Info("Stop netsh")
-	if err := ncp.stopNetworkCapture(); err != nil {
+	// stopNetworkCapture creates its own context; parent ctx is expired here
+	if err := ncp.stopNetworkCapture(); err != nil { //nolint:contextcheck // stopNetworkCapture creates its own context
 		ncp.l.Error("Failed to stop netsh trace by 'netsh trace stop', will kill the process", zap.Error(err))
 		_ = captureStartCmd.Process.Kill()
 		return fmt.Errorf("netsh stop failed: Output: %s", err)

--- a/pkg/capture/provider/network_capture_win_test.go
+++ b/pkg/capture/provider/network_capture_win_test.go
@@ -6,7 +6,13 @@
 package provider
 
 import (
+	"context"
 	"testing"
+	"time"
+
+	"github.com/microsoft/retina/pkg/capture/file"
+	"github.com/microsoft/retina/pkg/log"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestValidateNetshFilter(t *testing.T) {
@@ -113,4 +119,38 @@ func TestValidateNetshFilter(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestStopNetworkCapture_ContextIndependence verifies stopNetworkCapture creates its own context
+func TestStopNetworkCapture_ContextIndependence(t *testing.T) {
+	now := metav1.Now()
+	ncp := &NetworkCaptureProvider{
+		NetworkCaptureProviderCommon: NetworkCaptureProviderCommon{
+			TmpCaptureDir: t.TempDir(),
+			l:             log.Logger().Named("test-capture"),
+		},
+		Filename: file.CaptureFilename{
+			CaptureName:    "test-capture",
+			NodeHostname:   "test-node",
+			StartTimestamp: &now,
+		},
+	}
+
+	// Create an expired context (simulating capture duration ending)
+	parentCtx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+	time.Sleep(10 * time.Millisecond)
+	defer cancel()
+
+	if parentCtx.Err() == nil {
+		t.Fatal("Setup error: parent context should be expired")
+	}
+
+	// Call StopNetworkCapture - should NOT return "context deadline exceeded"
+	err := ncp.stopNetworkCapture()
+
+	if err != nil && err.Error() == "context deadline exceeded" {
+		t.Fatal("StopNetworkCapture returned 'context deadline exceeded' - bug reintroduced")
+	}
+
+	t.Logf("StopNetworkCapture uses independent context (netsh error expected: %v)", err)
 }


### PR DESCRIPTION
# Description

Fix Windows capture ctx.

Stop Network capture parent ctx is expired by the time `stopNetworkCapture` is called.

Please provide a brief description of the changes made in this pull request.

## Related Issue

#2298 

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed
<img width="1247" height="692" alt="image" src="https://github.com/user-attachments/assets/751f4df6-08c8-46ac-b169-df3094994642" />

<img width="1885" height="407" alt="image" src="https://github.com/user-attachments/assets/3470c845-0364-4bc5-b121-3abd720009b4" />


## Additional Notes

Issue introduced: #2322 

https://github.com/microsoft/retina/pull/2322/changes#diff-bd1c3510276019b2f8f85384d4963e4fa366a428acad36280432a841079a9bf2