### PR TITLE
fix(dns,tcpretrans): Add nolint to fix vendoring bug

### DIFF
--- a/pkg/plugin/dns/_cprog/dns.c
+++ b/pkg/plugin/dns/_cprog/dns.c
@@ -1,4 +1,4 @@
-// go:build ignore
+//go:build ignore
 
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.

--- a/pkg/plugin/dns/_cprog/placeholder.go
+++ b/pkg/plugin/dns/_cprog/placeholder.go
@@ -1,0 +1,3 @@
+package cprog //nolint:all
+
+// This file is a placeholder to make Go include this directory when vendoring.

--- a/pkg/plugin/dns/dns_linux.go
+++ b/pkg/plugin/dns/dns_linux.go
@@ -21,6 +21,7 @@ import (
 	"github.com/microsoft/retina/pkg/log"
 	"github.com/microsoft/retina/pkg/metrics"
 	plugincommon "github.com/microsoft/retina/pkg/plugin/common"
+	_ "github.com/microsoft/retina/pkg/plugin/dns/_cprog" // nolint // This is needed so cprog is included when vendoring
 	"github.com/microsoft/retina/pkg/plugin/registry"
 	"github.com/microsoft/retina/pkg/utils"
 	"github.com/pkg/errors"
@@ -285,6 +286,7 @@ func (d *dns) handleDNSEvent(record perf.Record) {
 
 // parseDNSPayload extracts the query name, response addresses, and query type
 // from the raw DNS payload using gopacket.
+//
 //nolint:nonamedreturns // named returns used by defer recovery
 func (d *dns) parseDNSPayload(payload []byte, isResponse bool) (
 	dnsName string, addresses []string, qtype layers.DNSType,

--- a/pkg/plugin/tcpretrans/_cprog/placeholder.go
+++ b/pkg/plugin/tcpretrans/_cprog/placeholder.go
@@ -1,0 +1,3 @@
+package cprog //nolint:all
+
+// This file is a placeholder to make Go include this directory when vendoring.

--- a/pkg/plugin/tcpretrans/tcpretrans_linux.go
+++ b/pkg/plugin/tcpretrans/tcpretrans_linux.go
@@ -21,6 +21,7 @@ import (
 	"github.com/microsoft/retina/pkg/metrics"
 	plugincommon "github.com/microsoft/retina/pkg/plugin/common"
 	"github.com/microsoft/retina/pkg/plugin/registry"
+	_ "github.com/microsoft/retina/pkg/plugin/tcpretrans/_cprog" // nolint // This is needed so cprog is included when vendoring
 	"github.com/microsoft/retina/pkg/utils"
 	"go.uber.org/zap"
 	"golang.org/x/sys/unix"


### PR DESCRIPTION
# Description

Add nolint to make sure _cprog files are included for functional vendoring.



## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.


---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
