### PR TITLE
feat(packetparser): report dropped events on buffer write failure

### DIFF
--- a/pkg/plugin/packetparser/_cprog/packetparser.c
+++ b/pkg/plugin/packetparser/_cprog/packetparser.c
@@ -28,6 +28,31 @@ struct
 #endif
 } retina_packetparser_events SEC(".maps");
 
+// Counts events dropped in the kernel when the event buffer write fails.
+struct
+{
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, __u32);
+	__type(value, __u64);
+} retina_packetparser_metrics SEC(".maps");
+
+static __always_inline void submit_packetparser_event(struct __sk_buff *skb, struct packet *p)
+{
+	long ret;
+#ifdef USE_RING_BUFFER
+	ret = bpf_ringbuf_output(&retina_packetparser_events, p, sizeof(*p), 0);
+#else
+	ret = bpf_perf_event_output(skb, &retina_packetparser_events, BPF_F_CURRENT_CPU, p, sizeof(*p));
+#endif
+	if (ret < 0) {
+		__u32 zero = 0;
+		__u64 *dropped = bpf_map_lookup_elem(&retina_packetparser_metrics, &zero);
+		if (dropped)
+			*dropped += 1;
+	}
+}
+
 // Define const variables to avoid warnings.
 const struct packet *unused __attribute__((unused));
 
@@ -239,11 +264,7 @@ static void parse(struct __sk_buff *skb, __u8 obs)
 		p.previously_observed_packets = 0;
 		p.previously_observed_bytes = 0;
 		__builtin_memset(&p.previously_observed_flags, 0, sizeof(struct tcpflagscount));
-#ifdef USE_RING_BUFFER
-		bpf_ringbuf_output(&retina_packetparser_events, &p, sizeof(p), 0);
-#else
-		bpf_perf_event_output(skb, &retina_packetparser_events, BPF_F_CURRENT_CPU, &p, sizeof(p));
-#endif
+		submit_packetparser_event(skb, &p);
 		return;
 	// If the data aggregation level is high, only send the packet to the perf buffer if it needs to be reported.
 	#elif DATA_AGGREGATION_LEVEL == DATA_AGGREGATION_LEVEL_HIGH
@@ -251,11 +272,7 @@ static void parse(struct __sk_buff *skb, __u8 obs)
 			p.previously_observed_packets = report.previously_observed_packets;
 			p.previously_observed_bytes = report.previously_observed_bytes;
 			p.previously_observed_flags = report.previously_observed_flags;
-#ifdef USE_RING_BUFFER
-			bpf_ringbuf_output(&retina_packetparser_events, &p, sizeof(p), 0);
-#else
-			bpf_perf_event_output(skb, &retina_packetparser_events, BPF_F_CURRENT_CPU, &p, sizeof(p));
-#endif
+			submit_packetparser_event(skb, &p);
 		}
 	#endif
 	#endif

--- a/pkg/plugin/packetparser/_cprog/packetparser.c
+++ b/pkg/plugin/packetparser/_cprog/packetparser.c
@@ -28,6 +28,33 @@ struct
 #endif
 } retina_packetparser_events SEC(".maps");
 
+// Counts events dropped in the kernel when the event buffer write fails.
+struct
+{
+	__uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+	__uint(max_entries, 1);
+	__type(key, __u32);
+	__type(value, __u64);
+} retina_packetparser_metrics SEC(".maps");
+
+static __always_inline void submit_packetparser_event(struct __sk_buff *skb, struct packet *p)
+{
+	long ret;
+#ifdef USE_RING_BUFFER
+	ret = bpf_ringbuf_output(&retina_packetparser_events, p, sizeof(*p), 0);
+#else
+	ret = bpf_perf_event_output(skb, &retina_packetparser_events, BPF_F_CURRENT_CPU, p, sizeof(*p));
+#endif
+	if (ret < 0) {
+		__u32 zero = 0;
+		__u64 *dropped = bpf_map_lookup_elem(&retina_packetparser_metrics, &zero);
+		// Atomic because a non-atomic read-modify-write can lose counts if this hook is
+		// preempted mid-update on the same CPU.
+		if (dropped)
+			__sync_fetch_and_add(dropped, 1);
+	}
+}
+
 // Define const variables to avoid warnings.
 const struct packet *unused __attribute__((unused));
 
