### PR TITLE
fix(toolbox): bump go directive to 1.25.0 to match kapinger

### DIFF
--- a/hack/tools/toolbox/go.mod
+++ b/hack/tools/toolbox/go.mod
@@ -1,6 +1,6 @@
 module github.com/microsoft/retina/hack/tools/toolbox
 
-go 1.24.2
+go 1.25.0
 
 replace github.com/microsoft/retina/hack/tools/kapinger => ../kapinger
 


### PR DESCRIPTION
# Description

The `Build and Push Kapinger Image` workflow's `Build Linux Toolbox Image` job has failed on every run since 2026-07-02 ([latest](https://github.com/microsoft/retina/actions/runs/29115041358)):

```
go: updates to go.mod needed; to update it:
	go mod tidy
```

#2486 bumped `hack/tools/kapinger/go.mod`'s `go` directive `1.24.2` → `1.25.0`. `hack/tools/toolbox` consumes kapinger through a local `replace`, but still declared `go 1.24.2` — and `go build`'s default readonly module mode refuses to build a module whose dependency requires a newer `go` directive. Dependabot never repairs this because toolbox's only requirement is the local-replaced module, so the mismatch can only recur silently on future kapinger bumps.

This bumps the toolbox `go` directive to `1.25.0` — the exact (and only) output of `go mod tidy` in `hack/tools/toolbox`.

## Related Issue

N/A — found while reviewing failing CI workflows.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`).
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable. (N/A — go.mod directive bump.)

## Screenshots (if applicable) or Testing Completed

Reproduced the exact CI build locally: `docker buildx build --platform linux/amd64 -f hack/tools/toolbox/Dockerfile hack/tools` fails on `main` with the error above and completes with this change.

## Additional Notes
