### PR TITLE
deps: group lockstep dependency families in dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -44,7 +44,10 @@ updates:
     cooldown:
       default-days: 3
     groups:
+      codeql-action:
+        patterns: ["github/codeql-action*"]
       actions-patch:
+        exclude-patterns: ["github/codeql-action*"]
         update-types: ["patch"]
 
   # npm (Docusaurus site)
@@ -82,13 +85,21 @@ updates:
     cooldown:
       default-days: 7
       semver-major-days: 30
+    ignore:
+      # hive/statedb/stream versions are pinned by cilium/cilium's go.mod;
+      # they can only move when cilium/cilium moves.
+      - dependency-name: "github.com/cilium/hive"
+      - dependency-name: "github.com/cilium/statedb"
+      - dependency-name: "github.com/cilium/stream"
     groups:
       k8s:
         patterns:
           - "k8s.io/*"
           - "sigs.k8s.io/*"
+          - "helm.sh/helm/v3"
+          - "sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader"
         exclude-patterns:
-          - "sigs.k8s.io/cloud-provider-azure/*"
+          - "sigs.k8s.io/cloud-provider-azure/pkg/azclient"
         update-types: ["patch", "minor"]
       cilium:
         patterns:
@@ -106,4 +117,4 @@ updates:
       otel:
         patterns:
           - "go.opentelemetry.io/*"
-        update-types: ["patch"]
+        update-types: ["patch", "minor"]


### PR DESCRIPTION
# Description

Dependabot splits three dependency families that must move together, so each PR is unmergeable on its own.

**codeql-action** — `codeql.yaml` pins `init`, `autobuild` and `analyze` to one SHA, and CodeQL rejects mixed versions. `actions-patch` covers `patch` only, so minor bumps get one PR per sub-action and every `Analyze` job fails:

```
##[error]Loaded a configuration file for version '4.36.3', but running version '4.37.2'
```

That is #2573, #2574 and #2575.

**k8s** — `helm.sh/helm/v3` is in no group but pins `k8s.io/client-go` transitively (`v3.21.3` needs `v0.36.2`, `controller-runtime v0.23.3` needs `v0.35.0`). Bumping helm alone fails on `handlerRegistration does not implement cache.ResourceEventHandlerRegistration (missing method HasSyncedChecker)`, so #2544 and #2324 are two halves of one change.

**cilium** — `cilium/cilium v1.19.3` pins `hive`, `statedb` and `stream` to exactly retina's versions; moving them alone breaks cilium's own source (#2543, #2520).

## Changes

- **codeql-action**: group over `github/codeql-action*`, covering all four sub-actions in `codeql.yaml` and `trivy.yaml`. `actions-patch` gets a matching `exclude-patterns`: with no `patterns` of its own it scores 500 against the new group's 106, so it would otherwise claim these and then drop them for not being `patch`.
- **k8s**: adds `helm.sh/helm/v3` and the exact path `sigs.k8s.io/cloud-provider-azure/pkg/azclient/configloader`, which pins client-go the same way. An exact path scores 1000, outranking `azure-sdk`. The exclusion narrows to `pkg/azclient`, which has no client-go dependency.
- **cilium**: ignore `hive`, `statedb` and `stream`. MVS still raises them when `cilium/cilium` moves.
- **otel**: widened to `minor`; `1.43.0` → `1.44.0` arrived as three PRs (#2408, #2409, #2410).

## Related Issue

N/A.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Local run against the real updater image: `main` produces three ungrouped codeql PRs, this config produces one holding all four. Dropping `exclude-patterns` reproduces `main` exactly.

Hosted Dependabot on a fork:

| PR | Contents |
|---|---|
| codeql-action, 4 updates | all four sub-actions on one SHA, `v4.37.3` |
| k8s, 7 updates | helm `3.21.1` → `3.21.3`, controller-runtime `0.23.3` → `0.24.1`, `k8s.io/*` → `0.36.2` |
| cilium, 4 updates | `cilium/cilium` `v1.19.3` → `v1.19.6` with `ebpf v0.22.0` and `statedb v0.5.9`, as `v1.19.6` requires |

Schema-validates against `dependabot-2.0.json` with no new errors versus `main`.

## Additional Notes

`configloader` stays put until the k8s group lands: its bump raises `k8s.io/api` to `0.36.x` while `kubectl` stays at `0.35.3`, whose `pkg/scheme` imports `k8s.io/api/scheduling/v1alpha1`, removed in `0.36`. `go mod tidy` fails with it alone and passes with the full set, so no extra config is needed.

Once this lands, #2573, #2574, #2575, #2544, #2324, #2543 and #2520 can be closed.
