### PR TITLE
fix(build): register current QEMU and compile pwru with clang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ RETINA_PLATFORM_TAG        = $(TAG)-windows-ltsc$(YEAR)-amd64
 endif
 
 qemu-user-static: ## Set up the host to run qemu multiplatform container builds.
-	sudo $(CONTAINER_RUNTIME) run --rm --privileged multiarch/qemu-user-static --reset -p yes
+	sudo $(CONTAINER_RUNTIME) run --rm --privileged tonistiigi/binfmt --install arm64
 
 .PHONY: version
 version: ## prints the root version

--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -18,7 +18,9 @@ RUN set -eux; \
     # GOEXPERIMENT=none disables the Microsoft Go OpenSSL crypto backend,
     # which dlopens libcrypto at startup and crashes inside a statically
     # linked binary. pwru does not need FIPS crypto.
-    GOEXPERIMENT=none make TARGET_GOARCH="$GOARCH" LIBPCAP_ARCH="$LIBPCAP_ARCH"; \
+    # CC=clang: the ADO pipeline builds arm64 under QEMU, and gcc cc1
+    # crashes there with an internal compiler error. clang does not.
+    GOEXPERIMENT=none CC=clang make TARGET_GOARCH="$GOARCH" LIBPCAP_ARCH="$LIBPCAP_ARCH"; \
     file pwru | grep -q 'ELF'; \
     # the binary must start; a broken crypto backend or link crashes here
     ./pwru --version


### PR DESCRIPTION
# Description

The ADO pipeline builds the arm64 shell image on amd64 agents under QEMU. The pwru source build (#2675) runs real compilers inside that stage, and modern aarch64 binaries crash under the old QEMU: gcc `cc1` died with an internal compiler error, and gawk segfaulted inside the libpcap configure. Every merge-queue `CI (Build Images)` run failed at `Build Retina Shell Images arm64`.

Two changes:

- **Current QEMU**: the `qemu-user-static` make target registered `multiarch/qemu-user-static`, which ships a QEMU from 2022. It now registers `tonistiigi/binfmt`, which ships a current QEMU. `docker/setup-qemu-action` uses the same image, so the GitHub Actions builds never saw these crashes.
- **clang**: the pwru build compiles with clang. clang builds the same static binary under QEMU, and one compiler serves both architectures.

The org's hosted ADO pool offers no arm64 images, and the OneBranch arm64 pool rejects pipelines that do not extend the OneBranch governed template. Native ADO arm64 therefore needs a OneBranch migration, which stays out of scope.

## Related Issue

N/A.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

- Local QEMU emulation with current QEMU (`tonistiigi/binfmt`): the arm64 stage builds, and the startup check prints `pwru v1.0.12` from the emulated binary. The extracted binary is a static ELF with `go1.26.7`.
- ADO run 124172 isolated the old QEMU as the cause: with clang alone, gawk still segfaulted under the old QEMU.
- The ADO PR run on this branch passes `Build Retina Shell Images arm64` with both changes.

## Additional Notes

N/A.
