### PR TITLE
fix(dropreason): filter EAGAIN false drops in inet_csk_accept metrics

### DIFF
--- a/pkg/plugin/dropreason/_cprog/drop_reason.c
+++ b/pkg/plugin/dropreason/_cprog/drop_reason.c
@@ -32,6 +32,7 @@ char __license[] SEC("license") = "Dual MIT/GPL";
 #define ETH_P_8021Q 0x8100
 #define ETH_P_ARP 0x0806
 #define TASK_COMM_LEN 16
+#define EAGAIN_ERRNO 11
 // TODO (Vamsi): Add top 100 dropped connections with LRU map
 
 // Ref: https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/if_packet.h#L26
@@ -426,8 +427,8 @@ int BPF_KRETPROBE(inet_csk_accept_ret, struct sock *sk)
     if (bpf_probe_read_kernel(&err, sizeof(err), (void *)(unsigned long)*err_ptr) < 0)
         return 0;
 
-    // err >= 0 means no error; -EAGAIN (-11) is normal for non-blocking accept.
-    if (err >= 0 || err == -11)
+    // err >= 0 means no error; -EAGAIN is normal for non-blocking accept.
+    if (err >= 0 || err == -EAGAIN_ERRNO)
         return 0;
 
     struct packet p;
@@ -461,10 +462,11 @@ int BPF_PROG(inet_csk_accept_fexit)
         if ((struct sock *)ctx[2] == NULL) {
             // Read err from proto_accept_arg (ctx[1] is the arg pointer).
             int err = 0;
-            bpf_probe_read_kernel(&err, sizeof(err),
-                &((struct proto_accept_arg___new *)ctx[1])->err);
-            // EAGAIN (-11) is normal for non-blocking accept; not a real drop.
-            if (err != 0 && err != -11)
+            if (bpf_probe_read_kernel(&err, sizeof(err),
+                &((struct proto_accept_arg___new *)ctx[1])->err) < 0)
+                return 0;
+            // EAGAIN is normal for non-blocking accept; not a real drop.
+            if (err != 0 && err != -EAGAIN_ERRNO)
                 update_metrics_map_basic(TCP_ACCEPT_BASIC, err, 0);
         }
     } else {

--- a/pkg/plugin/dropreason/_cprog/drop_reason.c
+++ b/pkg/plugin/dropreason/_cprog/drop_reason.c
@@ -420,12 +420,9 @@ int BPF_KRETPROBE(inet_csk_accept_ret, struct sock *sk)
     if (sk != NULL)
         return 0;
 
-    // *err_ptr holds the ADDRESS of the callee's errno output (the int *err
-    // parameter pre-6.10, &arg->err on 6.10+); the errno must be read through it.
-    int err = 0;
-    if (bpf_probe_read_kernel(&err, sizeof(err), (void *)(unsigned long)*err_ptr) < 0)
-        return 0;
-    if (err >= 0)
+    int err = (int)*err_ptr;
+    // err >= 0 means no error; -EAGAIN (-11) is normal for non-blocking accept.
+    if (err >= 0 || err == -11)
         return 0;
 
     struct packet p;
@@ -455,11 +452,26 @@ int BPF_PROG(inet_csk_accept_fexit)
     // Linux 6.10+: 2 params (sk, arg) -> retsk at ctx[2]
     // Pre-6.10:    4 params (sk, flags, err, kern) -> retsk at ctx[4]
     if (bpf_core_type_exists(struct proto_accept_arg___new)) {
-        if ((struct sock *)ctx[2] == NULL)
-            update_metrics_map_basic(TCP_ACCEPT_BASIC, 0, 0);
+        // 6.10+: ctx = [sk, arg, retsk]
+        if ((struct sock *)ctx[2] == NULL) {
+            // Read err from proto_accept_arg (ctx[1] is the arg pointer).
+            int err = 0;
+            bpf_probe_read_kernel(&err, sizeof(err),
+                &((struct proto_accept_arg___new *)ctx[1])->err);
+            // EAGAIN (-11) is normal for non-blocking accept; not a real drop.
+            if (err != 0 && err != -11)
+                update_metrics_map_basic(TCP_ACCEPT_BASIC, err, 0);
+        }
     } else {
-        if ((struct sock *)ctx[4] == NULL)
-            update_metrics_map_basic(TCP_ACCEPT_BASIC, 0, 0);
+        // Pre-6.10: ctx = [sk, flags, err_ptr, kern, retsk]
+        if ((struct sock *)ctx[4] == NULL) {
+            // ctx[2] is int *err — dereference to check error value.
+            int err = 0;
+            bpf_probe_read_kernel(&err, sizeof(err), (void *)ctx[2]);
+            // EAGAIN (-11) is normal for non-blocking accept; not a real drop.
+            if (err != 0 && err != -11)
+                update_metrics_map_basic(TCP_ACCEPT_BASIC, err, 0);
+        }
     }
 
     return 0;

--- a/pkg/plugin/dropreason/_cprog/drop_reason.c
+++ b/pkg/plugin/dropreason/_cprog/drop_reason.c
@@ -420,7 +420,12 @@ int BPF_KRETPROBE(inet_csk_accept_ret, struct sock *sk)
     if (sk != NULL)
         return 0;
 
-    int err = (int)*err_ptr;
+    // *err_ptr is the kernel pointer saved by the kprobe (not the error value).
+    // We must use bpf_probe_read_kernel to dereference it and get the actual error.
+    int err = 0;
+    if (bpf_probe_read_kernel(&err, sizeof(err), (void *)(unsigned long)*err_ptr) < 0)
+        return 0;
+
     // err >= 0 means no error; -EAGAIN (-11) is normal for non-blocking accept.
     if (err >= 0 || err == -11)
         return 0;
@@ -464,14 +469,12 @@ int BPF_PROG(inet_csk_accept_fexit)
         }
     } else {
         // Pre-6.10: ctx = [sk, flags, err_ptr, kern, retsk]
-        if ((struct sock *)ctx[4] == NULL) {
-            // ctx[2] is int *err — dereference to check error value.
-            int err = 0;
-            bpf_probe_read_kernel(&err, sizeof(err), (void *)ctx[2]);
-            // EAGAIN (-11) is normal for non-blocking accept; not a real drop.
-            if (err != 0 && err != -11)
-                update_metrics_map_basic(TCP_ACCEPT_BASIC, err, 0);
-        }
+        // On older kernels (e.g. 5.15), the BPF verifier rejects reading ctx[2]
+        // because the BTF encodes the int* parameter as scalar type INT.
+        // Since we cannot read the error code, we skip counting entirely.
+        // This eliminates the false-positive EAGAIN drops (the customer issue)
+        // at the cost of not reporting real accept errors on these kernels.
+        // The kretprobe path (enablePodLevel=true) handles this correctly.
     }
 
     return 0;

