### PR TITLE
deps: build pwru from source with the repo Go builder

### DIFF
--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -1,3 +1,28 @@
+# pwru is built from a pinned source commit with this repo's Go builder, so
+# its standard library tracks the golang base image instead of the upstream
+# release cadence. Upstream publishes binaries only on tags.
+# skopeo inspect docker://mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0 --format "{{.Name}}@{{.Digest}}"
+FROM mcr.microsoft.com/oss/go/microsoft/golang:1.26-azurelinux3.0@sha256:3960d75b1ddd28b4e5cffaa13f3ec0c95df95a3be84f67994ace5dc18110f563 AS pwru-build
+RUN tdnf install -y make git clang llvm gcc glibc-static gawk file flex bison tar diffutils
+# https://github.com/cilium/pwru/releases/tag/v1.0.12
+ARG PWRU_COMMIT=f1d6cf8898953ac1560401e181f3ac5f0e33b486
+RUN git clone https://github.com/cilium/pwru /pwru && git -C /pwru checkout "$PWRU_COMMIT"
+WORKDIR /pwru
+ARG GOARCH=amd64
+RUN set -eux; \
+    case "$GOARCH" in \
+        amd64) LIBPCAP_ARCH="x86_64-unknown-linux-gnu" ;; \
+        arm64) LIBPCAP_ARCH="aarch64-unknown-linux-gnu" ;; \
+        *) echo "Unsupported arch: $GOARCH" && exit 1 ;; \
+    esac; \
+    # GOEXPERIMENT=none disables the Microsoft Go OpenSSL crypto backend,
+    # which dlopens libcrypto at startup and crashes inside a statically
+    # linked binary. pwru does not need FIPS crypto.
+    GOEXPERIMENT=none make TARGET_GOARCH="$GOARCH" LIBPCAP_ARCH="$LIBPCAP_ARCH"; \
+    file pwru | grep -q 'ELF'; \
+    # the binary must start; a broken crypto backend or link crashes here
+    ./pwru --version
+
 # skopeo inspect docker://mcr.microsoft.com/azurelinux/base/core:3.0 --format "{{.Name}}@{{.Digest}}"
 FROM mcr.microsoft.com/azurelinux/base/core:3.0.20260809@sha256:8bb51342bd5eba915990ab608f91060d502bb7891a2d3d909e0419b932533029
 
@@ -52,26 +77,7 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 # Set the entrypoint
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
-# Re-use existing arg from Makefile target "container-docker"
-# https://github.com/microsoft/retina/blob/main/Makefile#L224
-ARG GOARCH=amd64
-ENV ARCH=${GOARCH}
-# https://github.com/cilium/pwru/releases
-ARG PWRU_TAG="v1.0.12"
-ENV PWRU_TAG=${PWRU_TAG}
-
-# Download and extract latest pwru release for the correct architecture (amd64 or arm64)
-RUN set -eux; \
-    case "$ARCH" in \
-        amd64|x86_64) PWRU_ARCH="amd64" ;; \
-        arm64|aarch64) PWRU_ARCH="arm64" ;; \
-        *) echo "Unsupported arch: $ARCH" && exit 1 ;; \
-    esac; \
-    PWRU_TAR="pwru-linux-${PWRU_ARCH}.tar.gz"; \
-    curl -fL -o /tmp/pwru.tar.gz "https://github.com/cilium/pwru/releases/download/${PWRU_TAG}/${PWRU_TAR}"; \
-    tar -xz -C /usr/local/bin -f /tmp/pwru.tar.gz pwru; \
-    chmod +x /usr/local/bin/pwru; \
-    rm /tmp/pwru.tar.gz; \
-    file /usr/local/bin/pwru | grep -q 'ELF'
+COPY --from=pwru-build /pwru/pwru /usr/local/bin/pwru
+RUN file /usr/local/bin/pwru | grep -q 'ELF' && /usr/local/bin/pwru --version
 
 CMD ["/bin/bash", "-l"]


### PR DESCRIPTION
# Description

The shell image downloads the pwru release binary. Upstream builds each release with a pinned Go image. `v1.0.12` carries Go 1.26.5, which 8 stdlib advisories affect. Upstream publishes binaries only on tags, and `main` already builds with Go 1.27.0, so the fix waits on their release cadence.

This PR builds pwru from source with this repo's golang base image:

- **Toolchain**: the binary's standard library now tracks the golang base image. A dependabot digest bump patches pwru with every other shipped binary.
- **Pin**: the `PWRU_COMMIT` build-arg pins the source to the `v1.0.12` commit (`f1d6cf88`). Same pwru version as today, current toolchain.
- **Build**: follows the upstream Makefile — vendored static libpcap (`gcc`, `gawk`, `flex`, `bison`), bpf2go generation (`clang`, `llvm`), and a statically linked CGO binary (`glibc-static`).
- **`GOEXPERIMENT=none`**: the Microsoft Go toolchain enables its OpenSSL crypto backend by default. The backend dlopens libcrypto at startup, which crashes a statically linked binary with `SIGFPE`. pwru does not need FIPS crypto, so the build disables the backend.
- **Startup check**: both stages run `pwru --version`. If the binary cannot start, the image build fails.

The build stage runs at the target platform. The arm64 image jobs run on native arm64 runners.

## Related Issue

N/A — clears the 8 Trivy stdlib findings on `retina-shell`, the last third-party item from the code-scanning cleanup.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Built the shell image locally for `linux/amd64`. The build log shows `pwru v1.0.12` from both startup checks. The binary in the image:

```
$ docker run --rm --entrypoint /usr/local/bin/pwru <image> --version
pwru v1.0.12
$ go version -m pwru
go1.26.7 (microsoft_toolset_version=go1.26.7-1-microsoft)
mod github.com/cilium/pwru v1.0.12
```

CI builds both architectures on this PR.

## Additional Notes

N/A.
