### PR TITLE
feat(chart): make retina-operator securityContext configurable

### DIFF
--- a/deploy/hubble/manifests/controller/helm/retina/templates/operator/deployment.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/templates/operator/deployment.yaml
@@ -45,8 +45,7 @@ spec:
       tolerations: {{- toYaml .Values.operator.tolerations | nindent 8 }}
       {{- end }}
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
+        {{- toYaml .Values.operator.podSecurityContext | nindent 8 }}
       containers:
         - image: {{ .Values.operator.repository }}:{{ .Values.operator.tag }}
           imagePullPolicy: {{ .Values.operator.pullPolicy }}
@@ -82,10 +81,7 @@ spec:
             - name: retina-operator-config
               mountPath: /retina/
           securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              drop:
-                - "ALL"
+            {{- toYaml .Values.operator.securityContext | nindent 12 }}
           # livenessProbe:
           #   httpGet:
           #     path: /healthz

--- a/deploy/hubble/manifests/controller/helm/retina/values.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/values.yaml
@@ -36,6 +36,16 @@ operator:
   # Namespace used for operator leader election lease.
   # Defaults to .Release.Namespace when empty.
   leaderElectionNamespace: ""
+  # -- retina-operator pod-level security context.
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+  # -- retina-operator container-level security context.
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
 
 agent:
   leaderElection: false

--- a/deploy/hubble/manifests/controller/helm/retina/values.yaml
+++ b/deploy/hubble/manifests/controller/helm/retina/values.yaml
@@ -44,6 +44,16 @@ operator:
     requests:
       cpu: 250m
       memory: 250Mi
+  # -- retina-operator pod-level security context.
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+  # -- retina-operator container-level security context.
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
 
 agent:
   leaderElection: false


### PR DESCRIPTION
# Motivation
The retina-operator pod and container securityContext are hardcoded, so hardening fields (e.g. `readOnlyRootFilesystem`, `seccompProfile`) can't be set without patching the rendered manifest. This exposes `operator.podSecurityContext` and `operator.securityContext`, defaulted to the current values, so rendered output is unchanged.