### PR TITLE
fix(build): bpf generation improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -261,6 +261,7 @@ container-docker-windows: # util target to build Windows container images withou
 
 retina-image: ## build the retina linux container image.
 	echo "Building for $(PLATFORM)"
+	set -e; \
 	for target in $(AGENT_TARGETS); do \
 		echo "Building for $$target"; \
 		if [ "$$target" = "init" ]; then \

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -25,6 +25,8 @@ ARG GOOS=linux
 ARG GOARCH=amd64
 ENV GOOS=${GOOS}
 ENV GOARCH=${GOARCH}
+ENV CGO_ENABLED=0
+ENV GOEXPERIMENT=ms_nocgo_opensslcrypto
 RUN if [ "$GOOS" = "linux" ] ; then \
     tdnf install -y clang lld bpftool libbpf-devel; \
     fi

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -30,9 +30,12 @@ RUN if [ "$GOOS" = "linux" ] ; then \
     fi
 COPY ./pkg/plugin /go/src/github.com/microsoft/retina/pkg/plugin
 WORKDIR /go/src/github.com/microsoft/retina
-RUN if [ "$GOOS" = "linux" ] ; then \
+RUN set -eu; \
+    if [ "$GOOS" = "linux" ] ; then \
     go mod init github.com/microsoft/retina; \
     go generate -skip "mockgen" -x /go/src/github.com/microsoft/retina/pkg/plugin/...; \
+    if [ "$GOARCH" = "amd64" ]; then bpf_arch=x86; else bpf_arch="$GOARCH"; fi; \
+    test -s "./pkg/plugin/conntrack/conntrack_bpfel_${bpf_arch}.o"; \
     tar czf /gen.tar.gz ./pkg/plugin; \
     rm go.mod; \
     else \

--- a/controller/Dockerfile
+++ b/controller/Dockerfile
@@ -32,12 +32,16 @@ RUN if [ "$GOOS" = "linux" ] ; then \
     fi
 COPY ./pkg/plugin /go/src/github.com/microsoft/retina/pkg/plugin
 WORKDIR /go/src/github.com/microsoft/retina
+# Sanity-check every arch-specific BPF object bpf2go produced is non-empty.
 RUN set -eu; \
     if [ "$GOOS" = "linux" ] ; then \
     go mod init github.com/microsoft/retina; \
     go generate -skip "mockgen" -x /go/src/github.com/microsoft/retina/pkg/plugin/...; \
     if [ "$GOARCH" = "amd64" ]; then bpf_arch=x86; else bpf_arch="$GOARCH"; fi; \
-    test -s "./pkg/plugin/conntrack/conntrack_bpfel_${bpf_arch}.o"; \
+    objects="$(find ./pkg/plugin -type f -name "*_bpfel_${bpf_arch}.o" -print)"; \
+    test -n "$objects" || { echo "no BPF objects generated for ${bpf_arch}" >&2; exit 1; }; \
+    empty_objects="$(find ./pkg/plugin -type f -name "*_bpfel_${bpf_arch}.o" ! -size +0c -print)"; \
+    test -z "$empty_objects" || { printf 'empty BPF objects:\n%s\n' "$empty_objects" >&2; exit 1; }; \
     tar czf /gen.tar.gz ./pkg/plugin; \
     rm go.mod; \
     else \


### PR DESCRIPTION
# Description

This PR hardens BPF object generation during Retina image builds, particularly for ARM64 builds running through QEMU.

The BPF generation stage could fail while compiling its temporary Go generator, leave an empty architecture-specific object file, and still allow the image build to continue. The resulting image then failed at runtime while loading the embedded BPF object.

## What changed

- Make the BPF generation stage fail immediately when a command fails.
- Verify that the generated architecture-specific conntrack object exists and is non-empty before packaging the generated plugin artifacts.
- Stop the `retina-image` target if either the init or agent image build fails, preventing a later loop iteration from masking an earlier failure.
- Disable CGO only in the temporary BPF generator stage and enable Microsoft' no-CGO OpenSSL system-crypto backend. This avoids QEMU-emulated GCC failures during ARM64 generation while preserving system-crypto compliance.

These changes affect build-time generators only. CGO and system-crypto behavior for the Retina runtime binaries is unchanged.

## Related Issue

No linked issue.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

- Built the exact `bpf-gen` stage for Linux AMD64.
- Built the exact `bpf-gen` stage for Linux ARM64 through QEMU.
- Confirmed both builds produce a non-empty architecture-specific conntrack BPF object.

## Additional Notes

The no-CGO configuration is intentionally scoped to the temporary generator stage in `controller/Dockerfile`; it is not a repository-wide or runtime build setting.

