### PR TITLE
deps: reduce docker cooldown to 2 days

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -18,8 +18,11 @@ updates:
       prefix: "deps"
     labels: ["area/infra", "area/dependencies"]
     open-pull-requests-limit: 10
+    # MCR rebuilds these base images to ship CVE fixes, so a long window
+    # delays the patches. A tag that is rebuilt more often than the window
+    # never becomes eligible.
     cooldown:
-      default-days: 7
+      default-days: 2
     groups:
       golang-base:
         patterns: ["*golang*"]


### PR DESCRIPTION
# Description

MCR rebuilds the base images to ship CVE fixes, so the cooldown delays the patches this repo needs. Nothing bypasses it. Dependabot does not scan image contents, so base image CVEs never raise a dependabot security alert. govulncheck and Trivy report them instead.

The delay is measurable:

- The libarchive fix shipped on 11 August. Dependabot proposed it on 18 August (#2664).
- `golang:1.26.6-azurelinux3.0` landed on 14 August and is still unproposed. The 7 error-severity stdlib findings stay open until it lands.

A long window also starves a frequently rebuilt tag. MCR re-pushed `1.26.6` on 17 August, which reset the window to 24 August.

Two days still covers a same-day bad push. The groups, the weekly interval, and the full image build on every PR already limit the risk. `gomod` and `npm` keep 7 days.

## Related Issue

N/A.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally. (N/A — dependabot runs server-side.)
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

N/A.

## Additional Notes

N/A.
