### PR TITLE
fix(helm): add missing hubble metrics port to retina agent daemonset

### DIFF
--- a/deploy/hubble/manifests/controller/helm/retina/templates/agent/daemonset.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/agent/daemonset.yaml
@@ -81,6 +81,11 @@ spec:
           {{- end}}
           ports:
           - containerPort: {{ .Values.agent.container.retina.ports.containerPort }}
+            name: retina
+            protocol: TCP
+          - containerPort: {{ .Values.hubble.metrics.port }}
+            name: hubble
+            protocol: TCP
           resources:
             requests:
               memory: {{ .Values.resources.requests.memory | quote }}
@@ -227,6 +232,11 @@ spec:
           image: {{ .Values.agent.repository }}:{{ .Values.agent.tag }}
           ports:
             - containerPort: {{ .Values.agent.container.retina.ports.containerPort }}
+              name: retina
+              protocol: TCP
+            - containerPort: {{ .Values.hubble.metrics.port }}
+              name: hubble
+              protocol: TCP
           command:
             - powershell.exe
             - -command

--- a/deploy/hubble/manifests/controller/helm/retina/templates/hubble/metrics-service.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/hubble/metrics-service.yaml
@@ -30,7 +30,7 @@ spec:
   - name: retina
     port: {{ .Values.retinaPort }}
     protocol: TCP
-    targetPort: {{ .Values.retinaPort }}
+    targetPort: {{ .Values.agent.container.retina.ports.containerPort }}
   selector:
     k8s-app: retina
 {{- end }}


### PR DESCRIPTION
## Description

Fix Prometheus metric scraping for Hubble metrics by adding the missing hubble metrics port to the Retina agent DaemonSet.

### Problem

The `network-observability` Service (`templates/hubble/metrics-service.yaml`) was configured with two ports:
- `hubble` port (default 9965) — for Hubble metrics
- `retina` port (default 10093) — for Retina metrics

However, the Retina agent DaemonSet (`templates/agent/daemonset.yaml`) only exposed a single port (10093). The Hubble metrics server, configured via ConfigMap to listen on port 9965 (`hubble-metrics-server: ":9965"`), had no corresponding `containerPort` declared in the pod spec. This caused Prometheus scrapes to Hubble metrics to fail.

Additionally, the `targetPort` for the retina port in the Service used `{{ .Values.retinaPort }}` instead of `{{ .Values.agent.container.retina.ports.containerPort }}`, which could cause inconsistency if these values diverge.

### Changes

- **`templates/agent/daemonset.yaml`** (Linux & Windows): Added the hubble metrics port (`{{ .Values.hubble.metrics.port }}`) to the container ports list
- **`templates/hubble/metrics-service.yaml`**: Fixed `targetPort` for the retina port to use `{{ .Values.agent.container.retina.ports.containerPort }}`

### Port Mapping

| Component | Port Name | Port Value | Purpose |
|-----------|-----------|------------|---------|
| DaemonSet (Linux/Windows) | `retina` | `{{ .Values.agent.container.retina.ports.containerPort }}` (default: 10093) | Retina metrics endpoint |
| DaemonSet (Linux/Windows) | `hubble` | `{{ .Values.hubble.metrics.port }}` (default: 9965) | Hubble metrics endpoint |
| Service | `retina` | `{{ .Values.retinaPort }}` → targets `retina` container port | Route to Retina metrics |
| Service | `hubble` | `{{ .Values.hubble.metrics.port }}` → targets `hubble` container port | Route to Hubble metrics |