### PR TITLE
feat(chart): make retina-operator resources configurable

### DIFF
--- a/deploy/hubble/manifests/controller/helm/retina/templates/operator/deployment.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/operator/deployment.yaml
@@ -99,12 +99,7 @@ spec:
           #   initialDelaySeconds: 5
           #   periodSeconds: 10
           resources:
-            limits:
-              cpu: 500m
-              memory: 500Mi
-            requests:
-              cpu: 250m
-              memory: 250Mi
+            {{- toYaml .Values.operator.resources | nindent 12 }}
       serviceAccountName: retina-operator
       {{- if .Values.operator.priorityClassName }}
       priorityClassName: {{ .Values.operator.priorityClassName }}

--- a/deploy/hubble/manifests/controller/helm/retina/values.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/values.yaml
@@ -36,6 +36,14 @@ operator:
   # Namespace used for operator leader election lease.
   # Defaults to .Release.Namespace when empty.
   leaderElectionNamespace: ""
+  # -- Resource requests and limits for the retina-operator container.
+  resources:
+    limits:
+      cpu: 500m
+      memory: 500Mi
+    requests:
+      cpu: 250m
+      memory: 250Mi
 
 agent:
   leaderElection: false


### PR DESCRIPTION
# Motivation
The retina-operator container's resources are hardcoded in the deployment template, so they can't be tuned without patching the rendered manifest — while the agent, relay and ui all expose `resources` in values. This adds `operator.resources`, defaulted to the current values, so rendered output is unchanged.