### PR TITLE
ci: add scheduled eBPF kernel-compatibility lane

### DIFF
--- a/.github/workflows/bpfcompat-compatibility.yml
+++ b/.github/workflows/bpfcompat-compatibility.yml
@@ -1,0 +1,179 @@
+name: eBPF kernel compatibility
+
+# Runs Retina's own eBPF tests (`make test-ebpf`, build tag `ebpf`) on kernels
+# other than the GitHub runner's, using bpfcompat to boot each kernel in a
+# disposable QEMU/KVM VM on the hosted runner's /dev/kvm.
+#
+# The lane deliberately adds no new test logic. It compiles the existing
+# per-plugin test binaries with `go test -c -tags=ebpf` and runs each one as
+# root inside each guest, so a verdict reflects Retina's own loader
+# (github.com/cilium/ebpf) and Retina's own assertions -- not a third-party
+# loader's opinion of the object files. The per-kernel verdict is the test
+# binary's exit code.
+#
+# Scope: plugins whose eBPF tests are self-contained. `packetparser` is
+# excluded because it compiles its BPF program at run time
+# (loader.CompileEbpf), which would need clang and the source tree inside each
+# guest rather than an embedded object.
+#
+# This workflow is scheduled and advisory: it never runs on pull requests and
+# cannot block a merge. Evidence is uploaded on every run, including failures.
+#
+# Security note: the only ${{ }} interpolation reaching a run: block is
+# matrix.plugin, which comes from the hardcoded list below rather than from
+# any github.event.* field, and it is passed through env: regardless.
+
+on:
+  schedule:
+    # Mondays, 05:30 UTC.
+    - cron: "30 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  ebpf-kernel-matrix:
+    name: ${{ matrix.plugin }} on kernel matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        plugin:
+          - dns
+          - tcpretrans
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Install host dependencies
+        # clang/llvm/libbpf-dev build the eBPF objects; qemu-system-x86 and
+        # qemu-utils boot the guest kernels; cloud-image-utils provides
+        # cloud-localds, which the RHEL-family guests (centos-stream,
+        # almalinux) need for their cloud-init CIDATA seed.
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            qemu-system-x86 qemu-utils cloud-image-utils \
+            clang llvm libbpf-dev jq
+
+      - name: Enable KVM on the hosted runner
+        # Hosted Linux runners expose /dev/kvm, but the runner user is not in
+        # the kvm group, so QEMU cannot open it and silently degrades to TCG
+        # software emulation -- slow enough that guests miss the SSH timeout.
+        run: |
+          set -euo pipefail
+          if [[ -e /dev/kvm ]]; then
+            sudo chmod 0666 /dev/kvm || true
+            ls -l /dev/kvm
+          else
+            echo "::warning::/dev/kvm not found; QEMU will fall back to TCG emulation (slow)."
+          fi
+
+      - name: Generate eBPF objects
+        # The .o files are committed as empty placeholders, so they must be
+        # generated before a test binary can embed them.
+        run: GOARCH=amd64 go generate ./pkg/plugin/...
+
+      - name: Build the plugin's eBPF test binary
+        # Statically linked and stripped so it can be copied into each guest and
+        # run there without a Go toolchain.
+        env:
+          PLUGIN: ${{ matrix.plugin }}
+        run: |
+          set -euo pipefail
+          mkdir -p build/bpfcompat
+          CGO_ENABLED=0 go test -c -tags=ebpf -ldflags="-s -w" \
+            -o "build/bpfcompat/${PLUGIN}.test" "./pkg/plugin/${PLUGIN}"
+          ls -l "build/bpfcompat/${PLUGIN}.test"
+
+      - name: Run the tests across the kernel matrix
+        id: bpfcompat
+        continue-on-error: true
+        uses: Kernel-Guard/bpfcompat@3701b08ac3cd6c7d30e6f20445fb7c6b7f290c0f # v0.3.6
+        with:
+          command-binary: build/bpfcompat/${{ matrix.plugin }}.test
+          command: $BPFCOMPAT_BIN -test.count=1
+          matrix: test/bpfcompat/kernel-matrix.yaml
+          out: reports/bpfcompat-${{ matrix.plugin }}.json
+
+      - name: Summarise
+        if: always()
+        env:
+          PLUGIN: ${{ matrix.plugin }}
+        run: |
+          set -euo pipefail
+          report="reports/bpfcompat-${PLUGIN}.json"
+          if [[ ! -f "$report" ]]; then
+            echo "No report was produced for ${PLUGIN}." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          {
+            echo "### ${PLUGIN}"
+            echo
+            echo "| Kernel profile | Required | Result |"
+            echo "|---|---|---|"
+            jq -r '.targets[]
+              | "| \(.profile_id) | \(if .required then "yes" else "no" end) | \(.status) |"' \
+              "$report"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # A kernel result of "fail" is a finding and is allowed to stand: the
+          # lane is advisory and non-required profiles are expected to fail.
+          # "infra_error" is different -- it means the VM never ran the tests,
+          # so the lane proved nothing. Fail the job in that case rather than
+          # reporting a green run that silently tested nothing.
+          total="$(jq '.targets | length' "$report")"
+          infra="$(jq '[.targets[] | select(.status == "infra_error")] | length' "$report")"
+          if [[ "$total" -gt 0 && "$infra" -eq "$total" ]]; then
+            {
+              echo
+              echo "**Every kernel returned \`infra_error\`: the lane did not run"
+              echo "the tests and proved nothing. Failing so this is not mistaken"
+              echo "for a passing run.**"
+            } >> "$GITHUB_STEP_SUMMARY"
+            jq -r '.targets[0].infra_error // "no detail"' "$report" >&2
+            exit 1
+          fi
+
+      - name: Dump guest boot logs on failure
+        if: failure()
+        run: |
+          set +e
+          echo "===== /dev/kvm ====="; ls -l /dev/kvm
+          while IFS= read -r -d '' log; do
+            echo "===== $log ====="
+            tail -n 60 "$log"
+          done < <(find .bpfcompat -type f \( -name serial.log -o -name qemu.log \) -print0 2>/dev/null)
+
+      - name: Upload evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: bpfcompat-${{ matrix.plugin }}
+          if-no-files-found: warn
+          # Allowlist only -- never `.bpfcompat/runs/**` wholesale. The per-run
+          # directory also holds the generated guest SSH private key
+          # (id_ed25519), the cloud-init seed and the disk overlay, none of
+          # which belong in a downloadable artifact. The test binary's own
+          # stdout/stderr are what explain a failing kernel, so they are
+          # included: the JSON report says a kernel failed, these say why.
+          path: |
+            reports/
+            .bpfcompat/runs/**/targets/**/command.stdout
+            .bpfcompat/runs/**/targets/**/command.stderr
+            .bpfcompat/runs/**/targets/**/command-exit-code
+            .bpfcompat/runs/**/targets/**/serial.log
+            .bpfcompat/runs/**/targets/**/qemu.log

--- a/test/bpfcompat/kernel-matrix.yaml
+++ b/test/bpfcompat/kernel-matrix.yaml
@@ -1,0 +1,21 @@
+# Kernel profiles for the bpfcompat compatibility lane.
+#
+# Chosen to cover the kernels Retina realistically runs on plus one older
+# enterprise kernel that sits below the fexit threshold documented in
+# pkg/plugin/dropreason/ebpfsetup_linux.go (amd64 >= 5.5).
+#
+# required: false means a failure on that kernel is reported but does not fail
+# the lane. The lane is scheduled and advisory, so nothing here gates a merge.
+name: retina-ebpf-kernel-compatibility
+profiles:
+  - id: ubuntu-22.04-5.15
+    required: true
+  - id: ubuntu-24.04-6.8
+    required: true
+  - id: debian-12-6.1
+    required: true
+  - id: centos-stream-9-5.14
+    required: false
+  # RHEL-family 4.18: below the fexit threshold and a known CO-RE boundary.
+  - id: almalinux-8-4.18
+    required: false


### PR DESCRIPTION
# Description


## What this does

Retina's eBPF tests (`make test-ebpf`, build tag `ebpf`) currently run only on the GitHub runner's kernel. This adds an **advisory scheduled lane** that runs those same tests on a spread of other kernels, by booting each one in a disposable QEMU/KVM VM on the hosted runner's `/dev/kvm`.

**It adds no new test logic.** It builds the existing per-plugin test binaries with `go test -c -tags=ebpf` and runs each as root inside each guest, so a verdict comes from Retina's own loader (`github.com/cilium/ebpf`) and Retina's own assertions — not a third-party loader's opinion of the object files. The per-kernel verdict is the test binary's exit code.

Two files, +200 lines. The lane generates the eBPF objects it needs at run time and commits nothing.

## Results

Full run on my fork: https://github.com/ErenAri/retina/actions/runs/32594848147

| Plugin | ubuntu 22.04 / 5.15 | ubuntu 24.04 / 6.8 | debian 12 / 6.1 | centos-stream 9 / 5.14 | almalinux 8 / 4.18 |
|---|---|---|---|---|---|
| `dns` | pass | pass | pass | pass | pass |
| `tcpretrans` | pass | pass | pass | pass | **fail** |

`almalinux-8-4.18` is marked `required: false`, so that failure is reported without failing the lane.

The reason is in the uploaded evidence for that run (kernel `4.18.0-553.150.1.el8_10.x86_64`) — four tests fail at load:

```
--- FAIL: TestBPFLoadAndVerify
--- FAIL: TestBPFTracepointAttach
--- FAIL: TestBPFPerfReaderCreate
--- FAIL: TestBPFStopAfterInitWithoutStart

program retina_tcp_retransmit_skb: load program:
bad CO-RE relocation: invalid func unknown#195896080
```

I have no idea whether EL8 is in scope for Retina. If it isn't, drop that row from the matrix and the lane is all-green. I would rather show it than quietly leave the kernel out.

## Scope and honest caveats

- **`packetparser` is excluded.** It compiles its BPF program at run time via `loader.CompileEbpf`, so it would need clang and the source tree inside each guest rather than an embedded object. Addable later as a heavier build-in-guest lane.
- **`dropreason` is excluded from this first pass.** Its `resolvePayload` picks different program sets per kernel (fexit ≥5.5 amd64 / ≥6.0 arm64, kprobe fallback below, plus a Mariner subset). I did not want the lane to duplicate that logic and drift from it. Running its tests is the natural next step if this shape is useful.
- Loading `dropreason`'s objects in a bare guest also needs `nf_conntrack` present, since the fexit programs target `__nf_conntrack_confirm` in that module. Worth knowing if those tests ever run outside a real node.
- The lane fails the job if every kernel returns `infra_error`. A kernel failure is a finding and is allowed to stand, but "the VM never ran the tests" is not a pass and should not be able to look like one.

## One thing you may find interesting

`getEbpfPayload()` has a Mariner / Azure Linux path (`IsAzureLinux()`, core-kernel-funcs-only subset) that as far as I can tell nothing currently exercises in CI. I added Azure Linux 2.0 and 3.0 kernel profiles to bpfcompat this week, so that path is testable — but Microsoft publishes no public Azure Linux cloud image, so I cannot run it. If someone can point me at an image or a VHD export, I am happy to extend the lane to cover the Mariner branch.

## About the tool

[bpfcompat](https://github.com/Kernel-Guard/bpfcompat) is Apache-2.0. The action is pinned by commit SHA (`v0.3.6`). A comparable lane runs in `falcosecurity/libs` ([#3024](https://github.com/falcosecurity/libs/pull/3024), [#3061](https://github.com/falcosecurity/libs/pull/3061)) if it helps to see it in another project first.

The lane is scheduled-only and the validation step is `continue-on-error`, so it never runs on pull requests and cannot block a merge. Evidence uploads on every run, including failures. Happy to change the kernel list, the schedule, or the scope — or to close this if it is not useful.

_Independent test of a public project; not affiliated with or endorsed by Microsoft._

## Related Issue

Follow-up to #2460, where I asked whether a per-kernel compatibility matrix would be useful.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). The commit is **signed-off** (DCO), but not GPG-signed — I do not have a signing key registered. Happy to re-sign and force-push if that is required to merge.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary. The workflow documents itself in a header comment; happy to add a section to the contributing docs if you would prefer the lane described there.
- [x] I have added tests, if applicable. No new tests — the lane deliberately runs the existing `-tags=ebpf` tests on more kernels.

## Testing Completed

Four full rehearsals on my fork. The final one (linked above) is green with evidence uploaded:

- `dns` passes on all 5 kernels.
- `tcpretrans` passes on 4 and fails on `almalinux-8-4.18` (non-required), with the CO-RE relocation error quoted above readable in the uploaded `command.stdout`.

## Additional Notes

The artifact upload is an explicit allowlist rather than `.bpfcompat/runs/**`, because the per-run directory also holds the generated guest SSH private key, the cloud-init seed and the disk overlay. I verified the uploaded artifact contains only the named log files and no key material.
