### PR TITLE
fix(metrics): emit a port value for non-TCP/UDP flows to keep cardinality aligned

### DIFF
--- a/pkg/module/metrics/types.go
+++ b/pkg/module/metrics/types.go
@@ -314,6 +314,9 @@ func (c *ContextOptions) getByDirectionValues(f *flow.Flow, dest bool) []string 
 				} else {
 					values = append(values, fmt.Sprintf("%d", udp.GetSourcePort()))
 				}
+			} else {
+				// Non-TCP/UDP L4 (e.g. ICMP) has no port; keep values aligned with labels.
+				values = append(values, "unknown")
 			}
 		} else {
 			values = append(values, "unknown")

--- a/pkg/module/metrics/types_test.go
+++ b/pkg/module/metrics/types_test.go
@@ -159,6 +159,17 @@ func TestNewCtxOps(t *testing.T) {
 			f:            &flow.Flow{},
 			expectedVals: []string{"unknown"},
 		},
+		{
+			name:     "port option with a non-TCP/UDP flow keeps values aligned with labels",
+			opts:     []string{"ip", "port"},
+			ctxType:  source,
+			expected: []string{"source_ip", "source_port"},
+			f: &flow.Flow{
+				IP: &flow.IP{Source: "10.0.0.1"},
+				L4: &flow.Layer4{Protocol: &flow.Layer4_ICMPv4{ICMPv4: &flow.ICMPv4{}}},
+			},
+			expectedVals: []string{"10.0.0.1", "unknown"},
+		},
 	}
 
 	for _, tc := range tt {
@@ -176,4 +187,28 @@ func flowWithZones(srcZone, dstZone string) *flow.Flow {
 	utils.AddZones(ext, srcZone, dstZone)
 	utils.SetExtensions(f, ext)
 	return f
+}
+
+// TestPortContextCardinalityAcrossL4 brute-forces every Layer4 variant in both
+// directions: the value count must equal the label count, or WithLabelValues panics.
+func TestPortContextCardinalityAcrossL4(t *testing.T) {
+	l4s := map[string]*flow.Layer4{
+		"nil":    nil,
+		"tcp":    {Protocol: &flow.Layer4_TCP{TCP: &flow.TCP{}}},
+		"udp":    {Protocol: &flow.Layer4_UDP{UDP: &flow.UDP{}}},
+		"sctp":   {Protocol: &flow.Layer4_SCTP{SCTP: &flow.SCTP{}}},
+		"icmpv4": {Protocol: &flow.Layer4_ICMPv4{ICMPv4: &flow.ICMPv4{}}},
+		"icmpv6": {Protocol: &flow.Layer4_ICMPv6{ICMPv6: &flow.ICMPv6{}}},
+	}
+	for _, ctxType := range []ctxOptionType{source, destination} {
+		c := NewCtxOption([]string{"ip", "port", "namespace"}, ctxType)
+		labels := c.getLabels()
+		for name, l4 := range l4s {
+			f := &flow.Flow{IP: &flow.IP{Source: "10.0.0.1", Destination: "10.0.0.2"}, L4: l4}
+			if values := c.getValues(f); len(values) != len(labels) {
+				t.Errorf("%s/%d: %d values %v vs %d labels %v -> WithLabelValues would panic",
+					name, ctxType, len(values), values, len(labels), labels)
+			}
+		}
+	}
 }


### PR DESCRIPTION
`getLabels()` adds the `port` label whenever the `port` context is set, but `getByDirectionValues()` only emitted a value for TCP, UDP, or a nil L4. A non-nil `Layer4` that is neither TCP nor UDP (ICMP, ICMPv6, SCTP) appended nothing, so the value slice was one short of the label slice and the next `WithLabelValues` panicked the metrics module with `inconsistent label cardinality`. A single ICMP flow triggers it once `port` is enabled.

This adds the missing `else`, emitting the same `"unknown"` placeholder the nil-L4 branch already uses, so the counts stay aligned.

Verified: a new `TestNewCtxOps` case with an ICMP flow, plus `TestPortContextCardinalityAcrossL4` which brute-forces every `Layer4` variant (TCP, UDP, SCTP, ICMPv4, ICMPv6, nil) in both directions, fail without the fix (`getValues` returns one fewer value than `getLabels`) and pass with it. `gofmt` and `go vet ./pkg/module/metrics/` are clean.

Fixes #2678
