### PR TITLE
fix(helm): use native gRPC probe on relay :4222 and bump default to v1.19.5

### DIFF
--- a/deploy/hubble/manifests/controller/helm/retina/templates/hubble-relay/configmap.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/hubble-relay/configmap.yaml
@@ -28,6 +28,7 @@ data:
     {{- if .Values.hubble.relay.prometheus.enabled }}
     metrics-listen-address: ":{{ .Values.hubble.relay.prometheus.port }}"
     {{- end }}
+    health-listen-address: ":{{ .Values.hubble.relay.grpcHealthPort }}"
     dial-timeout: {{ .Values.hubble.relay.dialTimeout }}
     retry-timeout: {{ .Values.hubble.relay.retryTimeout }}
     sort-buffer-len-max: {{ .Values.hubble.relay.sortBufferLenMax }}

--- a/deploy/hubble/manifests/controller/helm/retina/templates/hubble-relay/deployment.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/hubble-relay/deployment.yaml
@@ -55,7 +55,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.hubble.relay.image.repository }}:{{ .Values.hubble.relay.image.tag }}"
+          image: {{ include "cilium.image" .Values.hubble.relay.image | quote }}
           imagePullPolicy: {{ .Values.hubble.relay.image.pullPolicy }}
           command:
             - hubble-relay
@@ -193,24 +193,15 @@ spec:
 {{- end }}
 
 {{- define "hubble-relay.probe" }}
-{{- /* This distinction can be removed once we drop support for k8s 1.23 */}}
-{{- if and (semverCompare ">=1.24-0" .Capabilities.KubeVersion.Version) (not .Values.hubble.tls.enabled) -}}
+{{- /*
+Probe the relay's dedicated gRPC health server on :4222. It is always plaintext
+regardless of hubble.tls.enabled (the TLS-enabled listener is the main API on
+listenPort), so the kubelet's native gRPC probe works in both TLS and non-TLS
+deployments. Upstream Cilium removed the grpc_health_probe binary from the
+hubble-relay image (cilium/cilium#37806), so the prior exec-based probe is no
+longer viable on v1.16+ images.
+*/ -}}
 grpc:
-  port: {{ .Values.hubble.relay.listenPort }}
-{{- else }}
-exec:
-  command:
-  - grpc_health_probe
-  - -addr=localhost:{{ .Values.hubble.relay.listenPort }}
-{{- if .Values.hubble.tls.enabled }}
-  - -tls
-  - -tls-ca-cert=/var/lib/hubble-relay/tls/hubble-server-ca.crt
-  - -tls-client-cert=/var/lib/hubble-relay/tls/client.crt
-  - -tls-client-key=/var/lib/hubble-relay/tls/client.key
-  - -tls-server-name=instance.hubble-relay.cilium.io
-  - -connect-timeout=5s
-  - -rpc-timeout=5s
-{{- end }}
-{{- end }}
+  port: {{ .Values.hubble.relay.grpcHealthPort }}
 timeoutSeconds: 3
 {{- end }}

--- a/deploy/hubble/manifests/controller/helm/retina/templates/hubble-ui/deployment.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/hubble-ui/deployment.yaml
@@ -57,7 +57,7 @@ spec:
       {{- end }}
       containers:
       - name: frontend
-        image: "{{ .Values.hubble.ui.frontend.image.repository }}:{{ .Values.hubble.ui.frontend.image.tag }}"
+        image: {{ include "cilium.image" .Values.hubble.ui.frontend.image | quote }}
         imagePullPolicy: {{ .Values.hubble.ui.frontend.image.pullPolicy }}
         ports:
         - name: http
@@ -93,7 +93,7 @@ spec:
           {{- toYaml . | trim | nindent 10 }}
         {{- end }}
       - name: backend
-        image: "{{ .Values.hubble.ui.backend.image.repository }}:{{ .Values.hubble.ui.backend.image.tag}}"
+        image: {{ include "cilium.image" .Values.hubble.ui.backend.image | quote }}
         imagePullPolicy: {{ .Values.hubble.ui.backend.image.pullPolicy }}
         env:
         - name: EVENTS_SERVER_PORT

--- a/deploy/hubble/manifests/controller/helm/retina/values.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/values.yaml
@@ -429,12 +429,14 @@ hubble:
     rollOutPods: false
 
     # -- Hubble-relay container image.
