### PR TITLE
chore(ci): migrate fic-using workflows to ADO pipelines

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -55,13 +55,14 @@ jobs:
           scriptLocation: inlineScript
           inlineScript: |
             set -euo pipefail
-            echo "TAG=$(make version)" >> tag.env
+            TAG=$(make version)
             az acr login -n $(ACR_NAME)
             make retina-image \
               IMAGE_NAMESPACE=$(imageNamespace) \
               PLATFORM=linux/$(arch) \
               IMAGE_REGISTRY=$(ACR_NAME) \
               APP_INSIGHTS_ID=$APP_INSIGHTS_ID \
+              TAG=$TAG \
               BUILDX_ACTION=--push
 
   - job: build_windows_binaries
@@ -141,7 +142,8 @@ jobs:
               IMAGE_REGISTRY=$(ACR_NAME) \
               APP_INSIGHTS_ID=$APP_INSIGHTS_ID \
               BINARIES_PATH=output/windows_$(arch) \
-              REPO_PATH=.
+              REPO_PATH=. \
+              TAG=$TAG
             docker push $(ACR_NAME)/$(imageNamespace)/retina-agent:${TAG}-windows-ltsc$(year)-$(arch)
 
   - job: operator_images
@@ -170,12 +172,14 @@ jobs:
           scriptLocation: inlineScript
           inlineScript: |
             set -euo pipefail
+            TAG=$(make version)
             az acr login -n $(ACR_NAME)
             make retina-operator-image \
               IMAGE_NAMESPACE=$(imageNamespace) \
               PLATFORM=linux/$(arch) \
               IMAGE_REGISTRY=$(ACR_NAME) \
               APP_INSIGHTS_ID=$APP_INSIGHTS_ID \
+              TAG=$TAG \
               BUILDX_ACTION=--push
 
   - job: retina_shell_images
@@ -202,11 +206,13 @@ jobs:
           scriptLocation: inlineScript
           inlineScript: |
             set -euo pipefail
+            TAG=$(make version)
             az acr login -n $(ACR_NAME)
             make retina-shell-image \
               IMAGE_NAMESPACE=$(imageNamespace) \
               PLATFORM=linux/$(arch) \
               IMAGE_REGISTRY=$(ACR_NAME) \
+              TAG=$TAG \
               BUILDX_ACTION=--push
 
   - job: kubectl_retina_images
@@ -233,11 +239,13 @@ jobs:
           scriptLocation: inlineScript
           inlineScript: |
             set -euo pipefail
+            TAG=$(make version)
             az acr login -n $(ACR_NAME)
             make kubectl-retina-image \
               IMAGE_NAMESPACE=$(imageNamespace) \
               PLATFORM=linux/$(arch) \
               IMAGE_REGISTRY=$(ACR_NAME) \
+              TAG=$TAG \
               BUILDX_ACTION=--push
 
   - job: manifests
@@ -273,8 +281,9 @@ jobs:
           scriptLocation: inlineScript
           inlineScript: |
             set -euo pipefail
+            TAG=$(make version)
             az acr login -n $(ACR_NAME)
-            make manifest COMPONENT=$(component) IMAGE_REGISTRY=$(ACR_NAME)
+            make manifest COMPONENT=$(component) IMAGE_REGISTRY=$(ACR_NAME) TAG=$TAG
 
   - job: e2e
     displayName: Run E2E Tests

--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -36,14 +36,14 @@ jobs:
       matrix:
         amd64:
           arch: amd64
-          agentImage: ubuntu-latest
         arm64:
           arch: arm64
-          agentImage: ubuntu-22.04-arm64
     pool:
-      vmImage: $(agentImage)
+      vmImage: ubuntu-latest
     steps:
       - checkout: self
+      - bash: make qemu-user-static
+        displayName: Set up QEMU
       - template: steps/setup-go.yml
       - task: AzureCLI@2
         displayName: Build and push retina image
@@ -151,14 +151,14 @@ jobs:
       matrix:
         amd64:
           arch: amd64
-          agentImage: ubuntu-latest
         arm64:
           arch: arm64
-          agentImage: ubuntu-22.04-arm64
     pool:
-      vmImage: $(agentImage)
+      vmImage: ubuntu-latest
     steps:
       - checkout: self
+      - bash: make qemu-user-static
+        displayName: Set up QEMU
       - template: steps/setup-go.yml
       - task: AzureCLI@2
         displayName: Build and push operator image
@@ -185,14 +185,14 @@ jobs:
       matrix:
         amd64:
           arch: amd64
-          agentImage: ubuntu-latest
         arm64:
           arch: arm64
-          agentImage: ubuntu-22.04-arm64
     pool:
-      vmImage: $(agentImage)
+      vmImage: ubuntu-latest
     steps:
       - checkout: self
+      - bash: make qemu-user-static
+        displayName: Set up QEMU
       - template: steps/setup-go.yml
       - task: AzureCLI@2
         displayName: Build and push retina-shell image
@@ -216,14 +216,14 @@ jobs:
       matrix:
         amd64:
           arch: amd64
-          agentImage: ubuntu-latest
         arm64:
           arch: arm64
-          agentImage: ubuntu-22.04-arm64
     pool:
-      vmImage: $(agentImage)
+      vmImage: ubuntu-latest
     steps:
       - checkout: self
+      - bash: make qemu-user-static
+        displayName: Set up QEMU
       - template: steps/setup-go.yml
       - task: AzureCLI@2
         displayName: Build and push kubectl-retina image
@@ -263,9 +263,8 @@ jobs:
           component: kubectl-retina
     steps:
       - checkout: self
-      - bash: |
-          docker run --privileged --rm tonistiigi/binfmt --install all
-        displayName: Setup QEMU
+      - bash: make qemu-user-static
+        displayName: Set up QEMU
       - task: AzureCLI@2
         displayName: make manifest
         inputs:

--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -54,6 +54,7 @@ jobs:
       vmImage: ubuntu-latest
     steps:
       - checkout: self
+      - template: steps/free-disk-space.yml
       - bash: make qemu-user-static
         displayName: Set up QEMU
       - template: steps/setup-go.yml
@@ -190,6 +191,7 @@ jobs:
       vmImage: ubuntu-latest
     steps:
       - checkout: self
+      - template: steps/free-disk-space.yml
       - bash: make qemu-user-static
         displayName: Set up QEMU
       - template: steps/setup-go.yml
@@ -234,6 +236,7 @@ jobs:
       vmImage: ubuntu-latest
     steps:
       - checkout: self
+      - template: steps/free-disk-space.yml
       - bash: make qemu-user-static
         displayName: Set up QEMU
       - template: steps/setup-go.yml
@@ -276,6 +279,7 @@ jobs:
       vmImage: ubuntu-latest
     steps:
       - checkout: self
+      - template: steps/free-disk-space.yml
       - bash: make qemu-user-static
         displayName: Set up QEMU
       - template: steps/setup-go.yml

--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -30,15 +30,29 @@ pr:
     include:
       - main
 
+parameters:
+  # TEMPORARY (revert this parameter and the isMergeGroup if/else below after
+  # dark-launch validation): when true, forces full merge-group behavior on any
+  # trigger (push to ACR, embed APP_INSIGHTS_ID, run manifests + e2e + perf).
+  # Use it to validate the full pipeline from a manual queue against any branch.
+  - name: forceMergeGroup
+    displayName: Force merge-group behavior (push + telemetry + tests)
+    type: boolean
+    default: false
+
 variables:
   - name: azureServiceConnection
     value: r2d
   - name: imageNamespace
     value: microsoft/retina
-  # True only when the build was triggered by a push to a merge-queue temp branch.
-  # PR builds and manual queues evaluate to False -> dry-run behavior.
+  # True only when the build was triggered by a push to a merge-queue temp branch,
+  # OR when the forceMergeGroup parameter is checked at queue time.
+  # PR builds and manual queues with the checkbox off evaluate to False -> dry-run.
   - name: isMergeGroup
-    value: $[ startsWith(variables['Build.SourceBranch'], 'refs/heads/gh-readonly-queue/') ]
+    ${{ if eq(parameters.forceMergeGroup, true) }}:
+      value: 'True'
+    ${{ else }}:
+      value: $[ startsWith(variables['Build.SourceBranch'], 'refs/heads/gh-readonly-queue/') ]
 
 jobs:
   - job: retina_images

