### PR TITLE
deps: update nanoid to v3.3.18

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -14310,9 +14310,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

Update the transitive documentation-site dependency `nanoid` from 3.3.16 to 3.3.18 in `site/package-lock.json`.

PostCSS declares `nanoid ^3.3.16`, so this is a compatible lockfile-only patch update. Retina does not import nanoid directly, and the package is used only by the Docusaurus/PostCSS build toolchain. It is not included in Retina container images or generated static-site runtime assets.

This update addresses:

| Advisory | Severity | Before | After |
| --- | --- | --- | --- |
| CVE-2026-67213 / GHSA-2v37-7h3g-55p8 | High | nanoid 3.3.16 | nanoid 3.3.18 |

The advisory can cause `customAlphabet` or `customRandom` to loop indefinitely when configured with a size of zero.

CVE-2026-67214 does not affect this change: its nanoid 3.x range is fixed in 3.3.16, so it was already resolved before this update.

## Vulnerability validation

Scanned the site lockfile before and after the update with Trivy 0.69.3:

```bash
trivy fs --ignore-unfixed --scanners vuln --skip-dirs artifacts site
```

Before:

```text
package-lock.json  CVE-2026-67213  nanoid  3.3.16  3.3.17, 5.1.6  HIGH
```

After:

```text
nanoid findings: 0
```

`npm audit` also no longer reports nanoid. Its total high-severity dependency nodes decrease from 20 to 19. The remaining findings are the separately tracked Docusaurus `image-size` advisory chain, for which no patched npm release is currently available.

## Validation

```bash
cd site
npm ci
npm ls nanoid postcss --all
npm run build
npm audit
```

The installed dependency chain resolves to PostCSS 8.5.23 and nanoid 3.3.18, and the optimized Docusaurus production build completes successfully.


## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
