### PR TITLE
ci: remove krew-index update step on dev/v0.0.33-windows

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -48,6 +48,3 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Update new version in krew-index
-        if: github.repository_owner == 'microsoft'
-        uses: rajatjindal/krew-release-bot@v0.0.47

--- a/.github/workflows/release-validation.yaml
+++ b/.github/workflows/release-validation.yaml
@@ -42,23 +42,6 @@ jobs:
       - name: Setup kind cluster
         uses: helm/kind-action@v1.12.0
 
-      # krew does not support installing a specific verison
-      # so if this step fails it means there was something wrong
-      # with the krew index update as part of the release
-      - name: Test krew install retina
-        run: |
-          (
-            set -x; cd "$(mktemp -d)" &&
-            OS="$(uname | tr '[:upper:]' '[:lower:]')" &&
-            ARCH="$(uname -m | sed -e 's/x86_64/amd64/' -e 's/\(arm\)\(64\)\?.*/\1\2/' -e 's/aarch64$/arm64/')" &&
-            KREW="krew-${OS}_${ARCH}" &&
-            curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/${KREW}.tar.gz" &&
-            tar zxvf "${KREW}.tar.gz" &&
-            ./"${KREW}" install krew
-            export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"
-            kubectl krew install retina
-          )
-
       - name: Check Go package version
         run: |
           TAG=${{ env.TAG }}


### PR DESCRIPTION
The krew-release-bot step in goreleaser.yaml triggers on every tag pushed from this branch, including pre-release tags like `v0.0.33-windows-rc.2`, opening spurious PRs against [krew-index](https://github.com/kubernetes-sigs/krew-index) (e.g. #5787).

Main has #2107 which gates the step on final release tags, but this dev branch forked before that landed. Since this branch only produces pre-release/windows-dev tags that should never publish to krew, removing the step entirely is the simplest fix.

The new tag `v0.0.33-windows-rc.2` already points to a commit with this change applied, so the in-flight release is unaffected.