### PR TITLE
fix(ci): split trivy SARIF categories by scan target

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -51,3 +51,8 @@ jobs:
         uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           sarif_file: "trivy-results.sarif"
+          # Scheduled/manual runs scan the latest release image; workflow_run
+          # runs scan the per-commit image just pushed by release-images.
+          # Separate SARIF categories keep the two artifacts' alerts from
+          # closing and reopening each other on every upload.
+          category: "image:${{ matrix.image }}/${{ github.event_name == 'workflow_run' && 'main' || 'release' }}"


### PR DESCRIPTION
# Description

The trivy workflow scans two different artifacts into the same SARIF category per image. Scheduled and manual runs scan the latest release image (~77 CRITICAL/HIGH findings). `workflow_run` runs fire after every push to `main` and scan the per-commit image just rebuilt from current Azure Linux packages (0–5 findings).

Code scanning derives alert state from the newest analysis in a category. Each merge closes the release image's alerts as fixed, and each scheduled scan reopens them. The result is Trivy alerts that flip between fixed and open with no repo change behind either transition.

This PR appends the scan target to the upload category — `image:<name>/release` or `image:<name>/main` — so each artifact's alerts track independently.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`).
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.
