### PR TITLE
fix(ci): move ADO pipelines to the Build Validations service connection

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -17,7 +17,7 @@
 #     AZURE_AGENT_LINUX_ARM_SKU
 #   Variables (secret):
 #     AZURE_APP_INSIGHTS_KEY
-#   Service connection (Azure RM, WIF): r2d
+#   Service connection (Azure RM, WIF): Azure Container Networking - Build Validations - Federated
 #   Settings: "Limit building pull requests from forked GitHub repositories" = Disable
 
 trigger:
@@ -42,7 +42,7 @@ parameters:
 
 variables:
   - name: azureServiceConnection
-    value: r2d
+    value: Azure Container Networking - Build Validations - Federated
   - name: imageNamespace
     value: microsoft/retina
   # True only when the build was triggered by a push to a merge-queue temp branch,

--- a/.azure-pipelines/perf.yml
+++ b/.azure-pipelines/perf.yml
@@ -12,7 +12,7 @@
 #     AZURE_AGENT_LINUX_ARM_SKU
 #   Variables (secret):
 #     AZURE_APP_INSIGHTS_KEY
-#   Service connection (Azure RM, WIF): r2d
+#   Service connection (Azure RM, WIF): Azure Container Networking - Build Validations - Federated
 #   Settings: "Limit building pull requests from forked GitHub repositories" = Disable
 
 trigger: none
@@ -48,7 +48,7 @@ parameters:
 
 variables:
   - name: azureServiceConnection
-    value: r2d
+    value: Azure Container Networking - Build Validations - Federated
 
 jobs:
   - ${{ each mode in parameters.modes }}:

--- a/.azure-pipelines/scale.yml
+++ b/.azure-pipelines/scale.yml
@@ -8,7 +8,7 @@
 #     ACR_NAME
 #   Variables (secret):
 #     AZURE_APP_INSIGHTS_KEY
-#   Service connection (Azure RM, WIF): r2d
+#   Service connection (Azure RM, WIF): Azure Container Networking - Build Validations - Federated
 #   Settings: "Limit building pull requests from forked GitHub repositories" = Disable
 
 trigger: none
@@ -63,7 +63,7 @@ parameters:
 
 variables:
   - name: azureServiceConnection
-    value: r2d
+    value: Azure Container Networking - Build Validations - Federated
 
 jobs:
   - job: scale_test


### PR DESCRIPTION
# Description

ADO CI, perf, and scale runs fail with `ResourceGroupQuotaExceeded` when their subscription cannot fit new resource groups. This PR switches `azureServiceConnection` in the three ADO pipelines to the `Azure Container Networking - Build Validations - Federated` connection, which targets the same subscription the GitHub workflows already use for e2e and perf. The pipeline run on this PR validates the connection end to end before merge.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`).
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.