--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -1,0 +1,434 @@
+# retina CI pipeline (Azure DevOps).
+#
+# Mirrors .github/workflows/images.yaml. Runs on GitHub merge-queue events
+# via the Azure Pipelines GitHub App: pushes to gh-readonly-queue/main/*.
+#
+# Required ADO pipeline configuration (set in the ADO UI before first run):
+#   Variables (plain):
+#     ACR_NAME                    e.g. retinaacr (or full FQDN, matches current vars.ACR_NAME)
+#     AZURE_LOCATION              e.g. eastus2
+#     AZURE_AGENT_LINUX_SKU
+#     AZURE_AGENT_WINDOWS_SKU
+#     AZURE_AGENT_LINUX_ARM_SKU
+#   Variables (secret):
+#     AZURE_APP_INSIGHTS_KEY
+#   Service connection (Azure RM, WIF): r2d
+#   Settings: "Limit building pull requests from forked GitHub repositories" = Disable
+
+trigger:
+  branches:
+    include:
+      - gh-readonly-queue/main/*
+
+pr: none
+
+variables:
+  - name: azureServiceConnection
+    value: r2d
+  - name: imageNamespace
+    value: microsoft/retina
+
+jobs:
+  - job: retina_images
+    displayName: Build Agent Images - Linux
+    timeoutInMinutes: 60
+    strategy:
+      matrix:
+        amd64:
+          arch: amd64
+          agentImage: ubuntu-latest
+        arm64:
+          arch: arm64
+          agentImage: ubuntu-22.04-arm64
+    pool:
+      vmImage: $(agentImage)
+    steps:
+      - checkout: self
+      - task: GoTool@0
+        inputs:
+          version: 'from go.mod'
+      - task: AzureCLI@2
+        displayName: Build and push retina image
+        env:
+          APP_INSIGHTS_ID: $(AZURE_APP_INSIGHTS_KEY)
+        inputs:
+          azureSubscription: $(azureServiceConnection)
+          scriptType: bash
+          scriptLocation: inlineScript
+          inlineScript: |
+            set -euo pipefail
+            echo "TAG=$(make version)" >> tag.env
+            az acr login -n $(ACR_NAME)
+            make retina-image \
+              IMAGE_NAMESPACE=$(imageNamespace) \
+              PLATFORM=linux/$(arch) \
+              IMAGE_REGISTRY=$(ACR_NAME) \
+              APP_INSIGHTS_ID=$APP_INSIGHTS_ID \
+              BUILDX_ACTION=--push
+
+  - job: build_windows_binaries
+    displayName: Build Windows Binaries
+    timeoutInMinutes: 30
+    pool:
+      vmImage: ubuntu-latest
+    steps:
+      - checkout: self
+      - task: GoTool@0
+        inputs:
+          version: 'from go.mod'
+      - bash: |
+          set -euo pipefail
+          TAG=$(make version)
+          make build-windows-binaries \
+            GOOS=windows \
+            GOARCH=amd64 \
+            TAG=$TAG \
+            APP_INSIGHTS_ID=$APP_INSIGHTS_ID
+        displayName: make build-windows-binaries
+        env:
+          APP_INSIGHTS_ID: $(AZURE_APP_INSIGHTS_KEY)
+      - task: PublishPipelineArtifact@1
+        inputs:
+          targetPath: output/windows_amd64/
+          artifactName: windows-binaries
+
+  - job: retina_image_win
+    displayName: Build Agent Image - Windows 2022
+    dependsOn: build_windows_binaries
+    timeoutInMinutes: 60
+    pool:
+      vmImage: windows-2022
+    variables:
+      year: '2022'
+      arch: amd64
+      platform: windows
+    steps:
+      - checkout: self
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          artifactName: windows-binaries
+          targetPath: output/windows_amd64/
+      - powershell: |
+          $timeout = 120
+          $timer = [Diagnostics.Stopwatch]::StartNew()
+          while ($timer.Elapsed.TotalSeconds -lt $timeout) {
+            $svc = Get-Service docker -ErrorAction SilentlyContinue
+            if ($svc -and $svc.Status -ne 'Running') {
+              Start-Service docker -ErrorAction SilentlyContinue
+            }
+            $result = docker info 2>&1
+            if ($LASTEXITCODE -eq 0) {
+              Write-Host "Docker daemon is ready"
+              return
+            }
+            Write-Host "Waiting for Docker daemon to start..."
+            Start-Sleep -Seconds 5
+          }
+          throw "Docker daemon failed to start within $timeout seconds"
+        displayName: Ensure Docker daemon is running
+      - task: AzureCLI@2
+        displayName: Build and push retina Windows image
+        env:
+          APP_INSIGHTS_ID: $(AZURE_APP_INSIGHTS_KEY)
+        inputs:
+          azureSubscription: $(azureServiceConnection)
+          scriptType: bash
+          scriptLocation: inlineScript
+          inlineScript: |
+            set -euo pipefail
+            TAG=$(make version)
+            az acr login -n $(ACR_NAME)
+            make retina-image-win \
+              IMAGE_NAMESPACE=$(imageNamespace) \
+              PLATFORM=$(platform)/$(arch) \
+              WINDOWS_YEARS=$(year) \
+              IMAGE_REGISTRY=$(ACR_NAME) \
+              APP_INSIGHTS_ID=$APP_INSIGHTS_ID \
+              BINARIES_PATH=output/windows_$(arch) \
+              REPO_PATH=.
+            docker push $(ACR_NAME)/$(imageNamespace)/retina-agent:${TAG}-windows-ltsc$(year)-$(arch)
+
+  - job: operator_images
+    displayName: Build Operator Images
+    timeoutInMinutes: 60
+    strategy:
+      matrix:
+        amd64:
+          arch: amd64
+          agentImage: ubuntu-latest
+        arm64:
+          arch: arm64
+          agentImage: ubuntu-22.04-arm64
+    pool:
+      vmImage: $(agentImage)
+    steps:
+      - checkout: self
+      - task: GoTool@0
+        inputs:
+          version: 'from go.mod'
+      - task: AzureCLI@2
+        displayName: Build and push operator image
+        env:
+          APP_INSIGHTS_ID: $(AZURE_APP_INSIGHTS_KEY)
+        inputs:
+          azureSubscription: $(azureServiceConnection)
+          scriptType: bash
+          scriptLocation: inlineScript
+          inlineScript: |
+            set -euo pipefail
+            az acr login -n $(ACR_NAME)
+            make retina-operator-image \
+              IMAGE_NAMESPACE=$(imageNamespace) \
+              PLATFORM=linux/$(arch) \
+              IMAGE_REGISTRY=$(ACR_NAME) \
+              APP_INSIGHTS_ID=$APP_INSIGHTS_ID \
+              BUILDX_ACTION=--push
+
+  - job: retina_shell_images
+    displayName: Build Retina Shell Images
+    timeoutInMinutes: 60
+    strategy:
+      matrix:
+        amd64:
+          arch: amd64
+          agentImage: ubuntu-latest
+        arm64:
+          arch: arm64
+          agentImage: ubuntu-22.04-arm64
+    pool:
+      vmImage: $(agentImage)
+    steps:
+      - checkout: self
+      - task: GoTool@0
+        inputs:
+          version: 'from go.mod'
+      - task: AzureCLI@2
+        displayName: Build and push retina-shell image
+        inputs:
+          azureSubscription: $(azureServiceConnection)
+          scriptType: bash
+          scriptLocation: inlineScript
+          inlineScript: |
+            set -euo pipefail
+            az acr login -n $(ACR_NAME)
+            make retina-shell-image \
+              IMAGE_NAMESPACE=$(imageNamespace) \
+              PLATFORM=linux/$(arch) \
+              IMAGE_REGISTRY=$(ACR_NAME) \
+              BUILDX_ACTION=--push
+
+  - job: kubectl_retina_images
+    displayName: Build Kubectl Retina Images
+    timeoutInMinutes: 60
+    strategy:
+      matrix:
+        amd64:
+          arch: amd64
+          agentImage: ubuntu-latest
+        arm64:
+          arch: arm64
+          agentImage: ubuntu-22.04-arm64
+    pool:
+      vmImage: $(agentImage)
+    steps:
+      - checkout: self
+      - task: GoTool@0
+        inputs:
+          version: 'from go.mod'
+      - task: AzureCLI@2
+        displayName: Build and push kubectl-retina image
+        inputs:
+          azureSubscription: $(azureServiceConnection)
+          scriptType: bash
+          scriptLocation: inlineScript
+          inlineScript: |
+            set -euo pipefail
+            az acr login -n $(ACR_NAME)
+            make kubectl-retina-image \
+              IMAGE_NAMESPACE=$(imageNamespace) \
+              PLATFORM=linux/$(arch) \
+              IMAGE_REGISTRY=$(ACR_NAME) \
+              BUILDX_ACTION=--push
+
+  - job: manifests
+    displayName: Generate Manifests
+    dependsOn:
+      - retina_images
+      - retina_image_win
+      - operator_images
+      - retina_shell_images
+      - kubectl_retina_images
+    timeoutInMinutes: 30
+    pool:
+      vmImage: ubuntu-latest
+    strategy:
+      matrix:
+        retina:
+          component: retina
+        operator:
+          component: operator
+        shell:
+          component: shell
+        kubectl-retina:
+          component: kubectl-retina
+    steps:
+      - checkout: self
+      - bash: |
+          docker run --privileged --rm tonistiigi/binfmt --install all
+        displayName: Setup QEMU
+      - task: AzureCLI@2
+        displayName: make manifest
+        inputs:
+          azureSubscription: $(azureServiceConnection)
+          scriptType: bash
+          scriptLocation: inlineScript
+          inlineScript: |
+            set -euo pipefail
+            az acr login -n $(ACR_NAME)
+            make manifest COMPONENT=$(component) IMAGE_REGISTRY=$(ACR_NAME)
+
+  - job: e2e
+    displayName: Run E2E Tests
+    dependsOn: manifests
+    timeoutInMinutes: 90
+    pool:
+      vmImage: ubuntu-latest
+    variables:
+      CLUSTER_NAME: retina-e2e-$(Build.BuildId)-$(System.JobAttempt)
+    steps:
+      - checkout: self
+      - task: GoTool@0
+        inputs:
+          version: 'from go.mod'
+      - task: AzureCLI@2
+        displayName: Run E2E Tests
+        env:
+          AZURE_LOCATION: $(AZURE_LOCATION)
+          AZURE_AGENT_LINUX_SKU: $(AZURE_AGENT_LINUX_SKU)
+          AZURE_AGENT_WINDOWS_SKU: $(AZURE_AGENT_WINDOWS_SKU)
+          AZURE_AGENT_LINUX_ARM_SKU: $(AZURE_AGENT_LINUX_ARM_SKU)
+        inputs:
+          azureSubscription: $(azureServiceConnection)
+          scriptType: bash
+          scriptLocation: inlineScript
+          inlineScript: |
+            set -euo pipefail
+            export AZURE_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+            go test -v ./test/e2e/. -timeout 60m -tags=e2e -count=1 -args \
+              -image-tag=$(make version) \
+              -image-registry=$(ACR_NAME) \
+              -image-namespace=$(imageNamespace)
+      - task: AzureCLI@2
+        displayName: Cleanup resource group
+        condition: always()
+        inputs:
+          azureSubscription: $(azureServiceConnection)
+          scriptType: bash
+          scriptLocation: inlineScript
+          inlineScript: |
+            if az group exists --name "$(CLUSTER_NAME)" 2>/dev/null | grep -q true; then
+              echo "Deleting resource group $(CLUSTER_NAME)..."
+              az group delete --name "$(CLUSTER_NAME)" --yes --no-wait || true
+            fi
+
+  - job: perf_basic
+    displayName: Retina basic Performance Test
+    dependsOn:
+      - manifests
+      - e2e
+    timeoutInMinutes: 150
+    pool:
+      vmImage: ubuntu-latest
+    variables:
+      CLUSTER_NAME: retina-perf-basic-$(Build.BuildId)-$(System.JobAttempt)
+      MODE: basic
+    steps:
+      - checkout: self
+      - task: GoTool@0
+        inputs:
+          version: 'from go.mod'
+      - task: AzureCLI@2
+        displayName: Run perf test
+        env:
+          AZURE_APP_INSIGHTS_KEY: $(AZURE_APP_INSIGHTS_KEY)
+          AZURE_LOCATION: $(AZURE_LOCATION)
+          AZURE_AGENT_LINUX_SKU: $(AZURE_AGENT_LINUX_SKU)
+          AZURE_AGENT_WINDOWS_SKU: $(AZURE_AGENT_WINDOWS_SKU)
+          AZURE_AGENT_LINUX_ARM_SKU: $(AZURE_AGENT_LINUX_ARM_SKU)
+        inputs:
+          azureSubscription: $(azureServiceConnection)
+          scriptType: bash
+          scriptLocation: inlineScript
+          inlineScript: |
+            set -euo pipefail
+            export AZURE_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+            TAG=$(make version)
+            echo "Running in $MODE mode..."
+            go test -v ./test/e2e/. -timeout 2h -tags=perf -count=1 -args \
+              -image-tag="$TAG" \
+              -image-registry="$(ACR_NAME)" \
+              -image-namespace="$(imageNamespace)" \
+              -retina-mode="$MODE"
+      - task: AzureCLI@2
+        displayName: Cleanup resource group
+        condition: always()
+        inputs:
+          azureSubscription: $(azureServiceConnection)
+          scriptType: bash
+          scriptLocation: inlineScript
+          inlineScript: |
+            if az group exists --name "$(CLUSTER_NAME)" 2>/dev/null | grep -q true; then
+              echo "Deleting resource group $(CLUSTER_NAME)..."
+              az group delete --name "$(CLUSTER_NAME)" --yes --no-wait || true
+            fi
+
+  - job: perf_advanced
+    displayName: Retina advanced Performance Test
+    dependsOn:
+      - manifests
+      - e2e
+    timeoutInMinutes: 150
+    pool:
+      vmImage: ubuntu-latest
+    variables:
+      CLUSTER_NAME: retina-perf-advanced-$(Build.BuildId)-$(System.JobAttempt)
+      MODE: advanced
+    steps:
+      - checkout: self
+      - task: GoTool@0
+        inputs:
+          version: 'from go.mod'
+      - task: AzureCLI@2
+        displayName: Run perf test
+        env:
+          AZURE_APP_INSIGHTS_KEY: $(AZURE_APP_INSIGHTS_KEY)
+          AZURE_LOCATION: $(AZURE_LOCATION)
+          AZURE_AGENT_LINUX_SKU: $(AZURE_AGENT_LINUX_SKU)
+          AZURE_AGENT_WINDOWS_SKU: $(AZURE_AGENT_WINDOWS_SKU)
+          AZURE_AGENT_LINUX_ARM_SKU: $(AZURE_AGENT_LINUX_ARM_SKU)
+        inputs:
+          azureSubscription: $(azureServiceConnection)
+          scriptType: bash
+          scriptLocation: inlineScript
+          inlineScript: |
+            set -euo pipefail
+            export AZURE_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+            TAG=$(make version)
+            echo "Running in $MODE mode..."
+            go test -v ./test/e2e/. -timeout 2h -tags=perf -count=1 -args \
+              -image-tag="$TAG" \
+              -image-registry="$(ACR_NAME)" \
+              -image-namespace="$(imageNamespace)" \
+              -retina-mode="$MODE"
+      - task: AzureCLI@2
+        displayName: Cleanup resource group
+        condition: always()
+        inputs:
+          azureSubscription: $(azureServiceConnection)
+          scriptType: bash
+          scriptLocation: inlineScript
+          inlineScript: |
+            if az group exists --name "$(CLUSTER_NAME)" 2>/dev/null | grep -q true; then
+              echo "Deleting resource group $(CLUSTER_NAME)..."
+              az group delete --name "$(CLUSTER_NAME)" --yes --no-wait || true
+            fi

--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -44,9 +44,7 @@ jobs:
       vmImage: $(agentImage)
     steps:
       - checkout: self
-      - task: GoTool@0
-        inputs:
-          version: 'from go.mod'
+      - template: steps/setup-go.yml
       - task: AzureCLI@2
         displayName: Build and push retina image
         env:
@@ -73,9 +71,7 @@ jobs:
       vmImage: ubuntu-latest
     steps:
       - checkout: self
-      - task: GoTool@0
-        inputs:
-          version: 'from go.mod'
+      - template: steps/setup-go.yml
       - bash: |
           set -euo pipefail
           TAG=$(make version)
@@ -163,9 +159,7 @@ jobs:
       vmImage: $(agentImage)
     steps:
       - checkout: self
-      - task: GoTool@0
-        inputs:
-          version: 'from go.mod'
+      - template: steps/setup-go.yml
       - task: AzureCLI@2
         displayName: Build and push operator image
         env:
@@ -199,9 +193,7 @@ jobs:
       vmImage: $(agentImage)
     steps:
       - checkout: self
-      - task: GoTool@0
-        inputs:
-          version: 'from go.mod'
+      - template: steps/setup-go.yml
       - task: AzureCLI@2
         displayName: Build and push retina-shell image
         inputs:
@@ -232,9 +224,7 @@ jobs:
       vmImage: $(agentImage)
     steps:
       - checkout: self
-      - task: GoTool@0
-        inputs:
-          version: 'from go.mod'
+      - template: steps/setup-go.yml
       - task: AzureCLI@2
         displayName: Build and push kubectl-retina image
         inputs:
@@ -297,9 +287,7 @@ jobs:
       CLUSTER_NAME: retina-e2e-$(Build.BuildId)-$(System.JobAttempt)
     steps:
       - checkout: self
-      - task: GoTool@0
-        inputs:
-          version: 'from go.mod'
+      - template: steps/setup-go.yml
       - task: AzureCLI@2
         displayName: Run E2E Tests
         env:
@@ -344,9 +332,7 @@ jobs:
       MODE: basic
     steps:
       - checkout: self
-      - task: GoTool@0
-        inputs:
-          version: 'from go.mod'
+      - template: steps/setup-go.yml
       - task: AzureCLI@2
         displayName: Run perf test
         env:
@@ -395,9 +381,7 @@ jobs:
       MODE: advanced
     steps:
       - checkout: self
-      - task: GoTool@0
-        inputs:
-          version: 'from go.mod'
+      - template: steps/setup-go.yml
       - task: AzureCLI@2
         displayName: Run perf test
         env:

--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -1,7 +1,12 @@
 # retina CI pipeline (Azure DevOps).
 #
-# Mirrors .github/workflows/images.yaml. Runs on GitHub merge-queue events
-# via the Azure Pipelines GitHub App: pushes to gh-readonly-queue/main/*.
+# Mirrors .github/workflows/images.yaml. Triggered by:
+#   - GitHub merge-queue events (push to gh-readonly-queue/main/*) via the
+#     Azure Pipelines GitHub App -> full run: builds, pushes to ACR, embeds
+#     APP_INSIGHTS_ID, runs manifests + e2e + perf tests.
+#   - Pull requests targeting main -> build only (no push, no telemetry key
+#     embedded, manifests/e2e/perf skipped) - same as GH pull_request behavior.
+#   - Manual queue from ADO UI -> same behavior as PR (dry-run build only).
 #
 # Required ADO pipeline configuration (set in the ADO UI before first run):
 #   Variables (plain):
@@ -20,13 +25,20 @@ trigger:
     include:
       - gh-readonly-queue/main/*
 
-pr: none
+pr:
+  branches:
+    include:
+      - main
 
 variables:
   - name: azureServiceConnection
     value: r2d
   - name: imageNamespace
     value: microsoft/retina
+  # True only when the build was triggered by a push to a merge-queue temp branch.
+  # PR builds and manual queues evaluate to False -> dry-run behavior.
+  - name: isMergeGroup
+    value: $[ startsWith(variables['Build.SourceBranch'], 'refs/heads/gh-readonly-queue/') ]
 
 jobs:
   - job: retina_images
@@ -48,6 +60,7 @@ jobs:
       - task: AzureCLI@2
         displayName: Build and push retina image
         env:
+          IS_MERGE_GROUP: $(isMergeGroup)
           APP_INSIGHTS_ID: $(AZURE_APP_INSIGHTS_KEY)
         inputs:
           azureSubscription: $(azureServiceConnection)
@@ -56,14 +69,21 @@ jobs:
           inlineScript: |
             set -euo pipefail
             TAG=$(make version)
-            az acr login -n $(ACR_NAME)
-            make retina-image \
-              IMAGE_NAMESPACE=$(imageNamespace) \
-              PLATFORM=linux/$(arch) \
-              IMAGE_REGISTRY=$(ACR_NAME) \
-              APP_INSIGHTS_ID=$APP_INSIGHTS_ID \
-              TAG=$TAG \
-              BUILDX_ACTION=--push
+            if [ "$IS_MERGE_GROUP" == "True" ]; then
+              az acr login -n $(ACR_NAME)
+              make retina-image \
+                IMAGE_NAMESPACE=$(imageNamespace) \
+                PLATFORM=linux/$(arch) \
+                IMAGE_REGISTRY=$(ACR_NAME) \
+                APP_INSIGHTS_ID=$APP_INSIGHTS_ID \
+                TAG=$TAG \
+                BUILDX_ACTION=--push
+            else
+              make retina-image \
+                IMAGE_NAMESPACE=$(imageNamespace) \
+                PLATFORM=linux/$(arch) \
+                TAG=$TAG
+            fi
 
   - job: build_windows_binaries
     displayName: Build Windows Binaries
@@ -126,6 +146,7 @@ jobs:
       - task: AzureCLI@2
         displayName: Build and push retina Windows image
         env:
+          IS_MERGE_GROUP: $(isMergeGroup)
           APP_INSIGHTS_ID: $(AZURE_APP_INSIGHTS_KEY)
         inputs:
           azureSubscription: $(azureServiceConnection)
@@ -134,17 +155,27 @@ jobs:
           inlineScript: |
             set -euo pipefail
             TAG=$(make version)
-            az acr login -n $(ACR_NAME)
-            make retina-image-win \
-              IMAGE_NAMESPACE=$(imageNamespace) \
-              PLATFORM=$(platform)/$(arch) \
-              WINDOWS_YEARS=$(year) \
-              IMAGE_REGISTRY=$(ACR_NAME) \
-              APP_INSIGHTS_ID=$APP_INSIGHTS_ID \
-              BINARIES_PATH=output/windows_$(arch) \
-              REPO_PATH=. \
-              TAG=$TAG
-            docker push $(ACR_NAME)/$(imageNamespace)/retina-agent:${TAG}-windows-ltsc$(year)-$(arch)
+            if [ "$IS_MERGE_GROUP" == "True" ]; then
+              az acr login -n $(ACR_NAME)
+              make retina-image-win \
+                IMAGE_NAMESPACE=$(imageNamespace) \
+                PLATFORM=$(platform)/$(arch) \
+                WINDOWS_YEARS=$(year) \
+                IMAGE_REGISTRY=$(ACR_NAME) \
+                APP_INSIGHTS_ID=$APP_INSIGHTS_ID \
+                BINARIES_PATH=output/windows_$(arch) \
+                REPO_PATH=. \
+                TAG=$TAG
+              docker push $(ACR_NAME)/$(imageNamespace)/retina-agent:${TAG}-windows-ltsc$(year)-$(arch)
+            else
+              make retina-image-win \
+                IMAGE_NAMESPACE=$(imageNamespace) \
+                PLATFORM=$(platform)/$(arch) \
+                WINDOWS_YEARS=$(year) \
+                BINARIES_PATH=output/windows_$(arch) \
+                REPO_PATH=. \
+                TAG=$TAG
+            fi
 
   - job: operator_images
     displayName: Build Operator Images
@@ -165,6 +196,7 @@ jobs:
       - task: AzureCLI@2
         displayName: Build and push operator image
         env:
+          IS_MERGE_GROUP: $(isMergeGroup)
           APP_INSIGHTS_ID: $(AZURE_APP_INSIGHTS_KEY)
         inputs:
           azureSubscription: $(azureServiceConnection)
@@ -173,14 +205,21 @@ jobs:
           inlineScript: |
             set -euo pipefail
             TAG=$(make version)
-            az acr login -n $(ACR_NAME)
-            make retina-operator-image \
-              IMAGE_NAMESPACE=$(imageNamespace) \
-              PLATFORM=linux/$(arch) \
-              IMAGE_REGISTRY=$(ACR_NAME) \
-              APP_INSIGHTS_ID=$APP_INSIGHTS_ID \
-              TAG=$TAG \
-              BUILDX_ACTION=--push
+            if [ "$IS_MERGE_GROUP" == "True" ]; then
+              az acr login -n $(ACR_NAME)
+              make retina-operator-image \
+                IMAGE_NAMESPACE=$(imageNamespace) \
+                PLATFORM=linux/$(arch) \
+                IMAGE_REGISTRY=$(ACR_NAME) \
+                APP_INSIGHTS_ID=$APP_INSIGHTS_ID \
+                TAG=$TAG \
+                BUILDX_ACTION=--push
+            else
+              make retina-operator-image \
+                IMAGE_NAMESPACE=$(imageNamespace) \
+                PLATFORM=linux/$(arch) \
+                TAG=$TAG
+            fi
 
   - job: retina_shell_images
     displayName: Build Retina Shell Images
@@ -200,6 +239,8 @@ jobs:
       - template: steps/setup-go.yml
       - task: AzureCLI@2
         displayName: Build and push retina-shell image
+        env:
+          IS_MERGE_GROUP: $(isMergeGroup)
         inputs:
           azureSubscription: $(azureServiceConnection)
           scriptType: bash
@@ -207,13 +248,20 @@ jobs:
           inlineScript: |
             set -euo pipefail
             TAG=$(make version)
-            az acr login -n $(ACR_NAME)
-            make retina-shell-image \
-              IMAGE_NAMESPACE=$(imageNamespace) \
-              PLATFORM=linux/$(arch) \
-              IMAGE_REGISTRY=$(ACR_NAME) \
-              TAG=$TAG \
-              BUILDX_ACTION=--push
+            if [ "$IS_MERGE_GROUP" == "True" ]; then
+              az acr login -n $(ACR_NAME)
+              make retina-shell-image \
+                IMAGE_NAMESPACE=$(imageNamespace) \
+                PLATFORM=linux/$(arch) \
+                IMAGE_REGISTRY=$(ACR_NAME) \
+                TAG=$TAG \
+                BUILDX_ACTION=--push
+            else
+              make retina-shell-image \
+                IMAGE_NAMESPACE=$(imageNamespace) \
+                PLATFORM=linux/$(arch) \
+                TAG=$TAG
+            fi
 
   - job: kubectl_retina_images
     displayName: Build Kubectl Retina Images
@@ -233,6 +281,8 @@ jobs:
       - template: steps/setup-go.yml
       - task: AzureCLI@2
         displayName: Build and push kubectl-retina image
+        env:
+          IS_MERGE_GROUP: $(isMergeGroup)
         inputs:
           azureSubscription: $(azureServiceConnection)
           scriptType: bash
@@ -240,16 +290,24 @@ jobs:
           inlineScript: |
             set -euo pipefail
             TAG=$(make version)
-            az acr login -n $(ACR_NAME)
-            make kubectl-retina-image \
-              IMAGE_NAMESPACE=$(imageNamespace) \
-              PLATFORM=linux/$(arch) \
-              IMAGE_REGISTRY=$(ACR_NAME) \
-              TAG=$TAG \
-              BUILDX_ACTION=--push
+            if [ "$IS_MERGE_GROUP" == "True" ]; then
+              az acr login -n $(ACR_NAME)
+              make kubectl-retina-image \
+                IMAGE_NAMESPACE=$(imageNamespace) \
+                PLATFORM=linux/$(arch) \
+                IMAGE_REGISTRY=$(ACR_NAME) \
+                TAG=$TAG \
+                BUILDX_ACTION=--push
+            else
+              make kubectl-retina-image \
+                IMAGE_NAMESPACE=$(imageNamespace) \
+                PLATFORM=linux/$(arch) \
+                TAG=$TAG
+            fi
 
   - job: manifests
     displayName: Generate Manifests
+    condition: eq(variables['isMergeGroup'], 'True')
     dependsOn:
       - retina_images
       - retina_image_win
@@ -287,6 +345,7 @@ jobs:
 
   - job: e2e
     displayName: Run E2E Tests
+    condition: eq(variables['isMergeGroup'], 'True')
     dependsOn: manifests
     timeoutInMinutes: 90
     pool:
@@ -329,6 +388,7 @@ jobs:
 
   - job: perf_basic
     displayName: Retina basic Performance Test
+    condition: eq(variables['isMergeGroup'], 'True')
     dependsOn:
       - manifests
       - e2e
@@ -378,6 +438,7 @@ jobs:
 
   - job: perf_advanced
     displayName: Retina advanced Performance Test
+    condition: eq(variables['isMergeGroup'], 'True')
     dependsOn:
       - manifests
       - e2e

--- a/.azure-pipelines/perf.yml
+++ b/.azure-pipelines/perf.yml
@@ -62,9 +62,7 @@ jobs:
           MODE: ${{ mode }}
         steps:
           - checkout: self
-          - task: GoTool@0
-            inputs:
-              version: 'from go.mod'
+          - template: steps/setup-go.yml
           - task: AzureCLI@2
             displayName: Resolve image tag
             name: resolve_tag

--- a/.azure-pipelines/perf.yml
+++ b/.azure-pipelines/perf.yml
@@ -1,0 +1,119 @@
+# retina Performance Test pipeline (Azure DevOps).
+#
+# Mirrors .github/workflows/perf-schedule.yaml + perf-manual.yaml + perf-template.yaml.
+# Scheduled: twice-daily at 00:17 and 12:17 UTC (both basic and advanced).
+# Manual: single mode chosen at queue time.
+#
+# Required ADO pipeline configuration (set in the ADO UI):
+#   Variables (plain):
+#     AZURE_LOCATION
+#     AZURE_AGENT_LINUX_SKU
+#     AZURE_AGENT_WINDOWS_SKU
+#     AZURE_AGENT_LINUX_ARM_SKU
+#   Variables (secret):
+#     AZURE_APP_INSIGHTS_KEY
+#   Service connection (Azure RM, WIF): r2d
+#   Settings: "Limit building pull requests from forked GitHub repositories" = Disable
+
+trigger: none
+pr: none
+
+schedules:
+  - cron: '17 0,12 * * *'
+    displayName: Twice-daily perf test (00:17 and 12:17 UTC)
+    branches:
+      include:
+        - main
+    always: true
+
+parameters:
+  - name: image_registry
+    displayName: Image Registry
+    type: string
+    default: ghcr.io
+  - name: image_namespace
+    displayName: Image Namespace
+    type: string
+    default: microsoft/retina
+  - name: tag
+    displayName: Image Tag (blank = latest GitHub release tag)
+    type: string
+    default: ' '
+  - name: modes
+    displayName: Retina modes to run
+    type: object
+    default:
+      - basic
+      - advanced
+
+variables:
+  - name: azureServiceConnection
+    value: r2d
+
+jobs:
+  - ${{ each mode in parameters.modes }}:
+      - job: perf_${{ mode }}
+        displayName: Retina ${{ mode }} Performance Test
+        timeoutInMinutes: 150
+        pool:
+          vmImage: ubuntu-latest
+        variables:
+          CLUSTER_NAME: retina-perf-${{ mode }}-$(Build.BuildId)-$(System.JobAttempt)
+          MODE: ${{ mode }}
+        steps:
+          - checkout: self
+          - task: GoTool@0
+            inputs:
+              version: 'from go.mod'
+          - task: AzureCLI@2
+            displayName: Resolve image tag
+            name: resolve_tag
+            inputs:
+              azureSubscription: $(azureServiceConnection)
+              scriptType: bash
+              scriptLocation: inlineScript
+              inlineScript: |
+                set -euo pipefail
+                TAG="${{ parameters.tag }}"
+                TAG="${TAG// /}"
+                if [[ -z "$TAG" ]]; then
+                  TAG=$(curl -s https://api.github.com/repos/microsoft/retina/releases/latest | jq -r .tag_name)
+                fi
+                echo "##vso[task.setvariable variable=RESOLVED_TAG]$TAG"
+                echo "Resolved tag: $TAG"
+          - task: AzureCLI@2
+            displayName: Run performance measurement for Retina
+            env:
+              AZURE_APP_INSIGHTS_KEY: $(AZURE_APP_INSIGHTS_KEY)
+              AZURE_LOCATION: $(AZURE_LOCATION)
+              AZURE_AGENT_LINUX_SKU: $(AZURE_AGENT_LINUX_SKU)
+              AZURE_AGENT_WINDOWS_SKU: $(AZURE_AGENT_WINDOWS_SKU)
+              AZURE_AGENT_LINUX_ARM_SKU: $(AZURE_AGENT_LINUX_ARM_SKU)
+              TAG: $(RESOLVED_TAG)
+              REGISTRY: ${{ parameters.image_registry }}
+              NAMESPACE: ${{ parameters.image_namespace }}
+            inputs:
+              azureSubscription: $(azureServiceConnection)
+              scriptType: bash
+              scriptLocation: inlineScript
+              inlineScript: |
+                set -euo pipefail
+                export AZURE_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+                echo "Running in $MODE mode with tag $TAG..."
+                go test -v ./test/e2e/. -timeout 2h -tags=perf -count=1 -args \
+                  -image-tag="$TAG" \
+                  -image-registry="$REGISTRY" \
+                  -image-namespace="$NAMESPACE" \
+                  -retina-mode="$MODE"
+          - task: AzureCLI@2
+            displayName: Cleanup resource group
+            condition: always()
+            inputs:
+              azureSubscription: $(azureServiceConnection)
+              scriptType: bash
+              scriptLocation: inlineScript
+              inlineScript: |
+                if az group exists --name "$(CLUSTER_NAME)" 2>/dev/null | grep -q true; then
+                  echo "Deleting resource group $(CLUSTER_NAME)..."
+                  az group delete --name "$(CLUSTER_NAME)" --yes --no-wait || true
+                fi

--- a/.azure-pipelines/scale.yml
+++ b/.azure-pipelines/scale.yml
@@ -73,9 +73,7 @@ jobs:
       vmImage: ubuntu-latest
     steps:
       - checkout: self
-      - task: GoTool@0
-        inputs:
-          version: 'from go.mod'
+      - template: steps/setup-go.yml
       - task: AzureCLI@2
         displayName: Run Scale Test
         env:

--- a/.azure-pipelines/scale.yml
+++ b/.azure-pipelines/scale.yml
@@ -1,0 +1,114 @@
+# retina Scale Test pipeline (Azure DevOps).
+#
+# Mirrors .github/workflows/scale-test.yaml + daily-scale-test.yaml.
+# Daily scheduled run (00:00 UTC) + manual runs from ADO UI.
+#
+# Required ADO pipeline configuration (set in the ADO UI):
+#   Variables (plain):
+#     ACR_NAME
+#   Variables (secret):
+#     AZURE_APP_INSIGHTS_KEY
+#   Service connection (Azure RM, WIF): r2d
+#   Settings: "Limit building pull requests from forked GitHub repositories" = Disable
+
+trigger: none
+pr: none
+
+schedules:
+  - cron: '0 0 * * *'
+    displayName: Daily scale test (00:00 UTC)
+    branches:
+      include:
+        - main
+    always: true
+
+parameters:
+  # For manual runs from the ADO UI. Defaults match .github/workflows/daily-scale-test.yaml.
+  - name: resource_group
+    displayName: Azure Resource Group (leave blank to auto-create)
+    type: string
+    default: ' '
+  - name: cluster_name
+    displayName: AKS Cluster Name (leave blank to auto-create)
+    type: string
+    default: ' '
+  - name: image_namespace
+    displayName: Image Namespace
+    type: string
+    default: microsoft/retina
+  - name: image_tag
+    displayName: Image Tag (blank = latest commit from main)
+    type: string
+    default: ' '
+  - name: num_deployments
+    displayName: Number of Traffic Deployments
+    type: number
+    default: 1000
+  - name: num_replicas
+    displayName: Number of Traffic Replicas per Deployment
+    type: number
+    default: 20
+  - name: num_netpol
+    displayName: Number of Network Policies
+    type: number
+    default: 0
+  - name: num_nodes
+    displayName: Number of nodes
+    type: number
+    default: 1000
+  - name: cleanup
+    displayName: Clean up environment after test
+    type: boolean
+    default: true
+
+variables:
+  - name: azureServiceConnection
+    value: r2d
+
+jobs:
+  - job: scale_test
+    displayName: Scale Test
+    timeoutInMinutes: 360
+    pool:
+      vmImage: ubuntu-latest
+    steps:
+      - checkout: self
+      - task: GoTool@0
+        inputs:
+          version: 'from go.mod'
+      - task: AzureCLI@2
+        displayName: Run Scale Test
+        env:
+          AZURE_RESOURCE_GROUP: ${{ parameters.resource_group }}
+          CLUSTER_NAME: ${{ parameters.cluster_name }}
+          NUM_DEPLOYMENTS: ${{ parameters.num_deployments }}
+          NUM_REPLICAS: ${{ parameters.num_replicas }}
+          NUM_NETPOLS: ${{ parameters.num_netpol }}
+          CLEANUP: ${{ parameters.cleanup }}
+          IMAGE_NAMESPACE: ${{ parameters.image_namespace }}
+          TAG: ${{ parameters.image_tag }}
+          NODES: ${{ parameters.num_nodes }}
+          AZURE_APP_INSIGHTS_KEY: $(AZURE_APP_INSIGHTS_KEY)
+        inputs:
+          azureSubscription: $(azureServiceConnection)
+          scriptType: bash
+          scriptLocation: inlineScript
+          inlineScript: |
+            set -euo pipefail
+            export AZURE_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+            export IMAGE_REGISTRY=$(ACR_NAME)
+            # Trim placeholder whitespace defaults (ADO string params cannot be truly empty).
+            TAG="${TAG// /}"
+            AZURE_RESOURCE_GROUP="${AZURE_RESOURCE_GROUP// /}"
+            CLUSTER_NAME="${CLUSTER_NAME// /}"
+            [[ $TAG == "" ]] && TAG=$(curl -s https://api.github.com/repos/microsoft/retina/commits | jq -r '.[0].sha' | cut -c1-7)
+            # Scheduled runs create infra; manual runs with a provided cluster reuse it.
+            if [[ "$(Build.Reason)" == "Manual" && -n "$CLUSTER_NAME" ]]; then
+              CREATE_INFRA=false
+            else
+              CREATE_INFRA=true
+            fi
+            export TAG AZURE_RESOURCE_GROUP CLUSTER_NAME
+            exec go test -v ./test/e2e/. -timeout 300m -tags=scale -count=1 -args \
+              -create-infra=$CREATE_INFRA \
+              -delete-infra=$CLEANUP

--- a/.azure-pipelines/scale.yml
+++ b/.azure-pipelines/scale.yml
@@ -99,7 +99,9 @@ jobs:
             TAG="${TAG// /}"
             AZURE_RESOURCE_GROUP="${AZURE_RESOURCE_GROUP// /}"
             CLUSTER_NAME="${CLUSTER_NAME// /}"
-            [[ $TAG == "" ]] && TAG=$(curl -s https://api.github.com/repos/microsoft/retina/commits | jq -r '.[0].sha' | cut -c1-7)
+            # Default TAG to the value make version would produce for this commit,
+            # keeping it consistent with the tag used by all image-build targets.
+            [[ -z "$TAG" ]] && TAG="$(make version)"
             # Scheduled runs create infra; manual runs with a provided cluster reuse it.
             if [[ "$(Build.Reason)" == "Manual" && -n "$CLUSTER_NAME" ]]; then
               CREATE_INFRA=false

--- a/.azure-pipelines/steps/free-disk-space.yml
+++ b/.azure-pipelines/steps/free-disk-space.yml
@@ -1,0 +1,31 @@
+# Free ~30-35 GB on Microsoft-hosted Ubuntu agents by removing pre-installed
+# toolchains. Needed for large image builds (retina-agent especially) where
+# the go build cache in /tmp overflows the root partition's ~14 GB free space.
+#
+# Notes on what is / isn't removed:
+#   Removed:      .NET SDK, Android SDK, Haskell (GHC), Boost, PowerShell,
+#                 Swift, node_modules — none of which retina builds use.
+#   Kept:         CodeQL toolcache (used by other pipelines in the repo),
+#                 hostedtoolcache/go (used by GoTool@0 to install Go).
+#   Docker prune: clears any preloaded images / build cache from the agent.
+#
+# Runs on every architecture — even native amd64 image builds need the space
+# once the go build cache grows to include every retina + plugin dependency.
+steps:
+  - bash: |
+      set -e
+      echo "=== Before cleanup ==="
+      df -h /
+      sudo rm -rf \
+        /usr/share/dotnet \
+        /usr/local/lib/android \
+        /opt/ghc \
+        /usr/local/share/boost \
+        /usr/local/share/powershell \
+        /opt/microsoft/powershell \
+        /usr/share/swift \
+        /usr/local/lib/node_modules
+      sudo docker system prune -af --volumes || true
+      echo "=== After cleanup ==="
+      df -h /
+    displayName: Free disk space

--- a/.azure-pipelines/steps/setup-go.yml
+++ b/.azure-pipelines/steps/setup-go.yml
@@ -1,0 +1,15 @@
+# Install the Go version declared in the repo's go.mod.
+# ADO's GoTool@0 does not support "from go.mod" (unlike GitHub Actions'
+# setup-go@v6), so we parse it explicitly and pass the value.
+#
+# Assumes `checkout: self` has already run in the calling job.
+steps:
+  - bash: |
+      set -euo pipefail
+      GO_VER=$(awk '/^go [0-9]/ {print $2; exit}' go.mod)
+      echo "Detected Go version from go.mod: $GO_VER"
+      echo "##vso[task.setvariable variable=GO_VERSION_FROM_GO_MOD]$GO_VER"
+    displayName: Read Go version from go.mod
+  - task: GoTool@0
+    inputs:
+      version: $(GO_VERSION_FROM_GO_MOD)

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,6 +1,10 @@
 # skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.26.3-azurelinux3.0 --format "{{.Name}}@{{.Digest}}"
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.26.4-1-azurelinux3.0@sha256:877a4c2aed044ce1b36c043c1af0c939c3129a7a854453117e5e2b9d574d4b52 AS builder
 
+# systemcrypto without cgo — required for arm64 cross-compile from amd64 host.
+# Becomes redundant with Go 1.27+ (auto-selected when CGO_ENABLED=0).
+ENV GOEXPERIMENT=ms_nocgo_opensslcrypto
+
 ARG VERSION
 ARG APP_INSIGHTS_ID
 ARG AGENT_IMAGE_NAME="ghcr.io/microsoft/retina/retina-agent"
@@ -29,7 +33,10 @@ FROM mcr.microsoft.com/azurelinux/base/core:3.0.20260706@sha256:0cdd0c6a200fc2b5
 
 # Target 1: Distroless (secure, minimal)
 # skopeo inspect docker://mcr.microsoft.com/azurelinux/distroless/minimal:3.0 --format "{{.Name}}@{{.Digest}}"
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/azurelinux/distroless/minimal:3.0.20260706@sha256:576d9769c0146cbf0cf7946bacf536c5758464c29eadfa03ef5090ae708e641f AS distroless-target
+# Final image must be $TARGETPLATFORM (default), not $BUILDPLATFORM — the
+# kubectl-retina binary is cross-compiled for the target arch and would fail
+# to run inside a wrong-arch base image.
+FROM mcr.microsoft.com/azurelinux/distroless/minimal:3.0.20260706@sha256:576d9769c0146cbf0cf7946bacf536c5758464c29eadfa03ef5090ae708e641f AS distroless-target
 COPY --from=libs /lib/ /lib
 COPY --from=libs /usr/lib/ /usr/lib
 COPY --from=libs /etc/pki/tls/ /etc/pki/tls/
@@ -38,7 +45,10 @@ COPY --from=builder /workspace/kubectl-retina .
 
 # Target 2: Shell-enabled (operational, init container support)
 # skopeo inspect docker://mcr.microsoft.com/azurelinux/base/core:3.0 --format "{{.Name}}@{{.Digest}}"
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/azurelinux/base/core:3.0.20260706@sha256:0cdd0c6a200fc2b5d6da711c34228126034bd428650b43dfb7e378214e6f2d32 AS shell-target
+# Final image must be $TARGETPLATFORM (default), not $BUILDPLATFORM — the
+# kubectl-retina binary is cross-compiled for the target arch and would fail
+# to run inside a wrong-arch base image.
+FROM mcr.microsoft.com/azurelinux/base/core:3.0.20260706@sha256:0cdd0c6a200fc2b5d6da711c34228126034bd428650b43dfb7e378214e6f2d32 AS shell-target
 WORKDIR /
 COPY --from=builder /workspace/kubectl-retina /bin/kubectl-retina
 RUN chmod +x /bin/kubectl-retina

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -13,6 +13,10 @@ FROM mcr.microsoft.com/azurelinux/distroless/minimal:3.0.20260706@sha256:576d976
 
 # intermediate go generate stage
 FROM golang AS intermediate 
+# systemcrypto without cgo — required for arm64 cross-compile from amd64 host
+# (Go auto-disables cgo when cross-compiling, and systemcrypto in Go <=1.26
+# requires cgo unless this experiment is set). Becomes redundant with Go 1.27+.
+ENV GOEXPERIMENT=ms_nocgo_opensslcrypto
 ARG APP_INSIGHTS_ID # set to enable AI telemetry
 ARG GOARCH=amd64 # default to amd64
 ARG GOOS=linux # default to linux

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -1,6 +1,10 @@
 # pinned base images
 
 # skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.26.3-azurelinux3.0 --format "{{.Name}}@{{.Digest}}"
+# Pinned to $BUILDPLATFORM so the Go builds cross-compile natively from the
+# host arch (fast). The eBPF .o files, which cannot be cleanly cross-compiled
+# by bpf2go, are produced in the separate `bpf-gen` stage below (which runs
+# at $TARGETPLATFORM — native on same-arch, emulated under QEMU otherwise).
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.26.4-1-azurelinux3.0@sha256:877a4c2aed044ce1b36c043c1af0c939c3129a7a854453117e5e2b9d574d4b52 AS golang
 
 # skopeo inspect docker://mcr.microsoft.com/azurelinux/base/core:3.0 --format "{{.Name}}@{{.Digest}}"
@@ -10,6 +14,30 @@ FROM mcr.microsoft.com/azurelinux/base/core:3.0.20260706@sha256:0cdd0c6a200fc2b5
 FROM mcr.microsoft.com/azurelinux/distroless/minimal:3.0.20260706@sha256:576d9769c0146cbf0cf7946bacf536c5758464c29eadfa03ef5090ae708e641f AS azurelinux-distroless
 
 # build stages
+
+# bpf-gen stage: runs at $TARGETPLATFORM (native for same-arch builds, emulated
+# via QEMU for cross-arch builds). Only responsible for producing correct eBPF
+# .o files via bpf2go/clang — those require native target-arch execution and
+# cannot be cross-compiled from an amd64 host cleanly. Isolating this work in a
+# small dedicated stage keeps the rest of the build fast at $BUILDPLATFORM.
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26.4-1-azurelinux3.0@sha256:877a4c2aed044ce1b36c043c1af0c939c3129a7a854453117e5e2b9d574d4b52 AS bpf-gen
+ARG GOOS=linux
+ARG GOARCH=amd64
+ENV GOOS=${GOOS}
+ENV GOARCH=${GOARCH}
+RUN if [ "$GOOS" = "linux" ] ; then \
+    tdnf install -y clang lld bpftool libbpf-devel; \
+    fi
+COPY ./pkg/plugin /go/src/github.com/microsoft/retina/pkg/plugin
+WORKDIR /go/src/github.com/microsoft/retina
+RUN if [ "$GOOS" = "linux" ] ; then \
+    go mod init github.com/microsoft/retina; \
+    go generate -skip "mockgen" -x /go/src/github.com/microsoft/retina/pkg/plugin/...; \
+    tar czf /gen.tar.gz ./pkg/plugin; \
+    rm go.mod; \
+    else \
+    tar czf /gen.tar.gz --files-from /dev/null; \
+    fi
 
 # intermediate go generate stage
 FROM golang AS intermediate 
@@ -22,17 +50,11 @@ ARG GOARCH=amd64 # default to amd64
 ARG GOOS=linux # default to linux
 ENV GOARCH=${GOARCH}
 ENV GOOS=${GOOS}
-RUN if [ "$GOOS" = "linux" ] ; then \
-    tdnf install -y clang lld bpftool libbpf-devel; \
-    fi
-COPY ./pkg/plugin /go/src/github.com/microsoft/retina/pkg/plugin
 WORKDIR /go/src/github.com/microsoft/retina
-RUN if [ "$GOOS" = "linux" ] ; then \
-    go mod init github.com/microsoft/retina; \
-    go generate -skip "mockgen" -x /go/src/github.com/microsoft/retina/pkg/plugin/...; \
-    tar czf /gen.tar.gz ./pkg/plugin; \
-    rm go.mod; \
-    fi
+# eBPF .o files were built in the bpf-gen stage (at $TARGETPLATFORM). Import
+# the tarball here and extract after `COPY . .` so bpf-gen's outputs replace
+# the zero-byte placeholders checked into the repo.
+COPY --from=bpf-gen /gen.tar.gz /gen.tar.gz
 COPY ./go.mod ./go.sum ./
 RUN go mod download
 COPY . .

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -1,6 +1,10 @@
 # skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.26.3-azurelinux3.0 --format "{{.Name}}@{{.Digest}}"
 FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.26.4-1-azurelinux3.0@sha256:877a4c2aed044ce1b36c043c1af0c939c3129a7a854453117e5e2b9d574d4b52 AS builder
 
+# systemcrypto without cgo — required for arm64 cross-compile from amd64 host.
+# Becomes redundant with Go 1.27+ (auto-selected when CGO_ENABLED=0).
+ENV GOEXPERIMENT=ms_nocgo_opensslcrypto
+
 ARG VERSION
 ARG APP_INSIGHTS_ID
 
@@ -25,7 +29,10 @@ RUN --mount=type=cache,target="/root/.cache/go-build" \
 
 ##################### controller #######################
 # skopeo inspect docker://mcr.microsoft.com/azurelinux/distroless/minimal:3.0 --format "{{.Name}}@{{.Digest}}"
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/azurelinux/distroless/minimal:3.0.20260706@sha256:576d9769c0146cbf0cf7946bacf536c5758464c29eadfa03ef5090ae708e641f
+# Final image must be $TARGETPLATFORM (default), not $BUILDPLATFORM — the
+# retina-operator binary is cross-compiled for the target arch and would fail
+# to run inside a wrong-arch base image.
+FROM mcr.microsoft.com/azurelinux/distroless/minimal:3.0.20260706@sha256:576d9769c0146cbf0cf7946bacf536c5758464c29eadfa03ef5090ae708e641f
 WORKDIR /
 COPY --from=builder /lib /lib
 COPY --from=builder /usr/lib/ /usr/lib

--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -20,7 +20,11 @@ ENV GOOS=${GOOS}
 ARG GOARCH=amd64
 ENV GOARCH=${GOARCH}
 
-RUN make manifests
+# make manifests runs controller-gen, a build-time host tool that must be
+# compiled for and executed on the build host, not the target arch. Unset the
+# cross-compile env for this step so `go tool` doesn't produce an arm64 binary
+# and then fail to exec it on the amd64 builder.
+RUN env -u GOOS -u GOARCH make manifests
 RUN --mount=type=cache,target="/root/.cache/go-build" \
 	GOOS=$GOOS GOARCH=$GOARCH go build \
 	-ldflags "-X github.com/microsoft/retina/internal/buildinfo.Version="$VERSION" \


### PR DESCRIPTION
# Description

This PR migrates all GH workflows using FIC to Azure Pipelines due to internal policy changes regarding FIC in GH.
It adds 3 pipelines under `.azure-pipelines` that mirrors today's GH workflows:

| ADO Pipeline | Mirrors |
| :--- | :--- |
| `ci.yml` | `images.yaml` (build + manifests + e2e + perf-basics + perf-advanced on merge-queue) |
| `scale.yml` | `daily-scale-test.yaml` + `scale-test.yaml` (daily cron + manual) | 
| `perf.yml` | `perf-schedule.yaml` + `perf-manual.yaml` + `perf-template.yaml` (twice-daily cron + manual) |

Bash bodies inside each `AzureCLI@2` task are copied verbatim from the existing GH workflows. Only the outer scaffolding is rewritten to ADO YAML schema (different from GH Actions YAML)

Also added:
- `setup-go.yml`: parses the Go version from `go.mod` (ADO's `GoTool@0` doesn't natively support `from go.mod` like GH's `setup-go@v6`).
- `free-disk-space.yml`: reclaims ~30GB of pre-installed toolchains on agents (needed to avoid lack of space for large image builds).

> Nothing in `workflows` is deleted or disabled by this PR. Both pipelines are available to run in parallel at this stage. A new PR will be raised to remove old workflows.

### What this PR does NOT do (deferred to a follow-up PR)
- Branch protection changes. Required checks still point at the GH workflows. Once ADO pipelines are validated, a subsequent admin action + PR will:
  - Add workflows to required status checks.
  - Remove the corresponding GH Actions checks.
  - Delete the FIC-using workflow files: `images.yaml`, `e2e.yaml`, `perf-template.yaml`, `scale-test.yaml`, `daily-scale-test.yaml`, `perf-manual.yaml`, `perf-schedule.yaml`.
- Secret / var cleanup.

### Behavior parity with today's GH workflows

The ADO pipelines match today's semantics exactly on all these axes:

- Triggers. `ci.yml` fires on merge-queue pushes (`gh-readonly-queue/main/*`) and PRs targeting main. Scale/perf fire on their existing crons.
- Merge-queue gating. ACR push, APP_INSIGHTS_ID embedding, and the manifests/e2e/perf jobs only run when isMergeGroup=True (mirrors GH's if: ${{ github.event_name == 'merge_group' }} gate). PR builds and manual queues run as dry-run.
- Fork PRs. The three pipelines are configured with "Disable building pull requests from forked GitHub repositories" — same fork-safety posture as today's FIC-gated jobs (which never ran on fork PRs).
- Image tag. Both build and consumer use $(make version). The migration proactively fixed a latent tag-mismatch bug (see below).

### Required side-effect changes to retina source

Because ADO doesn't have ARM64 agents, arm64 image builds have to cross-compile from amd64 hosts. Retina's Dockerfiles have latent bugs / assumptions that only surface on cross-compile (native ARM64 CI on GH has always masked them since PR #2059 introduced systemcrypto/CGO). This PR includes minimal fixes:

| Change | Reason |
| :--- | :--- | 
| `operator/Dockerfile`, `cli/Dockerfile`: dropped `--platform=$BUILDPLATFORM` from final image stages | Otherwise arm64-built binaries got copied into amd64 base images (wrong arch → exec format error). | 
| `operator/Dockerfile`, `cli/Dockerfile`, `controller/Dockerfile`: added `ENV GOEXPERIMENT=ms_nocgo_opensslcrypto` in builder stages | Microsoft Go's default `systemcrypto` requires `CGO_ENABLED=1`, but Go auto-disables CGO when cross-compiling. This experiment (documented in Microsoft Go MigrationGuide) enables the cgo-less OpenSSL backend so systemcrypto works with `CGO_ENABLED=0`. Auto-selected in Go 1.27+; env var can be removed then. | 
| `operator/Dockerfile`: `RUN make manifests` wrapped in `env -u GOOS -u GOARCH` | `make manifests` shells out to `controller-gen` — a build-time host tool, not the target binary. Without unset, it cross-compiled to arm64 and failed to `exec` on the amd64 builder. | 
| `controller/Dockerfile`: split intermediate into two stages — new `bpf-gen` at `$TARGETPLATFORM`, existing intermediate stays at `$BUILDPLATFORM` | Retina's `//go:generate bpf2go -target ${GOARCH}` directives require target-arch execution (bpf2go invokes clang; can't cleanly cross-compile bpf2go itself). Split isolates that one requirement to a small emulated stage while keeping the Go build fast at $BUILDPLATFORM. Restores fast arm64 build without breaking bpf .o file generation. |

> Impact on amd64 builds: zero — all these changes are inert when host == target (CGO stays enabled, no cross-compile, bpf-gen runs natively).

### Tag consistency fix
The migration surfaced a pre-existing latent bug: `make retina-image` / `make manifest` didn't have `TAG` set by CI, so the Makefile fell back to `git describe --tags --always` (produces `v1.2.2-76-geade8685`), while all consumers (`e2e`, `perf-*`, `scale`) used make version (produces the 7-char SHA). Images were pushed under one tag, consumers looked for another. GH masked it because actions/checkout defaults to shallow (no tags, so git describe also falls back to short SHA); ADO defaults to full-clone.

ADO pipelines now pass `TAG=$(make version)` explicitly to every `make` invocation, ensuring builder and consumer speak the same tag string on both platforms. 

### Temporary items in this PR (will be reverted after cutover)

- `forceMergeGroup` pipeline parameter in `ci.yml`. Boolean checkbox in the "Run pipeline" UI that treats a manual queue as if it were a merge-queue event (push + telemetry + full test suite). Default `false`, safe. Used during dark-launch to validate the full flow without needing an actual merge-queue event. Revert once we've moved past validation.

### Verification
- manual run of pipelines completed successfully

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