@@ -239,11 +266,7 @@ static void parse(struct __sk_buff *skb, __u8 obs)
 		p.previously_observed_packets = 0;
 		p.previously_observed_bytes = 0;
 		__builtin_memset(&p.previously_observed_flags, 0, sizeof(struct tcpflagscount));
-#ifdef USE_RING_BUFFER
-		bpf_ringbuf_output(&retina_packetparser_events, &p, sizeof(p), 0);
-#else
-		bpf_perf_event_output(skb, &retina_packetparser_events, BPF_F_CURRENT_CPU, &p, sizeof(p));
-#endif
+		submit_packetparser_event(skb, &p);
 		return;
 	// If the data aggregation level is high, only send the packet to the perf buffer if it needs to be reported.
 	#elif DATA_AGGREGATION_LEVEL == DATA_AGGREGATION_LEVEL_HIGH
@@ -251,11 +274,7 @@ static void parse(struct __sk_buff *skb, __u8 obs)
 			p.previously_observed_packets = report.previously_observed_packets;
 			p.previously_observed_bytes = report.previously_observed_bytes;
 			p.previously_observed_flags = report.previously_observed_flags;
-#ifdef USE_RING_BUFFER
-			bpf_ringbuf_output(&retina_packetparser_events, &p, sizeof(p), 0);
-#else
-			bpf_perf_event_output(skb, &retina_packetparser_events, BPF_F_CURRENT_CPU, &p, sizeof(p));
-#endif
+			submit_packetparser_event(skb, &p);
 		}
 	#endif
 	#endif

--- a/pkg/plugin/packetparser/packetparser_bpfel_arm64.go
+++ b/pkg/plugin/packetparser/packetparser_bpfel_arm64.go
@@ -161,9 +161,10 @@ type packetparserProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type packetparserMapSpecs struct {
-	RetinaConntrack          *ebpf.MapSpec `ebpf:"retina_conntrack"`
-	RetinaFilter             *ebpf.MapSpec `ebpf:"retina_filter"`
-	RetinaPacketparserEvents *ebpf.MapSpec `ebpf:"retina_packetparser_events"`
+	RetinaConntrack           *ebpf.MapSpec `ebpf:"retina_conntrack"`
+	RetinaFilter              *ebpf.MapSpec `ebpf:"retina_filter"`
+	RetinaPacketparserEvents  *ebpf.MapSpec `ebpf:"retina_packetparser_events"`
+	RetinaPacketparserMetrics *ebpf.MapSpec `ebpf:"retina_packetparser_metrics"`
 }
 
 // packetparserObjects contains all objects after they have been loaded into the kernel.
