### PR TITLE
docs: add `zone` label documentation

### DIFF
--- a/docs/03-Metrics/modes/advanced.md
+++ b/docs/03-Metrics/modes/advanced.md
@@ -35,6 +35,8 @@ For Advanced mode with *remote context*, default context labels are the followin
 - `destination_pod`
 - `destination_workload`
 
+Additionally, `source_zone` and `destination_zone` can be enabled by adding `zone` to `sourceLabels` and/or `destinationLabels` in the [MetricsConfiguration CRD](../../05-Concepts/CRDs/MetricsConfiguration.md). The value is read from the node's [`topology.kubernetes.io/zone`](https://kubernetes.io/docs/reference/labels-annotations-taints/#topologykubernetesiozone) label; flows whose zone cannot be resolved are labelled `unknown`.
+
 ### Local Context
 
 For Advanced mode with *local context*, default context labels are the following for *outgoing* traffic:

--- a/docs/05-Concepts/CRDs/MetricsConfiguration.md
+++ b/docs/05-Concepts/CRDs/MetricsConfiguration.md
@@ -21,10 +21,12 @@ The `MetricsConfiguration` CRD is defined with the following specifications:
 
 - **spec.contextOptions:** Specifies the configuration for retina plugin metrics context. It includes the following properties:
   - `additionalLabels`: Represents additional context labels to be collected, such as Direction (ingress/egress).
-  - `destinationLabels`: Represents the destination context labels, such as IP, Pod, port, workload (deployment/replicaset/statefulset/daemonset).
+  - `destinationLabels`: Represents the destination context labels, such as IP, Pod, port, workload (deployment/replicaset/statefulset/daemonset), and `zone`.
   - `metricName`: Indicates the name of the metric.
-  - `sourceLabels`: Represents the source context labels, such as IP, Pod, port.
+  - `sourceLabels`: Represents the source context labels, such as IP, Pod, port, and `zone`.
   - `ttl`: Represents the time-to-live for the metric.  If there are no metric updates for a particular set of context labels for this duration the metric will be removed from export.  The value of `ttl` must be a valid Golang `time.Duration` string and non-negative.  A zero `ttl` (the default) means that metrics are never removed from export.
+
+  When `zone` is included in `sourceLabels` or `destinationLabels`, Retina emits `source_zone` / `destination_zone` labels populated from the node's [`topology.kubernetes.io/zone`](https://kubernetes.io/docs/reference/labels-annotations-taints/#topologykubernetesiozone) label. Flows whose zone cannot be resolved are labelled `unknown`.
 
 - **spec.namespaces:** Specifies the namespaces to include or exclude in metric collection. It includes the following properties:
   - `exclude`: Specifies namespaces to be excluded from metric collection.


### PR DESCRIPTION
# Description

Adds documentation for the availability-zone label support introduced in #1657. Two docs are updated:

- `docs/03-Metrics/modes/advanced.md`: documents that `source_zone` / `destination_zone` labels can be enabled in remote context by adding `zone` to `sourceLabels` and/or `destinationLabels`, that the value comes from the node's `topology.kubernetes.io/zone` label, and that unresolvable zones are labelled `unknown`.
- `docs/05-Concepts/CRDs/MetricsConfiguration.md`: notes `zone` as a valid `sourceLabels`/`destinationLabels` option and explains the emitted label names and `unknown` fallback.

This is a documentation-only change; no code is modified.

## Related Issue

Documents the feature added in #1657.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Documentation-only change. n/a

## Additional Notes

n/a