### PR TITLE
fix(dropreason): dereference err pointer in inet_csk_accept kretprobe

### DIFF
--- a/pkg/plugin/dropreason/_cprog/drop_reason.c
+++ b/pkg/plugin/dropreason/_cprog/drop_reason.c
@@ -420,7 +420,11 @@ int BPF_KRETPROBE(inet_csk_accept_ret, struct sock *sk)
     if (sk != NULL)
         return 0;
 
-    int err = (int)*err_ptr;
+    // *err_ptr holds the ADDRESS of the callee's errno output (the int *err
+    // parameter pre-6.10, &arg->err on 6.10+); the errno must be read through it.
+    int err = 0;
+    if (bpf_probe_read_kernel(&err, sizeof(err), (void *)(unsigned long)*err_ptr) < 0)
+        return 0;
     if (err >= 0)
         return 0;
 


### PR DESCRIPTION
# Description

The merge-queue `Build Images` E2E failed 39 of 57 runs between 2026-07-01 and 2026-07-07 ([first failure](https://github.com/microsoft/retina/actions/runs/28489511278), [recent](https://github.com/microsoft/retina/actions/runs/28846174839), [same-day pass](https://github.com/microsoft/retina/actions/runs/28848611516)). Every failing run sampled (11/11) died at the same check: the hubble-phase `Drop Metrics - Arch: arm64` scenario never finds `networkobservability_drop_count{reason="IPTABLE_RULE_DROP"}` — while `hubble_drop_total{reason="POLICY_DENIED"}` on the same node keeps reporting the drops (observed on a live reproduction; the CI job aborts before its hubble check).

## Root cause

The kernel returns `accept()` errors indirectly: the caller passes the address of an errno slot ([a stack local in `inet_accept()`](https://elixir.bootlin.com/linux/v6.8/source/net/ipv4/af_inet.c#L777)). [The entry kprobe saves that address](https://github.com/microsoft/retina/blob/577d9179/pkg/plugin/dropreason/_cprog/drop_reason.c#L383-L397) for the kretprobe to read once the function returns — but [the kretprobe casts the saved address itself to `int`](https://github.com/microsoft/retina/blob/577d9179/pkg/plugin/dropreason/_cprog/drop_reason.c#L423):

```
accept() enters
   │  kprobe: save "errno will land at address 0xFFFF...9F7C"
   ▼
accept() returns NULL sock (empty/failed accept — routine for nonblocking servers)
   │
   │  bug:  err = (int)saved_address      → -2086978436  (truncated kernel address)
   │  fix:  read 4 bytes AT saved_address → -11          (EAGAIN)
   ▼
metrics map key = {TCP_ACCEPT_BASIC, err}
```

Only negative values survive the `err >= 0` gate. When the truncated addresses land negative, every empty accept mints a *distinct* key (the address differs per call), and the [512-entry `retina_dropreason_metrics` map](https://github.com/microsoft/retina/blob/577d9179/pkg/plugin/dropreason/_cprog/drop_reason.c#L103-L109), [whose keys are never deleted](https://github.com/microsoft/retina/blob/577d9179/pkg/plugin/dropreason/dropreason_linux.go#L272), saturates minutes after agent start. Once full, [failed inserts are silently ignored](https://github.com/microsoft/retina/blob/577d9179/pkg/plugin/dropreason/_cprog/drop_reason.c#L127-L158): the `IPTABLE_RULE_DROP` row can never be created, while the perf path in the same handler keeps feeding hubble —

```
metrics map: 512 slots, keys never removed        (dump from a failing repro node)

┌────────────────────────────────┐
│ {ACCEPT, -2086978436}: 1       │
│ {ACCEPT, -2086945764}: 1       │   512/512 FULL — all drop_type=3,
│ ... 510 more junk keys ...     │   one truncated address per empty accept
└────────────────────────────────┘
        ▲
        │ insert {IPTABLE_RULE_DROP} → fails, return ignored → gauge never exists
        │
NPM drops packet ─► kprobe fires ─┬─► perf event ─► hubble_drop_total ✓ (no map involved)
                                  └─► map insert  ✗ silently lost
```

## Why 2026-07-01, and why the arm64 scenario

E2E clusters use an [unpinned Kubernetes version](https://github.com/microsoft/retina/blob/577d9179/test/e2e/framework/azure/create-cluster.go#L123); the westus2 default flipped to 1.35 with the [2026-06-19 AKS release](https://github.com/Azure/AKS/releases/tag/2026-06-19) rollout, and [1.35 moves nodes to Ubuntu 24.04](https://github.com/Azure/AKS/releases/tag/2026-01-04) (kernel `6.8`):

```
22.04 / 5.15 (unfixed build):  0 junk keys recorded — none after 150 induced
                               accepts → bug latent since the initial release
24.04 / 6.8  (unfixed build):  map saturates: 512/512 within minutes of
                               agent start → new drop reasons unrecordable
                        ▲
AKS default flip ───────┘  (westus2, ~Jul 1)
```

Which side of the gate the truncation lands on is a memory-layout accident. With `CONFIG_VMAP_STACK=y` the errno slot lives in the [vmalloc'd task stack](https://elixir.bootlin.com/linux/v6.8/source/kernel/fork.c#L307); on x86-64 [KASLR randomizes the vmalloc base per boot in 1 GiB steps](https://elixir.bootlin.com/linux/v6.8/source/arch/x86/mm/kaslr.c#L127), so bit 31 is a boot lottery, while [arm64's vmalloc layout is fixed](https://elixir.bootlin.com/linux/v6.8/source/arch/arm64/include/asm/pgtable.h#L24) — matching the observed determinism on the arm64 leg: zero drop-metric failures across a month of merge-queue runs on 5.15, then 11/11 sampled failures on 6.8. A gate-removed debug build confirmed the mechanism on a 5.15 node: the capture fires just as prolifically (434 junk keys after 200 induced accepts) but every truncated address landed *positive* (`0x4DE4xxxx`), so the gate filtered them all; on our 6.8 nodes they landed negative (`0x83xxxxxx`–`0x87xxxxxx`).

The cast is verbatim in the [initial release](https://github.com/microsoft/retina/commit/d2e5bf1f). The arm64 check is also the *last* drop validation (~8 min after the hubble-phase agent reinstall, following minutes of scrape-driven accepts), so it always polls the most-saturated agents. Hubble-phase agents always take the kprobe path because [pod-level mode pins kprobes](https://github.com/microsoft/retina/blob/577d9179/pkg/plugin/dropreason/ebpfsetup_linux.go#L100); the fexit accept variant records a constant `ret_val` and is unaffected.

## The fix

Read the errno through the saved pointer (`bpf_probe_read_kernel`; falls back to legacy `bpf_probe_read` on pre-5.5 kernels via cilium/ebpf's `fixupProbeReadKernel`), bounding key cardinality to the errno space — in practice a single `{TCP_ACCEPT_BASIC, -EAGAIN}` entry. Regenerating the bpf2go bindings (`GOARCH={amd64,arm64} go generate ./pkg/plugin/dropreason/...`) yields byte-identical `.go` wrappers; `.o` files remain empty stubs.

## Related Issue

N/A — found while investigating the merge-queue E2E failures above.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`).
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable. (No unit-testable surface — BPF C; validated end-to-end below.)

## Screenshots (if applicable) or Testing Completed

Agents built from this branch, deployed via the hubble chart (pod-level = the kprobe path) on live AKS NPM clusters; each leg: 200–300 induced accepts + soak, then the exact failing scenario (deny-all `NetworkPolicy` + `agnhost` + `curl` burst):

| Kernel / arch | Map after load | Drop scenario |
|---|---|---|
| `6.8.0-1059-azure` / amd64 | 1/512 — `(TCP_ACCEPT_BASIC, -11)` | pass, gauge on first scrape |
| `6.8.0-1059-azure` / arm64 | 1/512 — `-11` | pass, first scrape |
| `5.15.0-1114-azure` / amd64 | 1/512 — `-11` | pass |
| `5.15.0-1114-azure` / arm64 | 1/512 — `-11` | pass |

Negative control, same 6.8 cluster, unfixed image: map 512/512 junk keys, scenario fails identically to CI. The final branch build (`bpf_probe_read_kernel`) was additionally revalidated on a fresh 6.8/amd64 cluster with identical results (map `1/512` `-EAGAIN`; gauge on first scrape). `hubble_drop_total` stays correct in all legs; on 5.15 the accept metric now records real errnos where it previously recorded nothing.

## Additional Notes

Follow-ups (separate PRs):

- Surface `bpf_map_update_elem` failures / map occupancy in `dropreason` — silent insert failure kept this invisible for 2.5 years.
- Delete metrics-map keys after each read sweep (existing `TODO`).
- Finish the fexit rollout for pod-level mode (`resolvePayload` pins `isPodLevel` to kprobes).
- Add `kubernetes.io/os: linux` nodeSelector to the hubble chart's `hubble-generate-certs` job — it can land on Windows nodes and wedge installs.