+    # Official Cilium registry. Pick the latest patch of a maintained Cilium
+    # minor: https://quay.io/repository/cilium/hubble-relay?tab=tags
     image:
       override: ~
-      repository: "mcr.microsoft.com/oss/cilium/hubble-relay"
-      tag: "v1.15.0"
-      digest: "sha256:19cd56e7618832257bf88b2f281287cb57f9f7fcb9e04775a6198d4bc4daffae"
-      useDigest: false
+      repository: "quay.io/cilium/hubble-relay"
+      tag: "v1.19.5"
+      digest: "sha256:24409bfa1bca075c92acb26ba4b49cd573d99d68d5370f7cc825078185222a0c"
+      useDigest: true
       pullPolicy: "Always"
 
     # -- Specifies the resources for the hubble-relay pods
@@ -541,6 +543,9 @@ hubble:
 
     # -- Port to listen to.
     listenPort: "4245"
+
+    # -- Port for the relay's dedicated gRPC health server
+    grpcHealthPort: "4222"
 
     # -- TLS configuration for Hubble Relay
     tls:
@@ -675,9 +680,9 @@ hubble:
       # -- Hubble-ui backend image.
       image:
         override: ~
-        repository: "mcr.microsoft.com/oss/cilium/hubble-ui-backend"
-        tag: "v0.12.2"
-        digest: "sha256:b73dd1ac1b7159d42cdba31433964313e756daafefffad5e91c3b61b47c3782f"
+        repository: "quay.io/cilium/hubble-ui-backend"
+        tag: "v0.13.5"
+        digest: "sha256:fac0c300ae119274edca11fd89b1ad23c788792d8bc4ea2ba631c709e8d3c688"
         useDigest: true
         pullPolicy: "Always"
 
@@ -714,9 +719,9 @@ hubble:
       # -- Hubble-ui frontend image.
       image:
         override: ~
-        repository: "mcr.microsoft.com/oss/cilium/hubble-ui"
-        tag: "v0.12.2"
-        digest: "sha256:8c53cdaebb4ae863ad061387a68ea06e38777d2911e6c0e570be1932bb4ba526"
+        repository: "quay.io/cilium/hubble-ui"
+        tag: "v0.13.5"
+        digest: "sha256:f7d514fc54d784ed6df9d58cf0e97648b143f92b766dd1780ed3fc845bd4c516"
         useDigest: true
         pullPolicy: "Always"
 


### PR DESCRIPTION
Closes #2165

Address review comments from https://github.com/microsoft/retina/pull/2282 (closed due to inactivity)

## Summary

Fixes hubble-relay's startup/readiness/liveness probes, which fail on Cilium
v1.16+ images because the `grpc_health_probe` binary used by the legacy
exec-based probe was removed upstream ([cilium/cilium#37806](https://github.com/cilium/cilium/pull/37806)).

1. **`templates/hubble-relay/deployment.yaml`** — single native `grpc:` probe
   against the relay's dedicated health server (`hubble.relay.grpcHealthPort`,
   default `4222`), replacing the k8s-version-gated exec/native branching.
   The health listener is always plaintext regardless of `hubble.tls.enabled`
   (only the main API on `listenPort` is TLS-wrapped), so this probe works in
   both TLS and non-TLS deployments. Also renders the relay image via the
   `cilium.image` helper (previously a raw `repository:tag` string) so
   `useDigest`/`override` are actually honored.
2. **`templates/hubble-relay/configmap.yaml`** — wires `hubble.relay.grpcHealthPort`
   through to `health-listen-address`, so the relay's health server actually
   listens on the port the probes target.
3. **`templates/hubble-ui/deployment.yaml`** — frontend and backend images now
   also render via the `cilium.image` helper.
4. **`values.yaml`**:
   - `hubble.relay.image` default bumped from
     `mcr.microsoft.com/oss/cilium/hubble-relay:v1.15.0` to
     `quay.io/cilium/hubble-relay:v1.19.5` (matches the Cilium `v1.19.3`
     dependency in `go.mod`), with `useDigest: true`.
   - Added `hubble.relay.grpcHealthPort: "4222"`.
   - `hubble.ui.backend.image` and `hubble.ui.frontend.image` both moved from
     `mcr.microsoft.com` to `quay.io/cilium/hubble-ui{,-backend}:v0.13.5`
     (previously split across two registries at `v0.12.2`), matching upstream
     Cilium's `v1.19.5` chart image pins.