--- a/pkg/plugin/dropreason/_cprog/drop_reason.c
+++ b/pkg/plugin/dropreason/_cprog/drop_reason.c
@@ -474,7 +474,7 @@ int BPF_PROG(inet_csk_accept_fexit)
         // Since we cannot read the error code, we skip counting entirely.
         // This eliminates the false-positive EAGAIN drops (the customer issue)
         // at the cost of not reporting real accept errors on these kernels.
-        // The kretprobe path (enablePodLevel=true) handles this correctly.
+        // The kprobe/kretprobe path (attached by the Go loader) handles this correctly.
     }
 
     return 0;

--- a/pkg/plugin/dropreason/dropreason_linux.go
+++ b/pkg/plugin/dropreason/dropreason_linux.go
@@ -50,8 +50,6 @@ const (
 	nfConntrackConfirmFnFexit = "__nf_conntrack_confirm_fexit"
 )
 
-var errMissingAcceptKprobePrograms = errors.New("missing inet_csk_accept kprobe programs")
-
 func init() {
 	registry.Add(name, New)
 }
@@ -190,39 +188,30 @@ func (dr *dropReason) Init() error {
 		// Attach kprobe/kretprobe for inet_csk_accept alongside fexit programs.
 		// inet_csk_accept_fexit is not attached (pre-6.10 verifier limitation), so
 		// accept metrics depend on this kprobe/kretprobe pair being attached.
-		cleanupOnErr := func() {
-			for _, hook := range dr.hooks {
-				if hook != nil {
-					_ = hook.Close()
+		// If attachment fails, log a warning and continue — other drop metrics
+		// (IPTABLE_RULE_DROP, TCP_CONNECT_BASIC, etc.) remain functional.
+		if acceptKprobe == nil || acceptKretprobe == nil {
+			dr.l.Warn("inet_csk_accept kprobe programs not found in BPF object; TCP_ACCEPT_BASIC metrics will be unavailable")
+		} else {
+			kLink, kErr := link.Kprobe(inetCskAcceptFn, acceptKprobe, nil)
+			if kErr != nil {
+				dr.l.Error("Failed to attach kprobe for inet_csk_accept; TCP_ACCEPT_BASIC metrics will be unavailable",
+					zap.Error(kErr))
+			} else {
+				krLink, krErr := link.Kretprobe(inetCskAcceptFn, acceptKretprobe, nil)
+				if krErr != nil {
+					_ = kLink.Close()
+					dr.l.Error("Failed to attach kretprobe for inet_csk_accept; TCP_ACCEPT_BASIC metrics will be unavailable",
+						zap.Error(krErr))
+				} else {
+					dr.hooks = append(dr.hooks, kLink, krLink)
+					dr.l.Info("Attached kprobe", zap.String("program", inetCskAcceptFn))
+					dr.l.Info("Attached kretprobe", zap.String("program", inetCskAcceptFn))
 				}
 			}
-			dr.hooks = nil
-			if dr.reader != nil {
-				_ = dr.reader.Close()
-				dr.reader = nil
-			}
 		}
-		if acceptKprobe == nil || acceptKretprobe == nil {
-			cleanupOnErr()
-			return errMissingAcceptKprobePrograms
-		}
-
-		kLink, kErr := link.Kprobe(inetCskAcceptFn, acceptKprobe, nil)
-		if kErr != nil {
-			cleanupOnErr()
-			return fmt.Errorf("failed to attach kprobe for %s: %w", inetCskAcceptFn, kErr)
-		}
-
-		krLink, krErr := link.Kretprobe(inetCskAcceptFn, acceptKretprobe, nil)
-		if krErr != nil {
-			_ = kLink.Close()
-			cleanupOnErr()
-			return fmt.Errorf("failed to attach kretprobe for %s: %w", inetCskAcceptFn, krErr)
-		}
-
-		dr.hooks = append(dr.hooks, kLink, krLink)
-		dr.l.Info("Attached kprobe", zap.String("program", inetCskAcceptFn))
-		dr.l.Info("Attached kretprobe", zap.String("program", inetCskAcceptFn))
+		dr.l.Warn("inet_csk_accept_fexit is not attached (pre-6.10 BPF verifier limitation); " +
+			"using kprobe/kretprobe fallback for TCP accept error metrics")
 	} else {
 		err = dr.attachKprobes(progsKprobe, progsKprobeRet)
 	}

--- a/pkg/plugin/dropreason/dropreason_linux.go
+++ b/pkg/plugin/dropreason/dropreason_linux.go
@@ -50,6 +50,8 @@ const (
 	nfConntrackConfirmFnFexit = "__nf_conntrack_confirm_fexit"
 )
 
+var errMissingAcceptKprobePrograms = errors.New("missing inet_csk_accept kprobe programs")
+
 func init() {
 	registry.Add(name, New)
 }
@@ -186,27 +188,26 @@ func (dr *dropReason) Init() error {
 			return err
 		}
 		// Attach kprobe/kretprobe for inet_csk_accept alongside fexit programs.
-		// The fexit inet_csk_accept_fexit is a no-op on pre-6.10 kernels (BPF verifier
-		// rejects reading the err pointer from ctx). The kretprobe path correctly reads
-		// the error via bpf_probe_read_kernel and filters EAGAIN.
-		if acceptKprobe != nil {
-			kLink, kErr := link.Kprobe(inetCskAcceptFn, acceptKprobe, nil)
-			if kErr != nil {
-				dr.l.Error("Failed to attach kprobe for inet_csk_accept", zap.Error(kErr))
-				return errors.Wrap(kErr, "failed to attach kprobe for inet_csk_accept")
-			}
-			dr.hooks = append(dr.hooks, kLink)
-			dr.l.Info("Attached kprobe", zap.String("program", inetCskAcceptFn))
+		// inet_csk_accept_fexit is not attached (pre-6.10 verifier limitation), so
+		// accept metrics depend on this kprobe/kretprobe pair being attached.
+		if acceptKprobe == nil || acceptKretprobe == nil {
+			return errMissingAcceptKprobePrograms
 		}
-		if acceptKretprobe != nil {
-			krLink, krErr := link.Kretprobe(inetCskAcceptFn, acceptKretprobe, nil)
-			if krErr != nil {
-				dr.l.Error("Failed to attach kretprobe for inet_csk_accept", zap.Error(krErr))
-				return errors.Wrap(krErr, "failed to attach kretprobe for inet_csk_accept")
-			}
-			dr.hooks = append(dr.hooks, krLink)
-			dr.l.Info("Attached kretprobe", zap.String("program", inetCskAcceptFn))
+
+		kLink, kErr := link.Kprobe(inetCskAcceptFn, acceptKprobe, nil)
+		if kErr != nil {
+			return fmt.Errorf("failed to attach kprobe for %s: %w", inetCskAcceptFn, kErr)
 		}
+		dr.hooks = append(dr.hooks, kLink)
+		dr.l.Info("Attached kprobe", zap.String("program", inetCskAcceptFn))
+
+		krLink, krErr := link.Kretprobe(inetCskAcceptFn, acceptKretprobe, nil)
+		if krErr != nil {
+			kLink.Close()
+			return fmt.Errorf("failed to attach kretprobe for %s: %w", inetCskAcceptFn, krErr)
+		}
+		dr.hooks = append(dr.hooks, krLink)
+		dr.l.Info("Attached kretprobe", zap.String("program", inetCskAcceptFn))
 	} else {
 		err = dr.attachKprobes(progsKprobe, progsKprobeRet)
 	}

--- a/pkg/plugin/dropreason/dropreason_linux.go
+++ b/pkg/plugin/dropreason/dropreason_linux.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cilium/cilium/api/v1/flow"
 	hubblev1 "github.com/cilium/cilium/pkg/hubble/api/v1"
 	"github.com/cilium/ebpf"
+	"github.com/cilium/ebpf/link"
 	"github.com/cilium/ebpf/perf"
 	"github.com/microsoft/retina/internal/ktime"
 	kcfg "github.com/microsoft/retina/pkg/config"
@@ -177,10 +178,35 @@ func (dr *dropReason) Init() error {
 	}
 
 	progsKprobe, progsKprobeRet := buildKprobePrograms(objs)
-	progsFexit := buildFexitPrograms(objs)
+	progsFexit, acceptKprobe, acceptKretprobe := buildFexitPrograms(objs)
 
 	if supportsFexit {
 		err = dr.attachFexitPrograms(progsFexit)
+		if err != nil {
+			return err
+		}
+		// Attach kprobe/kretprobe for inet_csk_accept alongside fexit programs.
+		// The fexit inet_csk_accept_fexit is a no-op on pre-6.10 kernels (BPF verifier
+		// rejects reading the err pointer from ctx). The kretprobe path correctly reads
+		// the error via bpf_probe_read_kernel and filters EAGAIN.
+		if acceptKprobe != nil {
+			kLink, kErr := link.Kprobe(inetCskAcceptFn, acceptKprobe, nil)
+			if kErr != nil {
+				dr.l.Error("Failed to attach kprobe for inet_csk_accept", zap.Error(kErr))
+			} else {
+				dr.hooks = append(dr.hooks, kLink)
+				dr.l.Info("Attached kprobe", zap.String("program", inetCskAcceptFn))
+			}
+		}
+		if acceptKretprobe != nil {
+			krLink, krErr := link.Kretprobe(inetCskAcceptFn, acceptKretprobe, nil)
+			if krErr != nil {
+				dr.l.Error("Failed to attach kretprobe for inet_csk_accept", zap.Error(krErr))
+			} else {
+				dr.hooks = append(dr.hooks, krLink)
+				dr.l.Info("Attached kretprobe", zap.String("program", inetCskAcceptFn))
+			}
+		}
 	} else {
 		err = dr.attachKprobes(progsKprobe, progsKprobeRet)
 	}

--- a/pkg/plugin/dropreason/dropreason_linux.go
+++ b/pkg/plugin/dropreason/dropreason_linux.go
@@ -190,18 +190,33 @@ func (dr *dropReason) Init() error {
 		// Attach kprobe/kretprobe for inet_csk_accept alongside fexit programs.
 		// inet_csk_accept_fexit is not attached (pre-6.10 verifier limitation), so
 		// accept metrics depend on this kprobe/kretprobe pair being attached.
+		cleanupOnErr := func() {
+			for _, hook := range dr.hooks {
+				if hook != nil {
+					_ = hook.Close()
+				}
+			}
+			dr.hooks = nil
+			if dr.reader != nil {
+				_ = dr.reader.Close()
+				dr.reader = nil
+			}
+		}
 		if acceptKprobe == nil || acceptKretprobe == nil {
+			cleanupOnErr()
 			return errMissingAcceptKprobePrograms
 		}
 
 		kLink, kErr := link.Kprobe(inetCskAcceptFn, acceptKprobe, nil)
 		if kErr != nil {
+			cleanupOnErr()
 			return fmt.Errorf("failed to attach kprobe for %s: %w", inetCskAcceptFn, kErr)
 		}
 
 		krLink, krErr := link.Kretprobe(inetCskAcceptFn, acceptKretprobe, nil)
 		if krErr != nil {
-			kLink.Close()
+			_ = kLink.Close()
+			cleanupOnErr()
 			return fmt.Errorf("failed to attach kretprobe for %s: %w", inetCskAcceptFn, krErr)
 		}
 

--- a/pkg/plugin/dropreason/dropreason_linux.go
+++ b/pkg/plugin/dropreason/dropreason_linux.go
@@ -193,19 +193,19 @@ func (dr *dropReason) Init() error {
 			kLink, kErr := link.Kprobe(inetCskAcceptFn, acceptKprobe, nil)
 			if kErr != nil {
 				dr.l.Error("Failed to attach kprobe for inet_csk_accept", zap.Error(kErr))
-			} else {
-				dr.hooks = append(dr.hooks, kLink)
-				dr.l.Info("Attached kprobe", zap.String("program", inetCskAcceptFn))
+				return errors.Wrap(kErr, "failed to attach kprobe for inet_csk_accept")
 			}
+			dr.hooks = append(dr.hooks, kLink)
+			dr.l.Info("Attached kprobe", zap.String("program", inetCskAcceptFn))
 		}
 		if acceptKretprobe != nil {
 			krLink, krErr := link.Kretprobe(inetCskAcceptFn, acceptKretprobe, nil)
 			if krErr != nil {
 				dr.l.Error("Failed to attach kretprobe for inet_csk_accept", zap.Error(krErr))
-			} else {
-				dr.hooks = append(dr.hooks, krLink)
-				dr.l.Info("Attached kretprobe", zap.String("program", inetCskAcceptFn))
+				return errors.Wrap(krErr, "failed to attach kretprobe for inet_csk_accept")
 			}
+			dr.hooks = append(dr.hooks, krLink)
+			dr.l.Info("Attached kretprobe", zap.String("program", inetCskAcceptFn))
 		}
 	} else {
 		err = dr.attachKprobes(progsKprobe, progsKprobeRet)

--- a/pkg/plugin/dropreason/dropreason_linux.go
+++ b/pkg/plugin/dropreason/dropreason_linux.go
@@ -198,15 +198,15 @@ func (dr *dropReason) Init() error {
 		if kErr != nil {
 			return fmt.Errorf("failed to attach kprobe for %s: %w", inetCskAcceptFn, kErr)
 		}
-		dr.hooks = append(dr.hooks, kLink)
-		dr.l.Info("Attached kprobe", zap.String("program", inetCskAcceptFn))
 
 		krLink, krErr := link.Kretprobe(inetCskAcceptFn, acceptKretprobe, nil)
 		if krErr != nil {
 			kLink.Close()
 			return fmt.Errorf("failed to attach kretprobe for %s: %w", inetCskAcceptFn, krErr)
 		}
-		dr.hooks = append(dr.hooks, krLink)
+
+		dr.hooks = append(dr.hooks, kLink, krLink)
+		dr.l.Info("Attached kprobe", zap.String("program", inetCskAcceptFn))
 		dr.l.Info("Attached kretprobe", zap.String("program", inetCskAcceptFn))
 	} else {
 		err = dr.attachKprobes(progsKprobe, progsKprobeRet)

--- a/pkg/plugin/dropreason/dropreason_linux_test.go
+++ b/pkg/plugin/dropreason/dropreason_linux_test.go
@@ -738,31 +738,20 @@ func TestResolvePayload_KprobeObjectsNotAffected(t *testing.T) {
 	require.True(t, hasAcceptKretprobe, "kprobe objects should have inet_csk_accept kretprobe")
 }
 
-// TestBuildFexitPrograms_NilAcceptProgramsTriggerError verifies that when
+// TestBuildFexitPrograms_NilAcceptProgramsLogged verifies that when
 // buildFexitPrograms returns nil kprobe/kretprobe programs (e.g. due to a
-// struct mismatch), the Init() nil-check would catch it. This tests the
-// precondition that buildFexitPrograms with kprobe-only objects returns nil.
-func TestBuildFexitPrograms_NilAcceptProgramsTriggerError(t *testing.T) {
+// struct mismatch), Init() would log a warning and continue rather than
+// crashing the plugin. Other drop metrics remain functional.
+func TestBuildFexitPrograms_NilAcceptProgramsLogged(t *testing.T) {
 	// allKprobeObjects passed to buildFexitPrograms should return nil accept programs
-	// (since it's not a fexit object type). This simulates the scenario where
-	// Init() would call cleanupOnErr and return errMissingAcceptKprobePrograms.
+	// (since it's not a fexit object type).
 	objs := &allKprobeObjects{}
 	_, acceptKprobe, acceptKretprobe := buildFexitPrograms(objs)
 
-	// Verify these are nil — in Init(), this triggers the cleanup path
+	// Verify these are nil — in Init(), this triggers a warning log
+	// but does NOT cause the plugin to fail.
 	require.Nil(t, acceptKprobe)
 	require.Nil(t, acceptKretprobe)
-
-	// Verify the sentinel error message
-	require.EqualError(t, errMissingAcceptKprobePrograms, "missing inet_csk_accept kprobe programs")
-}
-
-// TestErrMissingAcceptKprobePrograms_IsSentinel verifies the sentinel error
-// can be checked with errors.Is for programmatic error handling.
-func TestErrMissingAcceptKprobePrograms_IsSentinel(t *testing.T) {
-	wrapped := fmt.Errorf("init failed: %w", errMissingAcceptKprobePrograms)
-	require.ErrorIs(t, wrapped, errMissingAcceptKprobePrograms)
-	require.EqualError(t, errMissingAcceptKprobePrograms, "missing inet_csk_accept kprobe programs")
 }
 
 // Helpers.

--- a/pkg/plugin/dropreason/dropreason_linux_test.go
+++ b/pkg/plugin/dropreason/dropreason_linux_test.go
@@ -738,6 +738,32 @@ func TestResolvePayload_KprobeObjectsNotAffected(t *testing.T) {
 	require.True(t, hasAcceptKretprobe, "kprobe objects should have inet_csk_accept kretprobe")
 }
 
+// TestBuildFexitPrograms_NilAcceptProgramsTriggerError verifies that when
+// buildFexitPrograms returns nil kprobe/kretprobe programs (e.g. due to a
+// struct mismatch), the Init() nil-check would catch it. This tests the
+// precondition that buildFexitPrograms with kprobe-only objects returns nil.
+func TestBuildFexitPrograms_NilAcceptProgramsTriggerError(t *testing.T) {
+	// allKprobeObjects passed to buildFexitPrograms should return nil accept programs
+	// (since it's not a fexit object type). This simulates the scenario where
+	// Init() would call cleanupOnErr and return errMissingAcceptKprobePrograms.
+	objs := &allKprobeObjects{}
+	_, acceptKprobe, acceptKretprobe := buildFexitPrograms(objs)
+
+	// Verify these are nil — in Init(), this triggers the cleanup path
+	require.Nil(t, acceptKprobe)
+	require.Nil(t, acceptKretprobe)
+
+	// Verify the sentinel error is the one returned
+	require.ErrorIs(t, errMissingAcceptKprobePrograms, errMissingAcceptKprobePrograms)
+}
+
+// TestErrMissingAcceptKprobePrograms_IsSentinel verifies the sentinel error
+// can be checked with errors.Is for programmatic error handling.
+func TestErrMissingAcceptKprobePrograms_IsSentinel(t *testing.T) {
+	require.True(t, errors.Is(errMissingAcceptKprobePrograms, errMissingAcceptKprobePrograms))
+	require.EqualError(t, errMissingAcceptKprobePrograms, "missing inet_csk_accept kprobe programs")
+}
+
 // Helpers.
 func takeBackup() {
 	// Get the directory of the current test file.

--- a/pkg/plugin/dropreason/dropreason_linux_test.go
+++ b/pkg/plugin/dropreason/dropreason_linux_test.go
@@ -753,14 +753,15 @@ func TestBuildFexitPrograms_NilAcceptProgramsTriggerError(t *testing.T) {
 	require.Nil(t, acceptKprobe)
 	require.Nil(t, acceptKretprobe)
 
-	// Verify the sentinel error is the one returned
-	require.ErrorIs(t, errMissingAcceptKprobePrograms, errMissingAcceptKprobePrograms)
+	// Verify the sentinel error message
+	require.EqualError(t, errMissingAcceptKprobePrograms, "missing inet_csk_accept kprobe programs")
 }
 
 // TestErrMissingAcceptKprobePrograms_IsSentinel verifies the sentinel error
 // can be checked with errors.Is for programmatic error handling.
 func TestErrMissingAcceptKprobePrograms_IsSentinel(t *testing.T) {
-	require.True(t, errors.Is(errMissingAcceptKprobePrograms, errMissingAcceptKprobePrograms))
+	wrapped := fmt.Errorf("init failed: %w", errMissingAcceptKprobePrograms)
+	require.ErrorIs(t, wrapped, errMissingAcceptKprobePrograms)
 	require.EqualError(t, errMissingAcceptKprobePrograms, "missing inet_csk_accept kprobe programs")
 }
 

--- a/pkg/plugin/dropreason/dropreason_linux_test.go
+++ b/pkg/plugin/dropreason/dropreason_linux_test.go
@@ -710,3 +710,70 @@ func restoreBackup() {
 		}
 	}
 }
+
+func TestBuildFexitPrograms_ReturnsKprobeForAccept(t *testing.T) {
+	// When using allFexitObjects, buildFexitPrograms should:
+	// 1. NOT include inet_csk_accept_fexit in the fexit map (it's a no-op on pre-6.10)
+	// 2. Return the kprobe and kretprobe programs for inet_csk_accept
+	objs := &allFexitObjects{}
+
+	progsFexit, acceptKprobe, acceptKretprobe := buildFexitPrograms(objs)
+
+	// inet_csk_accept_fexit should NOT be in the fexit map
+	if _, exists := progsFexit[inetCskAcceptFnFexit]; exists {
+		t.Error("inet_csk_accept_fexit should not be in progsFexit map (it's a no-op on pre-6.10)")
+	}
+
+	// Other fexit programs should be present
+	if _, exists := progsFexit[nfHookSlowFnFexit]; !exists {
+		t.Error("nf_hook_slow_fexit should be in progsFexit map")
+	}
+	if _, exists := progsFexit[tcpV4ConnectFexit]; !exists {
+		t.Error("tcp_v4_connect_fexit should be in progsFexit map")
+	}
+
+	// Kprobe/kretprobe for inet_csk_accept should be returned (nil programs since
+	// objects aren't loaded, but the fields should be accessed without panic)
+	_ = acceptKprobe
+	_ = acceptKretprobe
+}
+
+func TestBuildFexitPrograms_MarinerReturnsKprobeForAccept(t *testing.T) {
+	objs := &marinerObjects{}
+
+	progsFexit, acceptKprobe, acceptKretprobe := buildFexitPrograms(objs)
+
+	// inet_csk_accept_fexit should NOT be in the fexit map
+	if _, exists := progsFexit[inetCskAcceptFnFexit]; exists {
+		t.Error("inet_csk_accept_fexit should not be in progsFexit map for mariner")
+	}
+
+	// Other fexit programs should be present
+	if _, exists := progsFexit[nfHookSlowFnFexit]; !exists {
+		t.Error("nf_hook_slow_fexit should be in progsFexit map")
+	}
+	if _, exists := progsFexit[tcpV4ConnectFexit]; !exists {
+		t.Error("tcp_v4_connect_fexit should be in progsFexit map")
+	}
+
+	_ = acceptKprobe
+	_ = acceptKretprobe
+}
+
+func TestBuildFexitPrograms_KprobeObjectsReturnsNil(t *testing.T) {
+	// When passed a kprobe-only object, buildFexitPrograms should return empty map
+	// and nil kprobe/kretprobe (since kprobes are handled by buildKprobePrograms)
+	objs := &allKprobeObjects{}
+
+	progsFexit, acceptKprobe, acceptKretprobe := buildFexitPrograms(objs)
+
+	if len(progsFexit) != 0 {
+		t.Errorf("expected empty fexit map for kprobe objects, got %d entries", len(progsFexit))
+	}
+	if acceptKprobe != nil {
+		t.Error("expected nil acceptKprobe for kprobe objects")
+	}
+	if acceptKretprobe != nil {
+		t.Error("expected nil acceptKretprobe for kprobe objects")
+	}
+}

--- a/pkg/plugin/dropreason/dropreason_linux_test.go
+++ b/pkg/plugin/dropreason/dropreason_linux_test.go
@@ -157,7 +157,7 @@ func TestProcessMapValue(t *testing.T) {
 // After the fix, the eBPF program filters out EAGAIN (-11) and only writes
 // genuine errors to the map with their error code in ReturnVal.
 func TestProcessMapValue_TCPAcceptBasicWithError(t *testing.T) {
-	_ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	metrics.InitializeMetrics(slog.Default())
 	dr := &dropReason{
 		cfg: cfgPodLevelEnabled,
@@ -186,7 +186,7 @@ func TestProcessMapValue_TCPAcceptBasicWithError(t *testing.T) {
 // This test verifies that if somehow an EAGAIN entry did appear (e.g. race
 // during upgrade), it would still be processed — the filtering is in eBPF.
 func TestProcessMapValue_TCPAcceptBasicEAGAINNotInMap(t *testing.T) {
-	_ = log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	metrics.InitializeMetrics(slog.Default())
 	dr := &dropReason{
 		cfg: cfgPodLevelEnabled,

--- a/pkg/plugin/dropreason/dropreason_linux_test.go
+++ b/pkg/plugin/dropreason/dropreason_linux_test.go
@@ -178,7 +178,7 @@ func TestProcessMapValue_TCPAcceptBasicWithError(t *testing.T) {
 	dropCount := &dto.Metric{}
 	err := metrics.DropPacketsGauge.WithLabelValues(reason, direction).Write(dropCount)
 	require.NoError(t, err)
-	require.Equal(t, float64(5), dropCount.GetGauge().GetValue())
+	require.InDelta(t, float64(5), dropCount.GetGauge().GetValue(), 0)
 }
 
 // TestProcessMapValue_TCPAcceptBasicEAGAINNotInMap documents that after the
@@ -210,7 +210,7 @@ func TestProcessMapValue_TCPAcceptBasicEAGAINNotInMap(t *testing.T) {
 	dropCount := &dto.Metric{}
 	err := metrics.DropPacketsGauge.WithLabelValues(reason, direction).Write(dropCount)
 	require.NoError(t, err)
-	require.Equal(t, float64(942303), dropCount.GetGauge().GetValue())
+	require.InDelta(t, float64(942303), dropCount.GetGauge().GetValue(), 0)
 }
 
 // TestDropMetricKey_GetDirection verifies direction mapping for all drop types.

--- a/pkg/plugin/dropreason/dropreason_linux_test.go
+++ b/pkg/plugin/dropreason/dropreason_linux_test.go
@@ -152,6 +152,89 @@ func TestProcessMapValue(t *testing.T) {
 	require.Equal(t, float64(testMetricValues[0].Bytes), dropBytesValue, "Expected drop bytes to be %d but got %d", float64(testMetricValues[0].Bytes), dropBytesValue)
 }
 
+// TestProcessMapValue_TCPAcceptBasicWithError verifies that TCP_ACCEPT_BASIC
+// entries with a real error code (not EAGAIN) are correctly reported.
+// After the fix, the eBPF program filters out EAGAIN (-11) and only writes
+// genuine errors to the map with their error code in ReturnVal.
+func TestProcessMapValue_TCPAcceptBasicWithError(t *testing.T) {
+	log.SetupZapLogger(log.GetDefaultLogOpts())
+	metrics.InitializeMetrics(slog.Default())
+	dr := &dropReason{
+		cfg: cfgPodLevelEnabled,
+		l:   log.Logger().Named(name),
+	}
+
+	// TCP_ACCEPT_BASIC = 3, with a real error like -ENOMEM (-12).
+	testMetricKey := dropMetricKey{DropType: 3, ReturnVal: -12}
+	testMetricValues := dropMetricValues{{Count: 5, Bytes: 0}}
+
+	dr.processMapValue(testMetricKey, testMetricValues)
+
+	reason := testMetricKey.getType()
+	direction := testMetricKey.getDirection()
+	require.Equal(t, "TCP_ACCEPT_BASIC", reason)
+	require.Equal(t, "ingress", direction)
+
+	dropCount := &dto.Metric{}
+	err := metrics.DropPacketsGauge.WithLabelValues(reason, direction).Write(dropCount)
+	require.NoError(t, err)
+	require.Equal(t, float64(5), *dropCount.Gauge.Value)
+}
+
+// TestProcessMapValue_TCPAcceptBasicEAGAINNotInMap documents that after the
+// eBPF fix, EAGAIN errors are filtered in-kernel and never appear in the map.
+// This test verifies that if somehow an EAGAIN entry did appear (e.g. race
+// during upgrade), it would still be processed — the filtering is in eBPF.
+func TestProcessMapValue_TCPAcceptBasicEAGAINNotInMap(t *testing.T) {
+	log.SetupZapLogger(log.GetDefaultLogOpts())
+	metrics.InitializeMetrics(slog.Default())
+	dr := &dropReason{
+		cfg: cfgPodLevelEnabled,
+		l:   log.Logger().Named(name),
+	}
+
+	// Simulate what the OLD buggy code would produce: TCP_ACCEPT_BASIC with
+	// ReturnVal=0 (the old fexit didn't pass any error code).
+	testMetricKey := dropMetricKey{DropType: 3, ReturnVal: 0}
+	testMetricValues := dropMetricValues{{Count: 942303, Bytes: 0}}
+
+	dr.processMapValue(testMetricKey, testMetricValues)
+
+	reason := testMetricKey.getType()
+	direction := testMetricKey.getDirection()
+	require.Equal(t, "TCP_ACCEPT_BASIC", reason)
+	require.Equal(t, "ingress", direction)
+
+	// The Go side still processes whatever the map contains; the fix is that
+	// the eBPF program no longer writes these entries for EAGAIN.
+	dropCount := &dto.Metric{}
+	err := metrics.DropPacketsGauge.WithLabelValues(reason, direction).Write(dropCount)
+	require.NoError(t, err)
+	require.Equal(t, float64(942303), *dropCount.Gauge.Value)
+}
+
+// TestDropMetricKey_GetDirection verifies direction mapping for all drop types.
+func TestDropMetricKey_GetDirection(t *testing.T) {
+	tests := []struct {
+		dropType  uint16
+		wantDir   string
+		wantType  string
+	}{
+		{dropType: 0, wantDir: "unknown", wantType: "IPTABLE_RULE_DROP"},
+		{dropType: 1, wantDir: "unknown", wantType: "IPTABLE_NAT_DROP"},
+		{dropType: 2, wantDir: "egress", wantType: "TCP_CONNECT_BASIC"},
+		{dropType: 3, wantDir: "ingress", wantType: "TCP_ACCEPT_BASIC"},
+		{dropType: 5, wantDir: "unknown", wantType: "CONNTRACK_ADD_DROP"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.wantType, func(t *testing.T) {
+			dk := &dropMetricKey{DropType: tt.dropType}
+			require.Equal(t, tt.wantDir, dk.getDirection())
+			require.Equal(t, tt.wantType, dk.getType())
+		})
+	}
+}
+
 func TestDropReasonRun_Error(t *testing.T) {
 	log.SetupZapLogger(log.GetDefaultLogOpts())
 	ctrl := gomock.NewController(t)

--- a/pkg/plugin/dropreason/dropreason_linux_test.go
+++ b/pkg/plugin/dropreason/dropreason_linux_test.go
@@ -183,8 +183,8 @@ func TestProcessMapValue_TCPAcceptBasicWithError(t *testing.T) {
 
 // TestProcessMapValue_TCPAcceptBasicEAGAINNotInMap documents that after the
 // eBPF fix, EAGAIN errors are filtered in-kernel and never appear in the map.
-// This test verifies that if somehow an EAGAIN entry did appear (e.g. race
-// during upgrade), it would still be processed — the filtering is in eBPF.
+// This test verifies that if an EAGAIN entry did appear (e.g. during upgrade),
+// the Go-side processing would still record it; the filtering happens in eBPF.
 func TestProcessMapValue_TCPAcceptBasicEAGAINNotInMap(t *testing.T) {
 	_, _ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	metrics.InitializeMetrics(slog.Default())
@@ -193,9 +193,8 @@ func TestProcessMapValue_TCPAcceptBasicEAGAINNotInMap(t *testing.T) {
 		l:   log.Logger().Named(name),
 	}
 
-	// Simulate what the OLD buggy code would produce: TCP_ACCEPT_BASIC with
-	// ReturnVal=0 (the old fexit didn't pass any error code).
-	testMetricKey := dropMetricKey{DropType: 3, ReturnVal: 0}
+	// Simulate an unexpected TCP_ACCEPT_BASIC EAGAIN (-11) entry reaching userspace.
+	testMetricKey := dropMetricKey{DropType: 3, ReturnVal: -11}
 	testMetricValues := dropMetricValues{{Count: 942303, Bytes: 0}}
 
 	dr.processMapValue(testMetricKey, testMetricValues)

--- a/pkg/plugin/dropreason/dropreason_linux_test.go
+++ b/pkg/plugin/dropreason/dropreason_linux_test.go
@@ -157,7 +157,7 @@ func TestProcessMapValue(t *testing.T) {
 // After the fix, the eBPF program filters out EAGAIN (-11) and only writes
 // genuine errors to the map with their error code in ReturnVal.
 func TestProcessMapValue_TCPAcceptBasicWithError(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	metrics.InitializeMetrics(slog.Default())
 	dr := &dropReason{
 		cfg: cfgPodLevelEnabled,
@@ -178,7 +178,7 @@ func TestProcessMapValue_TCPAcceptBasicWithError(t *testing.T) {
 	dropCount := &dto.Metric{}
 	err := metrics.DropPacketsGauge.WithLabelValues(reason, direction).Write(dropCount)
 	require.NoError(t, err)
-	require.Equal(t, float64(5), *dropCount.Gauge.Value)
+	require.Equal(t, float64(5), dropCount.GetGauge().GetValue())
 }
 
 // TestProcessMapValue_TCPAcceptBasicEAGAINNotInMap documents that after the
@@ -186,7 +186,7 @@ func TestProcessMapValue_TCPAcceptBasicWithError(t *testing.T) {
 // This test verifies that if somehow an EAGAIN entry did appear (e.g. race
 // during upgrade), it would still be processed — the filtering is in eBPF.
 func TestProcessMapValue_TCPAcceptBasicEAGAINNotInMap(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_ = log.SetupZapLogger(log.GetDefaultLogOpts())
 	metrics.InitializeMetrics(slog.Default())
 	dr := &dropReason{
 		cfg: cfgPodLevelEnabled,
@@ -210,15 +210,15 @@ func TestProcessMapValue_TCPAcceptBasicEAGAINNotInMap(t *testing.T) {
 	dropCount := &dto.Metric{}
 	err := metrics.DropPacketsGauge.WithLabelValues(reason, direction).Write(dropCount)
 	require.NoError(t, err)
-	require.Equal(t, float64(942303), *dropCount.Gauge.Value)
+	require.Equal(t, float64(942303), dropCount.GetGauge().GetValue())
 }
 
 // TestDropMetricKey_GetDirection verifies direction mapping for all drop types.
 func TestDropMetricKey_GetDirection(t *testing.T) {
 	tests := []struct {
-		dropType  uint16
-		wantDir   string
-		wantType  string
+		dropType uint16
+		wantDir  string
+		wantType string
 	}{
 		{dropType: 0, wantDir: "unknown", wantType: "IPTABLE_RULE_DROP"},
 		{dropType: 1, wantDir: "unknown", wantType: "IPTABLE_NAT_DROP"},
@@ -671,6 +671,72 @@ func TestResolveEbpfPayload(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestResolvePayload_FexitObjectsHaveKprobeFields verifies that when resolvePayload
+// returns fexit objects (allFexitObjects or marinerObjects), the structs include
+// the InetCskAccept and InetCskAcceptRet fields needed for the kprobe fallback.
+func TestResolvePayload_FexitObjectsHaveKprobeFields(t *testing.T) {
+	tests := []struct {
+		name      string
+		arch      string
+		kv        semver.Version
+		isMariner bool
+	}{
+		{
+			name:      "allFexitObjects has kprobe fields",
+			arch:      "amd64",
+			kv:        mustVersion("5.15.0"),
+			isMariner: false,
+		},
+		{
+			name:      "marinerObjects has kprobe fields",
+			arch:      "amd64",
+			kv:        mustVersion("6.6.0"),
+			isMariner: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			objs, _, isFexit := resolvePayload(tt.arch, tt.kv, tt.isMariner, false, true)
+			require.True(t, isFexit, "expected fexit mode")
+
+			// buildFexitPrograms should be able to extract kprobe fields without panic
+			progsFexit, acceptKprobe, acceptKretprobe := buildFexitPrograms(objs)
+
+			// fexit map should have other programs but NOT inet_csk_accept_fexit
+			require.NotEmpty(t, progsFexit, "expected non-empty fexit map")
+			_, hasAcceptFexit := progsFexit[inetCskAcceptFnFexit]
+			require.False(t, hasAcceptFexit, "inet_csk_accept_fexit should not be in fexit map")
+			_, hasNfHook := progsFexit[nfHookSlowFnFexit]
+			require.True(t, hasNfHook, "nf_hook_slow_fexit should be in fexit map")
+
+			// kprobe/kretprobe fields should be accessible (nil since we didn't
+			// load the BPF ELF, but the struct fields must exist and be returned)
+			_ = acceptKprobe
+			_ = acceptKretprobe
+		})
+	}
+}
+
+// TestResolvePayload_KprobeObjectsNotAffected verifies that when pod-level mode
+// is used (kprobe-only), the buildFexitPrograms returns empty and nil.
+func TestResolvePayload_KprobeObjectsNotAffected(t *testing.T) {
+	objs, _, isFexit := resolvePayload("amd64", mustVersion("5.15.0"), false, true, true)
+	require.False(t, isFexit, "pod-level should not use fexit")
+
+	progsFexit, acceptKprobe, acceptKretprobe := buildFexitPrograms(objs)
+	require.Empty(t, progsFexit, "kprobe objects should yield empty fexit map")
+	require.Nil(t, acceptKprobe, "kprobe objects should not return acceptKprobe via buildFexitPrograms")
+	require.Nil(t, acceptKretprobe, "kprobe objects should not return acceptKretprobe via buildFexitPrograms")
+
+	// Verify kprobe programs are correctly built for inet_csk_accept
+	progsKprobe, progsKprobeRet := buildKprobePrograms(objs)
+	_, hasAcceptKprobe := progsKprobe[inetCskAcceptFn]
+	require.True(t, hasAcceptKprobe, "kprobe objects should have inet_csk_accept kprobe")
+	_, hasAcceptKretprobe := progsKprobeRet[inetCskAcceptFn]
+	require.True(t, hasAcceptKretprobe, "kprobe objects should have inet_csk_accept kretprobe")
 }
 
 // Helpers.

--- a/pkg/plugin/dropreason/ebpfsetup_linux.go
+++ b/pkg/plugin/dropreason/ebpfsetup_linux.go
@@ -185,21 +185,28 @@ func buildKprobePrograms(objs any) (progsKprobe, progsKprobeRet map[string]*ebpf
 	return progsKprobe, progsKprobeRet
 }
 
-func buildFexitPrograms(objs any) map[string]*ebpf.Program {
-	progsFexit := make(map[string]*ebpf.Program)
+func buildFexitPrograms(objs any) (progsFexit map[string]*ebpf.Program, acceptKprobe, acceptKretprobe *ebpf.Program) {
+	progsFexit = make(map[string]*ebpf.Program)
 
 	switch o := objs.(type) {
 	case *allFexitObjects:
-		progsFexit[inetCskAcceptFnFexit] = o.InetCskAcceptFexit
+		// inet_csk_accept_fexit is a no-op on pre-6.10 kernels (verifier rejects
+		// ctx[2] access). We use the kprobe/kretprobe pair instead, which correctly
+		// reads the error value and filters EAGAIN.
+		// On 6.10+ kernels, the fexit handles it via proto_accept_arg (CO-RE).
+		// Including both is safe: the fexit no-op won't conflict with the kretprobe.
+		acceptKprobe = o.InetCskAccept
+		acceptKretprobe = o.InetCskAcceptRet
 		progsFexit[nfHookSlowFnFexit] = o.NfHookSlowFexit
 		progsFexit[tcpV4ConnectFexit] = o.TcpV4ConnectFexit
 		progsFexit[nfNatInetFnFexit] = o.NfNatInetFnFexit
 		progsFexit[nfConntrackConfirmFnFexit] = o.NfConntrackConfirmFexit
 
 	case *marinerObjects:
-		progsFexit[inetCskAcceptFnFexit] = o.InetCskAcceptFexit
+		acceptKprobe = o.InetCskAccept
+		acceptKretprobe = o.InetCskAcceptRet
 		progsFexit[nfHookSlowFnFexit] = o.NfHookSlowFexit
 		progsFexit[tcpV4ConnectFexit] = o.TcpV4ConnectFexit
 	}
-	return progsFexit
+	return progsFexit, acceptKprobe, acceptKretprobe
 }

--- a/pkg/plugin/dropreason/ebpfsetup_linux.go
+++ b/pkg/plugin/dropreason/ebpfsetup_linux.go
@@ -190,11 +190,10 @@ func buildFexitPrograms(objs any) (progsFexit map[string]*ebpf.Program, acceptKp
 
 	switch o := objs.(type) {
 	case *allFexitObjects:
-		// inet_csk_accept_fexit is a no-op on pre-6.10 kernels (verifier rejects
-		// ctx[2] access). We use the kprobe/kretprobe pair instead, which correctly
-		// reads the error value and filters EAGAIN.
-		// On 6.10+ kernels, the fexit handles it via proto_accept_arg (CO-RE).
-		// Including both is safe: the fexit no-op won't conflict with the kretprobe.
+		// inet_csk_accept_fexit is not attached because pre-6.10 kernels' verifier rejects
+		// reading the err pointer from the fexit ctx. We always attach the inet_csk_accept
+		// kprobe/kretprobe pair (even in fexit mode) to report accept errors and filter
+		// out -EAGAIN.
 		acceptKprobe = o.InetCskAccept
 		acceptKretprobe = o.InetCskAcceptRet
 		progsFexit[nfHookSlowFnFexit] = o.NfHookSlowFexit

--- a/pkg/plugin/dropreason/types_linux.go
+++ b/pkg/plugin/dropreason/types_linux.go
@@ -49,6 +49,8 @@ type allFexitObjects struct {
 
 type allFexitPrograms struct {
 	InetCskAcceptFexit      *ebpf.Program `ebpf:"inet_csk_accept_fexit"`
+	InetCskAccept           *ebpf.Program `ebpf:"inet_csk_accept"`
+	InetCskAcceptRet        *ebpf.Program `ebpf:"inet_csk_accept_ret"`
 	NfConntrackConfirmFexit *ebpf.Program `ebpf:"nf_conntrack_confirm_fexit"`
 	NfHookSlowFexit         *ebpf.Program `ebpf:"nf_hook_slow_fexit"`
 	NfNatInetFnFexit        *ebpf.Program `ebpf:"nf_nat_inet_fn_fexit"`
@@ -62,6 +64,8 @@ type marinerObjects struct {
 
 type marinerPrograms struct {
 	InetCskAcceptFexit *ebpf.Program `ebpf:"inet_csk_accept_fexit"`
+	InetCskAccept      *ebpf.Program `ebpf:"inet_csk_accept"`
+	InetCskAcceptRet   *ebpf.Program `ebpf:"inet_csk_accept_ret"`
 	NfHookSlowFexit    *ebpf.Program `ebpf:"nf_hook_slow_fexit"`
 	TcpV4ConnectFexit  *ebpf.Program `ebpf:"tcp_v4_connect_fexit"` // nolint:revive // needs to match generated code
 }


### PR DESCRIPTION
# Description

Fix false/missing `TCP_ACCEPT_BASIC` drop metrics in the `dropreason` eBPF plugin. Two bugs were found:

1. **fexit path** (default mode): `inet_csk_accept_fexit` counted every NULL return from `inet_csk_accept()` as a packet drop without checking the error code. Non-blocking sockets returning EAGAIN (errno 11, "no pending connection") were incorrectly counted as drops, inflating `networkobservability_drop_count{reason="TCP_ACCEPT_BASIC"}` by orders of magnitude on busy nodes.

2. **kretprobe path** (pod-level mode): `inet_csk_accept_ret` did `int err = (int)*err_ptr` which truncates the stored **kernel pointer** to 32 bits instead of actually dereferencing it with `bpf_probe_read_kernel`. On x86_64, kernel stack addresses truncated to 32 bits are typically positive, so `err >= 0` was always true, so no drops were ever counted (not even real ones).

The fix:
- **fexit path (6.10+ kernels)**: Reads the error from `proto_accept_arg.err` via `bpf_probe_read_kernel()` and filters `err == 0` and `err == -EAGAIN`.
- **fexit path (pre-6.10 kernels)**: The BPF verifier on kernels like 5.15 rejects reading `ctx[2]` (encodes `int*` as scalar INT in BTF). The fexit `else` branch is now a no-op; instead, the Go loader attaches the kprobe/kretprobe pair for `inet_csk_accept` alongside the other fexit programs.
- **kretprobe path**: Uses `bpf_probe_read_kernel()` to properly dereference the saved kernel pointer, then filters `err >= 0 || err == -EAGAIN` (-11).

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

### Live cluster test environment
- AKS cluster
- Nodes: 3 Ubuntu 22.04 (kernel 5.15.0-1114-azure, amd64) + 1 AzureLinux 3.0 (kernel 6.6.139, amd64)
- Fixed image: `acnpublic.azurecr.io/carvela-dropreason-test:agent` / `:init`

### Test 1: Fix verification — EAGAIN no longer causes false drops
Deployed fixed image, ran non-blocking TCP accept server (tight EAGAIN loop) on Mariner node for 60 seconds:
```
Baseline TCP_ACCEPT_BASIC:  0
After 60s with EAGAIN load: 0    ← FIX CONFIRMED
```
For comparison, v1.2.0  « produced ~50,000,000 false drops in 60 seconds on the same node.

### Test 2: Programs attach correctly on all node types
Verified via pod logs on both Ubuntu 5.15 and AzureLinux 6.6:
```
Attached program: nf_hook_slow_fexit
Attached program: tcp_v4_connect_fexit
Attached kprobe: inet_csk_accept
Attached kretprobe: inet_csk_accept
```
All 4 pods (Ubuntu + Mariner) running with 0 restarts.

### Test 3: Bug reproduction (before fix, v1.2.0)
Same cluster, same non-blocking server, with the buggy v1.2.0 image:
```
Baseline: 20,076,242
After 30s: 45,743,820   (+25.7M false drops in 30s, ~856K/sec)
```

### Test 4: BPF verifier compatibility
The first iteration of the fix attempted to read `ctx[2]` in the fexit `else` branch on pre-6.10 kernels. This was rejected by the Ubuntu 5.15 BPF verifier:
```
func 'inet_csk_accept' arg2 type INT is not a struct: invalid bpf_context access off=16 size=8
```
The final fix uses the kprobe/kretprobe fallback for `inet_csk_accept` alongside fexit for other functions, avoiding this verifier limitation entirely.

### Unit tests added
- `TestProcessMapValue_TCPAcceptBasicWithError` — real error (ENOMEM) correctly reported
- `TestProcessMapValue_TCPAcceptBasicEAGAINNotInMap` — documents eBPF-level filtering
- `TestDropMetricKey_GetDirection` — direction mapping for all drop types
- `TestBuildFexitPrograms_ReturnsKprobeForAccept` — fexit objects return kprobe programs
- `TestBuildFexitPrograms_MarinerReturnsKprobeForAccept` — mariner variant
- `TestBuildFexitPrograms_KprobeObjectsReturnsNil` — kprobe-only mode unaffected
- `TestResolvePayload_FexitObjectsHaveKprobeFields` — integration of resolve + build
- `TestResolvePayload_KprobeObjectsNotAffected` — pod-level mode regression test

## Additional Notes

- The fexit `inet_csk_accept_fexit` program is still compiled into the BPF object (for 6.10+ kernels where it works via `proto_accept_arg`), but it is no longer attached as a fexit tracing program. Instead, the Go loader always attaches the kprobe/kretprobe pair for `inet_csk_accept`, which works correctly on all kernels.
- The `bpf_probe_read_kernel` call in the kretprobe is safe because the error pointer saved by the kprobe points to a stack variable in the caller (`sys_accept4`), which is still on-stack at kretprobe time.
- Affects all Retina versions v1.2.0–v1.2.2, all node OS types, on any kernel >= 5.5 with fexit support.
- Added `InetCskAccept` and `InetCskAcceptRet` fields to `allFexitPrograms` and `marinerPrograms` structs so the kprobe programs are loaded from the same BPF ELF alongside the fexit programs.
