### PR TITLE
deps: group k8s.io minor updates in dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -89,7 +89,7 @@ updates:
           - "sigs.k8s.io/*"
         exclude-patterns:
           - "sigs.k8s.io/cloud-provider-azure/*"
-        update-types: ["patch"]
+        update-types: ["patch", "minor"]
       cilium:
         patterns:
           - "github.com/cilium/*"


### PR DESCRIPTION
# Description

The `k8s` dependabot group only covers `patch` updates, so k8s release trains (`v0.35` → `v0.36` across `k8s.io/api`, `apimachinery`, `client-go`, `kubectl`, `metrics`, …) arrive as individual PRs. Those modules version in lockstep, so a lone bump is unresolvable — #2329 has been failing dependency resolution for weeks:

```
k8s.io/metrics | dependency_file_not_resolvable |
"go: ...k8s.io/kubectl/pkg/scheme imports k8s.io/api/scheduling/v1alpha1:
module k8s.io/api@latest found (v0.36.2), but does not contain package k8s.io/api/scheduling/v1alpha1"
```

The paired `sigs.k8s.io/controller-runtime` minor (#2324, `0.23` → `0.24`, which requires k8s `v0.36`) fails the same way. This extends the group to `minor` updates so the whole lockstep set ships as one PR. Majors stay excluded — k8s.io core modules are perpetually `v0.x`, so the release train is always a minor.

## Related Issue

N/A — follow-up from reviewing failing dependabot updates.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`).
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable. (N/A — dependabot config.)

## Screenshots (if applicable) or Testing Completed

YAML parses clean; dependabot validates the config on its next scheduled run — config-only change.

## Additional Notes

After this merges, close #2329 and #2324; the next daily gomod run will regenerate them as a single grouped `k8s` PR containing the coherent `v0.36` set.
