### PR TITLE
fix: add app.kubernetes.io/name and instance labels to helm workloads

### DIFF
--- a/deploy/hubble/manifests/controller/helm/retina/templates/agent/daemonset.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/agent/daemonset.yaml
@@ -8,6 +8,8 @@ metadata:
   namespace: {{ .Values.namespace }}
   labels:
     k8s-app: {{ include "retina.name" . }}
+    app.kubernetes.io/name: {{ include "retina.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   selector:
     matchLabels:
@@ -17,6 +19,8 @@ spec:
       labels:
         app: {{ include "retina.name" . }}
         k8s-app: {{ include "retina.name" . }}
+        app.kubernetes.io/name: {{ include "retina.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
       annotations:
         prometheus.io/port: "{{ .Values.retinaPort }}"
         prometheus.io/scrape: "true"

--- a/deploy/hubble/manifests/controller/helm/retina/templates/hubble-relay/deployment.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/hubble-relay/deployment.yaml
@@ -12,6 +12,7 @@ metadata:
     k8s-app: hubble-relay
     app.kubernetes.io/name: hubble-relay
     app.kubernetes.io/part-of: cilium
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   replicas: {{ .Values.hubble.relay.replicas }}
   selector:
@@ -35,6 +36,7 @@ spec:
         k8s-app: hubble-relay
         app.kubernetes.io/name: hubble-relay
         app.kubernetes.io/part-of: cilium
+        app.kubernetes.io/instance: {{ .Release.Name }}
         {{- with .Values.hubble.relay.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deploy/hubble/manifests/controller/helm/retina/templates/hubble-ui/deployment.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/hubble-ui/deployment.yaml
@@ -12,6 +12,7 @@ metadata:
     k8s-app: hubble-ui
     app.kubernetes.io/name: hubble-ui
     app.kubernetes.io/part-of: cilium
+    app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
   replicas: {{ .Values.hubble.ui.replicas }}
   selector:
@@ -35,6 +36,7 @@ spec:
         k8s-app: hubble-ui
         app.kubernetes.io/name: hubble-ui
         app.kubernetes.io/part-of: cilium
+        app.kubernetes.io/instance: {{ .Release.Name }}
         {{- with .Values.hubble.ui.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deploy/hubble/manifests/controller/helm/retina/templates/operator/deployment.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/operator/deployment.yaml
@@ -25,6 +25,8 @@ spec:
       labels:
         app: retina-operator
         control-plane: retina-operator
+        app.kubernetes.io/name: retina-operator
+        app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
# Description

Adding the standard Kubernetes recommended labels app.kubernetes.io/name and app.kubernetes.io/instance to the retina-agent, hubble-relay, hubble-ui, and retina-operator workloads.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