@@ -185,9 +186,10 @@ func (o *packetparserObjects) Close() error {
 //
 // It can be passed to loadPacketparserObjects or ebpf.CollectionSpec.LoadAndAssign.
 type packetparserMaps struct {
-	RetinaConntrack          *ebpf.Map `ebpf:"retina_conntrack"`
-	RetinaFilter             *ebpf.Map `ebpf:"retina_filter"`
-	RetinaPacketparserEvents *ebpf.Map `ebpf:"retina_packetparser_events"`
+	RetinaConntrack           *ebpf.Map `ebpf:"retina_conntrack"`
+	RetinaFilter              *ebpf.Map `ebpf:"retina_filter"`
+	RetinaPacketparserEvents  *ebpf.Map `ebpf:"retina_packetparser_events"`
+	RetinaPacketparserMetrics *ebpf.Map `ebpf:"retina_packetparser_metrics"`
 }
 
 func (m *packetparserMaps) Close() error {
@@ -195,6 +197,7 @@ func (m *packetparserMaps) Close() error {
 		m.RetinaConntrack,
 		m.RetinaFilter,
 		m.RetinaPacketparserEvents,
+		m.RetinaPacketparserMetrics,
 	)
 }
 

--- a/pkg/plugin/packetparser/packetparser_bpfel_x86.go
+++ b/pkg/plugin/packetparser/packetparser_bpfel_x86.go
@@ -161,9 +161,10 @@ type packetparserProgramSpecs struct {
 //
 // It can be passed ebpf.CollectionSpec.Assign.
 type packetparserMapSpecs struct {
-	RetinaConntrack          *ebpf.MapSpec `ebpf:"retina_conntrack"`
-	RetinaFilter             *ebpf.MapSpec `ebpf:"retina_filter"`
-	RetinaPacketparserEvents *ebpf.MapSpec `ebpf:"retina_packetparser_events"`
+	RetinaConntrack           *ebpf.MapSpec `ebpf:"retina_conntrack"`
+	RetinaFilter              *ebpf.MapSpec `ebpf:"retina_filter"`
+	RetinaPacketparserEvents  *ebpf.MapSpec `ebpf:"retina_packetparser_events"`
+	RetinaPacketparserMetrics *ebpf.MapSpec `ebpf:"retina_packetparser_metrics"`
 }
 
 // packetparserObjects contains all objects after they have been loaded into the kernel.
@@ -185,9 +186,10 @@ func (o *packetparserObjects) Close() error {
 //
 // It can be passed to loadPacketparserObjects or ebpf.CollectionSpec.LoadAndAssign.
 type packetparserMaps struct {
-	RetinaConntrack          *ebpf.Map `ebpf:"retina_conntrack"`
-	RetinaFilter             *ebpf.Map `ebpf:"retina_filter"`
-	RetinaPacketparserEvents *ebpf.Map `ebpf:"retina_packetparser_events"`
+	RetinaConntrack           *ebpf.Map `ebpf:"retina_conntrack"`
+	RetinaFilter              *ebpf.Map `ebpf:"retina_filter"`
+	RetinaPacketparserEvents  *ebpf.Map `ebpf:"retina_packetparser_events"`
+	RetinaPacketparserMetrics *ebpf.Map `ebpf:"retina_packetparser_metrics"`
 }
 
 func (m *packetparserMaps) Close() error {
@@ -195,6 +197,7 @@ func (m *packetparserMaps) Close() error {
 		m.RetinaConntrack,
 		m.RetinaFilter,
 		m.RetinaPacketparserEvents,
+		m.RetinaPacketparserMetrics,
 	)
 }
 

--- a/pkg/plugin/packetparser/packetparser_ebpf_test.go
+++ b/pkg/plugin/packetparser/packetparser_ebpf_test.go
@@ -1299,3 +1299,89 @@ func TestRingBufReaderWrapper(t *testing.T) {
 	_, err = wrapper.Read()
 	assert.ErrorIs(t, err, ringbuf.ErrClosed)
 }
+
+// readDropCounter sums the per-CPU kernel drop counter directly from the map.
+func readDropCounter(t *testing.T, m *ebpf.Map) uint64 {
+	t.Helper()
+	var perCPU []uint64
+	require.NoError(t, m.Lookup(uint32(0), &perCPU))
+	return sumPerCPUCounters(perCPU)
+}
+
+// TestKernelDropCounter_RingBuf fills the ring buffer without draining it, so
+// bpf_ringbuf_output starts failing, and asserts the eBPF drop counter records it.
+// This is the failure path the userspace reporter exports as kernel lost events.
+func TestKernelDropCounter_RingBuf(t *testing.T) {
+	if err := ensureRingBufKernelSupported(); err != nil {
+		t.Skipf("ring buffer not supported: %v", err)
+	}
+
+	// RING_BUFFER_SIZE is 4096 for this variant, so the submissions below overrun it.
+	objs, reader := compileAndLoadRingBufVariant(t, compileOpts{
+		bypassFilter:     1,
+		enableConntrack:  false,
+		aggregationLevel: 0,
+		samplingRate:     1,
+	})
+	// Deliberately do not read from the buffer; the reader only exists so the map has a
+	// consumer and is closed on cleanup.
+	_ = reader
+
+	require.Zero(t, readDropCounter(t, objs.RetinaPacketparserMetrics), "counter should start at zero")
+
+	pkt := ebpftest.BuildTCPPacket(ebpftest.TCPPacketOpts{
+		SrcIP:   net.ParseIP("10.0.99.1"),
+		DstIP:   net.ParseIP("10.0.99.2"),
+		SrcPort: 12345,
+		DstPort: 80,
+		SYN:     true,
+		SeqNum:  1000,
+	})
+
+	// Each packet submits one event and nothing drains them, so the buffer fills.
+	for range 512 {
+		ebpftest.RunProgram(t, objs.EndpointIngressFilter, pkt)
+	}
+
+	dropped := readDropCounter(t, objs.RetinaPacketparserMetrics)
+	require.Positive(t, dropped, "expected the kernel drop counter to record failed submissions")
+
+	// The counter is cumulative, so further failures only increase it.
+	for range 64 {
+		ebpftest.RunProgram(t, objs.EndpointIngressFilter, pkt)
+	}
+	assert.GreaterOrEqual(t, readDropCounter(t, objs.RetinaPacketparserMetrics), dropped,
+		"counter should be monotonic")
+}
+
+// TestKernelDropCounter_Perf covers the same failure path for perf buffers, where the
+// return value of bpf_perf_event_output is handled by separate code in the C program.
+func TestKernelDropCounter_Perf(t *testing.T) {
+	objs, reader := compileAndLoadVariant(t, compileOpts{
+		bypassFilter:     1,
+		enableConntrack:  false,
+		aggregationLevel: 0,
+		samplingRate:     1,
+	})
+	// Deliberately do not read from the buffer so submissions start failing once full.
+	_ = reader
+
+	require.Zero(t, readDropCounter(t, objs.RetinaPacketparserMetrics), "counter should start at zero")
+
+	pkt := ebpftest.BuildTCPPacket(ebpftest.TCPPacketOpts{
+		SrcIP:   net.ParseIP("10.0.98.1"),
+		DstIP:   net.ParseIP("10.0.98.2"),
+		SrcPort: 12345,
+		DstPort: 80,
+		SYN:     true,
+		SeqNum:  1000,
+	})
+
+	// The perf reader is sized at 4 pages, so this overruns it.
+	for range 4096 {
+		ebpftest.RunProgram(t, objs.EndpointIngressFilter, pkt)
+	}
+
+	assert.Positive(t, readDropCounter(t, objs.RetinaPacketparserMetrics),
+		"expected the kernel drop counter to record failed perf submissions")
+}

--- a/pkg/plugin/packetparser/packetparser_linux.go
+++ b/pkg/plugin/packetparser/packetparser_linux.go
@@ -13,6 +13,7 @@ import (
 	"path"
 	"runtime"
 	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -413,6 +414,15 @@ func (p *packetParser) Stop() error {
 		p.l.Debug("Closed records channel")
 	}
 
+	// Stop the drop reporter and wait for it to exit before closing the objects, since it
+	// reads a map from them. Cancelling here rather than relying on the context passed to
+	// Start keeps Stop from depending on the caller, and bounds the wait to one map read.
+	if p.stopReporter != nil {
+		p.stopReporter()
+		p.reporterWg.Wait()
+		p.l.Debug("Stopped lost event reporter")
+	}
+
 	// Stop map and progs.
 	if p.objs != nil {
 		if err := p.objs.Close(); err != nil {
@@ -768,6 +778,14 @@ func (p *packetParser) run(ctx context.Context) error {
 	// That call is unblocked when Reader is closed.
 	go p.handleEvents(ctx)
 
+	// Report kernel-side event drops (buffer write failures) from the eBPF metrics map.
+	// Tracked separately from wg so Stop can cancel and wait for just this goroutine
+	// before closing the objects whose map it reads.
+	reporterCtx, stopReporter := context.WithCancel(ctx)
+	p.stopReporter = stopReporter
+	p.reporterWg.Add(1)
+	go p.reportLostEvents(reporterCtx)
+
 	p.l.Info("Started packet parser")
 
 	// Wait for the context to be done.
@@ -929,9 +947,9 @@ func (p *packetParser) readData() {
 		return
 	}
 
+	// Kernel-side drops are counted in the eBPF program (retina_packetparser_metrics)
+	// and reported by reportLostEvents. Lost-sample records carry no event, so skip them.
 	if record.LostSamples > 0 {
-		// p.l.Warn("Lostsamples", zap.Uint64("lost samples", record.LostSamples))
-		metrics.LostEventsCounter.WithLabelValues(utils.Kernel, name).Add(float64(record.LostSamples))
 		return
 	}
 
@@ -942,6 +960,75 @@ func (p *packetParser) readData() {
 		// We shouldn't slow down the perf array reader.
 		metrics.LostEventsCounter.WithLabelValues(utils.BufferedChannel, name).Inc()
 	}
+}
+
+// reportLostEvents reports kernel-side event drops (recorded in eBPF because ring
+// buffers surface no lost-sample signal to userspace) on the metrics interval.
+func (p *packetParser) reportLostEvents(ctx context.Context) {
+	defer p.reporterWg.Done()
+
+	if p.objs == nil || p.objs.RetinaPacketparserMetrics == nil {
+		p.l.Warn("Kernel drop counter map is unavailable, not reporting kernel event drops")
+		return
+	}
+	ticker := time.NewTicker(p.cfg.MetricsInterval)
+	defer ticker.Stop()
+
+	var last uint64
+	for {
+		select {
+		case <-ctx.Done():
+			// Sample once more before exiting. Stop keeps the map open until this returns,
+			// so this is the only chance to report drops since the previous tick.
+			p.reportDroppedEventsDelta(&last)
+			return
+		case <-ticker.C:
+			p.reportDroppedEventsDelta(&last)
+		}
+	}
+}
+
+// reportDroppedEventsDelta reads the kernel drop counter and reports what is new since
+// last, advancing last to the value just read.
+func (p *packetParser) reportDroppedEventsDelta(last *uint64) {
+	total, err := p.readDroppedEvents()
+	if err != nil {
+		p.l.Error("Error reading kernel drop counter", zap.Error(err))
+		return
+	}
+	add, newLast := lostEventsDelta(total, *last)
+	*last = newLast
+	if add > 0 {
+		metrics.LostEventsCounter.WithLabelValues(utils.Kernel, name).Add(float64(add))
+	}
+}
+
+// readDroppedEvents sums the per-CPU kernel drop counter.
+func (p *packetParser) readDroppedEvents() (uint64, error) {
+	var perCPU []uint64
+	if err := p.objs.RetinaPacketparserMetrics.Lookup(uint32(0), &perCPU); err != nil {
+		return 0, errors.Wrap(err, "failed to lookup packetparser metrics map")
+	}
+	return sumPerCPUCounters(perCPU), nil
+}
+
+// sumPerCPUCounters totals a per-CPU counter array.
+func sumPerCPUCounters(perCPU []uint64) uint64 {
+	var total uint64
+	for _, v := range perCPU {
+		total += v
+	}
+	return total
+}
+
+// lostEventsDelta returns how many newly-dropped events to report given the current
+// cumulative counter value and the last-seen value, along with the new last-seen value.
+// A decrease is treated as a counter reset (report nothing, adopt the new value).
+func lostEventsDelta(total, last uint64) (add, newLast uint64) {
+	if total <= last {
+		return 0, total
+	}
+	return total - last, total
 }
 
 // Helper functions.

--- a/pkg/plugin/packetparser/packetparser_linux.go
+++ b/pkg/plugin/packetparser/packetparser_linux.go
@@ -13,6 +13,7 @@ import (
 	"path"
 	"runtime"
 	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -766,6 +767,9 @@ func (p *packetParser) run(ctx context.Context) error {
 	// That call is unblocked when Reader is closed.
 	go p.handleEvents(ctx)
 
+	// Report kernel-side event drops (buffer write failures) from the eBPF metrics map.
+	go p.reportLostEvents(ctx)
+
 	p.l.Info("Started packet parser")
 
 	// Wait for the context to be done.
@@ -927,9 +931,9 @@ func (p *packetParser) readData() {
 		return
 	}
 
+	// Kernel-side drops are counted in the eBPF program (retina_packetparser_metrics)
+	// and reported by reportLostEvents. Lost-sample records carry no event, so skip them.
 	if record.LostSamples > 0 {
-		// p.l.Warn("Lostsamples", zap.Uint64("lost samples", record.LostSamples))
-		metrics.LostEventsCounter.WithLabelValues(utils.Kernel, name).Add(float64(record.LostSamples))
 		return
 	}
 
@@ -940,6 +944,63 @@ func (p *packetParser) readData() {
 		// We shouldn't slow down the perf array reader.
 		metrics.LostEventsCounter.WithLabelValues(utils.BufferedChannel, name).Inc()
 	}
+}
+
+// reportLostEvents reports kernel-side event drops (recorded in eBPF because ring
+// buffers surface no lost-sample signal to userspace) on the metrics interval.
+func (p *packetParser) reportLostEvents(ctx context.Context) {
+	if p.objs == nil || p.objs.RetinaPacketparserMetrics == nil {
+		return
+	}
+	ticker := time.NewTicker(p.cfg.MetricsInterval)
+	defer ticker.Stop()
+
+	var last uint64
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			total, err := p.readDroppedEvents()
+			if err != nil {
+				p.l.Error("Error reading kernel drop counter", zap.Error(err))
+				continue
+			}
+			add, newLast := lostEventsDelta(total, last)
+			last = newLast
+			if add > 0 {
+				metrics.LostEventsCounter.WithLabelValues(utils.Kernel, name).Add(float64(add))
+			}
+		}
+	}
+}
+
+// readDroppedEvents sums the per-CPU kernel drop counter.
+func (p *packetParser) readDroppedEvents() (uint64, error) {
+	var perCPU []uint64
+	if err := p.objs.RetinaPacketparserMetrics.Lookup(uint32(0), &perCPU); err != nil {
+		return 0, errors.Wrap(err, "failed to lookup packetparser metrics map")
+	}
+	return sumPerCPUCounters(perCPU), nil
+}
+
+// sumPerCPUCounters totals a per-CPU counter array.
+func sumPerCPUCounters(perCPU []uint64) uint64 {
+	var total uint64
+	for _, v := range perCPU {
+		total += v
+	}
+	return total
+}
+
+// lostEventsDelta returns how many newly-dropped events to report given the current
+// cumulative counter value and the last-seen value, along with the new last-seen value.
+// A decrease is treated as a counter reset (report nothing, adopt the new value).
+func lostEventsDelta(total, last uint64) (add, newLast uint64) {
+	if total <= last {
+		return 0, total
+	}
+	return total - last, total
 }
 
 // Helper functions.

--- a/pkg/plugin/packetparser/packetparser_linux_test.go
+++ b/pkg/plugin/packetparser/packetparser_linux_test.go
@@ -835,3 +835,41 @@ func restoreBackup() {
 		}
 	}
 }
+
+func TestSumPerCPUCounters(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []uint64
+		want uint64
+	}{
+		{"nil", nil, 0},
+		{"single", []uint64{5}, 5},
+		{"multi", []uint64{1, 2, 3, 4}, 10},
+		{"zeros", []uint64{0, 0, 0}, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, sumPerCPUCounters(tt.in))
+		})
+	}
+}
+
+func TestLostEventsDelta(t *testing.T) {
+	tests := []struct {
+		name              string
+		total, last       uint64
+		wantAdd, wantLast uint64
+	}{
+		{"first read", 10, 0, 10, 10},
+		{"increase", 25, 10, 15, 25},
+		{"no change", 10, 10, 0, 10},
+		{"counter reset", 3, 100, 0, 3}, // map recreated: adopt new value, report nothing
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			add, newLast := lostEventsDelta(tt.total, tt.last)
+			assert.Equal(t, tt.wantAdd, add, "add")
+			assert.Equal(t, tt.wantLast, newLast, "newLast")
+		})
+	}
+}

