### PR TITLE
fix(hubble): surface controller-runtime manager start failures

### DIFF
--- a/cmd/hubble/daemon_linux.go
+++ b/cmd/hubble/daemon_linux.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s/watchers"
 	monitoragent "github.com/cilium/cilium/pkg/monitor/agent"
 	"github.com/cilium/cilium/pkg/node"
+	"github.com/cilium/hive"
 	"github.com/cilium/hive/cell"
 	"github.com/cilium/workerpool"
 
@@ -72,14 +73,40 @@ var (
 		}),
 
 		// Start the controller manager
-		cell.Invoke(func(l *slog.Logger, lifecycle cell.Lifecycle, ctrlManager ctrl.Manager) {
+		cell.Invoke(func(l *slog.Logger, lifecycle cell.Lifecycle, shutdowner hive.Shutdowner, ctrlManager ctrl.Manager) {
 			var wp *workerpool.WorkerPool
 			lifecycle.Append(
 				cell.Hook{
 					OnStart: func(cell.HookContext) error {
 						wp = workerpool.New(1)
 						l.Info("starting controller-runtime manager")
-						if err := wp.Submit("controller-runtime manager", ctrlManager.Start); err != nil {
+						if err := wp.Submit("controller-runtime manager", func(ctx context.Context) error {
+							// controller-runtime's manager.Start blocks until the context is
+							// cancelled or one of its runnables returns an error. The
+							// workerpool result is never drained, so an error returned here
+							// would otherwise be silently discarded. A silent exit leaves the
+							// node reconciler (and therefore Hubble peer discovery) dead while
+							// the agent keeps running, which surfaces downstream as
+							// hubble-relay never receiving any peers and failing its health
+							// check. Surface the failure and trigger a hive shutdown so the
+							// agent fails loudly (and is restarted) instead of running in a
+							// silently degraded state.
+							if err := ctrlManager.Start(ctx); err != nil {
+								l.Error("controller-runtime manager exited with error; node reconciler is no longer running", "error", err)
+								shutdowner.Shutdown(hive.ShutdownWithError(err))
+								return errors.Wrap(err, "running controller-runtime manager")
+							}
+							if ctx.Err() == nil {
+								// Start returned without error while the context is still
+								// active: the manager stopped unexpectedly even though the
+								// agent should still be running.
+								err := errors.New("controller-runtime manager stopped unexpectedly")
+								l.Error("controller-runtime manager stopped unexpectedly; node reconciler is no longer running")
+								shutdowner.Shutdown(hive.ShutdownWithError(err))
+								return err
+							}
+							return nil
+						}); err != nil {
 							return errors.Wrap(err, "failed to submit controller-runtime manager to workerpool")
 						}
 						return nil


### PR DESCRIPTION
# Description

Please provide a brief description of the changes made in this pull request.

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
