### PR TITLE
deps: bump pwru to v1.0.12 in shell image

### DIFF
--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -57,7 +57,7 @@ ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 ARG GOARCH=amd64
 ENV ARCH=${GOARCH}
 # https://github.com/cilium/pwru/releases
-ARG PWRU_TAG="v1.0.11"
+ARG PWRU_TAG="v1.0.12"
 ENV PWRU_TAG=${PWRU_TAG}
 
 # Download and extract latest pwru release for the correct architecture (amd64 or arm64)


### PR DESCRIPTION
# Description

Bumps the `pwru` binary baked into the `retina-shell` image from `v1.0.11` → `v1.0.12` ([release notes](https://github.com/cilium/pwru/releases/tag/v1.0.12)). Only the `PWRU_TAG` pin in `shell/Dockerfile` changes — the release asset names and tarball layout are unchanged.

## Related Issue

N/A.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Verified both `pwru-linux-{amd64,arm64}.tar.gz` assets for `v1.0.12` download and extract with the exact steps the Dockerfile runs; the arm64 binary executes locally and reports `pwru v1.0.12`, and the amd64 binary is a valid x86-64 ELF (`readelf`).

## Additional Notes

N/A.
