### PR TITLE
fix(ci): pass stale action outputs via env in Print outputs step

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -32,4 +32,6 @@ jobs:
           stale-issue-message: "This issue will be closed in 7 days due to inactivity."
           stale-pr-message: "This PR will be closed in 7 days due to inactivity."
       - name: Print outputs
-        run: echo "${{ join(steps.stale.outputs.*, ',') }}"
+        env:
+          STALE_OUTPUTS: ${{ join(steps.stale.outputs.*, ',') }}
+        run: echo "$STALE_OUTPUTS"


### PR DESCRIPTION
# Description

The `Stale PR and Issue Handler` workflow fails on exactly the days it does real work — most recently [every](https://github.com/microsoft/retina/actions/runs/29060740554) [night](https://github.com/microsoft/retina/actions/runs/28985949517). The stale action itself succeeds; the failure is the `Print outputs` step, which interpolates the action's JSON outputs directly into the bash script. Whenever anything was staled or closed, the JSON carries PR titles with quotes and parentheses, and the rendered script is invalid bash:

```
Run echo "[],[{"operations":...,"title":"fix(helm): use native gRPC probe on relay :4222...",...}]"
/home/runner/work/_temp/....sh: line 1: syntax error near unexpected token `('
##[error]Process completed with exit code 2.
```

On days with no stale/close activity the outputs render empty and the step passes — hence the "intermittent" pattern that exactly tracks the action's activity.

This passes the joined outputs through an environment variable and echoes the variable instead, so the shell never parses the payload. Reproduced locally: inlining a real payload into `bash -n` yields the identical `syntax error near unexpected token '('`; the env-var form prints the same payload intact.

## Related Issue

N/A — found while reviewing failing CI workflows.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`).
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable. (N/A — workflow-only change.)

## Screenshots (if applicable) or Testing Completed

Local reproduction as above (`bash -n` on the rendered forms); YAML parses clean. The workflow runs nightly (also `workflow_dispatch`), so the next scheduled run validates end-to-end.

## Additional Notes

N/A.