--- a/pkg/plugin/packetparser/types_linux.go
+++ b/pkg/plugin/packetparser/types_linux.go
@@ -4,6 +4,7 @@
 package packetparser
 
 import (
+	"context"
 	"sync"
 
 	kcfg "github.com/microsoft/retina/pkg/config"
@@ -151,8 +152,12 @@ type packetParser struct {
 	hostEgressInfo      *ebpf.ProgramInfo
 	wg                  sync.WaitGroup
 	recordsChannel      chan perfRecord
-	externalChannel     chan *v1.Event
-	tcxSupported        bool // Whether TCX is supported on this system
+	// stopReporter cancels reportLostEvents and reporterWg waits for it to exit. Stop uses
+	// both before closing objs, since the reporter reads a map from objs.
+	stopReporter    context.CancelFunc
+	reporterWg      sync.WaitGroup
+	externalChannel chan *v1.Event
+	tcxSupported    bool // Whether TCX is supported on this system
 }
 
 func ifaceToKey(iface netlink.LinkAttrs) attachmentKey {


### PR DESCRIPTION
# Description

For ring buffers, we can't get dropped events from user space.  Instead, track drop metrics in eBPF that user space then reports.

Re-use this logic for perf buffers as well.

## Related Issue

https://github.com/microsoft/retina/issues/2235

## Checklist

- [X] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [X] I have correctly attributed the author(s) of the code.
- [X] I have tested the changes locally.
- [X] I have followed the project's style guidelines.
- [X] I have updated the documentation, if necessary.
- [X] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Deployed into a test cluster with perf and ring buffers, drop metrics show up for ring buffers and perf metrics are the same.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
