### PR TITLE
test(shell): remove no-op unit tests

### DIFF
--- a/shell/trace_test.go
+++ b/shell/trace_test.go
@@ -4,13 +4,7 @@
 package shell
 
 import (
-	"bytes"
-	"context"
-	"errors"
-	"net"
-	"strings"
 	"testing"
-	"time"
 
 	v1 "k8s.io/api/core/v1"
 )
@@ -35,28 +29,6 @@ func TestTraceCapabilities(t *testing.T) {
 		if !capSet[required] {
 			t.Errorf("TraceCapabilities() missing required capability: %s", required)
 		}
-	}
-}
-
-func TestTraceConfigTypedFields(t *testing.T) {
-	// Verify TraceConfig only accepts typed values, not raw strings
-	config := TraceConfig{
-		FilterIPs:   []net.IP{net.ParseIP("10.0.0.1")},
-		FilterCIDRs: []*net.IPNet{},
-		OutputJSON:  true,
-	}
-
-	// FilterIPs should be net.IP, not string
-	if len(config.FilterIPs) != 1 {
-		t.Errorf("Expected 1 FilterIP, got %d", len(config.FilterIPs))
-	}
-	if !config.FilterIPs[0].Equal(net.ParseIP("10.0.0.1")) {
-		t.Errorf("FilterIP not set correctly")
-	}
-
-	// Verify OutputJSON is bool, not string
-	if !config.OutputJSON {
-		t.Errorf("OutputJSON should be true")
 	}
 }
 
@@ -226,158 +198,5 @@ func TestBoolPtr(t *testing.T) {
 	}
 	if falsePtr == nil || *falsePtr != false {
 		t.Error("boolPtr(false) should return pointer to false")
-	}
-}
-
-// TestExecInPodCommandIsArray verifies that execInPod takes command as array
-// This is a security test - commands must NOT be passed through a shell
-func TestExecInPodCommandIsArray(t *testing.T) {
-	// This test verifies the function signature and documentation
-	// The actual exec requires a running cluster, but we can verify
-	// that the function is designed correctly
-
-	// Verify the function signature accepts []string for command
-	// If this compiles, the function correctly uses array, not string
-	commandArray := []string{"bpftrace", "-e", "tracepoint:skb:kfree_skb { }"}
-
-	// Ensure the command array contains separate elements
-	if len(commandArray) != 3 {
-		t.Errorf("Command should be array of 3 elements, got %d", len(commandArray))
-	}
-
-	// Verify no shell metacharacters would be interpreted
-	// (they're just strings in an array, not executed by shell)
-	dangerousInput := "test; rm -rf /"
-	testCommand := []string{"echo", dangerousInput}
-
-	// In a shell: echo "test; rm -rf /" would be safe
-	// But echo test; rm -rf / would be dangerous
-	// With array exec: ["echo", "test; rm -rf /"] is always safe
-	// because "test; rm -rf /" is passed as a single argument to echo
-
-	if testCommand[0] != "echo" {
-		t.Error("First element should be 'echo'")
-	}
-	if testCommand[1] != dangerousInput {
-		t.Error("Second element should be the dangerous input as-is (not interpreted)")
-	}
-
-	// The key security property: the dangerous input stays as ONE argument
-	// It's not split by shell
-	if len(testCommand) != 2 {
-		t.Errorf("Command should have exactly 2 elements (not shell-split), got %d", len(testCommand))
-	}
-}
-
-// TestExecInPodContextCancellation verifies context cancellation behavior
-func TestExecInPodContextCancellation(t *testing.T) {
-	// Create a cancelled context
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // Cancel immediately
-
-	// Verify context is done
-	select {
-	case <-ctx.Done():
-		// Expected - context should be cancelled
-		if !errors.Is(ctx.Err(), context.Canceled) {
-			t.Errorf("Expected context.Canceled, got %v", ctx.Err())
-		}
-	default:
-		t.Error("Context should be done after cancel()")
-	}
-}
-
-// TestExecInPodTimeoutContext verifies timeout context behavior
-func TestExecInPodTimeoutContext(t *testing.T) {
-	// Create a context with very short timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
-	defer cancel()
-
-	// Wait for timeout
-	time.Sleep(5 * time.Millisecond)
-
-	// Verify context is done due to deadline
-	select {
-	case <-ctx.Done():
-		if !errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			t.Errorf("Expected context.DeadlineExceeded, got %v", ctx.Err())
-		}
-	default:
-		t.Error("Context should be done after timeout")
-	}
-}
-
-// TestExecOutputWriters verifies stdout/stderr writers work correctly
-func TestExecOutputWriters(t *testing.T) {
-	// This tests that our output handling pattern works correctly
-	var stdout, stderr bytes.Buffer
-
-	// Simulate writing to both
-	stdout.WriteString("stdout output\n")
-	stderr.WriteString("stderr output\n")
-
-	if !strings.Contains(stdout.String(), "stdout") {
-		t.Error("stdout buffer should contain stdout output")
-	}
-	if !strings.Contains(stderr.String(), "stderr") {
-		t.Error("stderr buffer should contain stderr output")
-	}
-}
-
-// TestExecCommandNoShellInterpolation verifies that special characters
-// are NOT interpreted when passed in command array
-func TestExecCommandNoShellInterpolation(t *testing.T) {
-	// These strings would be dangerous if passed to a shell
-	// But in array form, they're just literal strings
-	testCases := []struct {
-		name    string
-		command []string
-	}{
-		{
-			name:    "semicolon injection",
-			command: []string{"echo", "safe; rm -rf /"},
-		},
-		{
-			name:    "backtick injection",
-			command: []string{"echo", "`whoami`"},
-		},
-		{
-			name:    "dollar injection",
-			command: []string{"echo", "$(id)"},
-		},
-		{
-			name:    "pipe injection",
-			command: []string{"echo", "data | cat /etc/passwd"},
-		},
-		{
-			name:    "redirect injection",
-			command: []string{"echo", "> /tmp/evil"},
-		},
-		{
-			name:    "newline injection",
-			command: []string{"echo", "line1\nrm -rf /"},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			// In proper array exec, the "dangerous" part is always
-			// the second element - it's never parsed or split
-			if len(tc.command) != 2 {
-				t.Errorf("Expected 2-element array, got %d", len(tc.command))
-			}
-			if tc.command[0] != "echo" {
-				t.Error("First element should be 'echo'")
-			}
-			// The second element contains the "dangerous" string
-			// but it's just a literal string, not executed
-			if tc.command[1] == "" {
-				t.Error("Second element should not be empty")
-			}
-
-			// Key assertion: the command array length proves no shell parsing
-			// Shell would split "echo safe; rm -rf /" into multiple commands
-			// Array exec keeps it as ["echo", "safe; rm -rf /"] = 2 elements
-		})
 	}
 }


### PR DESCRIPTION
# Description

Six tests in `shell/trace_test.go` call no retina code. Each one builds a local value and asserts language or standard-library behavior:

- `TestTraceConfigTypedFields` — a struct literal keeps its values.
- `TestExecInPodCommandIsArray` — a local `[]string` has 3 elements.
- `TestExecInPodContextCancellation` — `context.WithCancel` cancels its context.
- `TestExecInPodTimeoutContext` — `context.WithTimeout` expires its context.
- `TestExecOutputWriters` — `bytes.Buffer` stores writes.
- `TestExecCommandNoShellInterpolation` — local slices keep their strings.

These tests add no coverage and can only fail falsely. `TestExecInPodTimeoutContext` does exactly that: it checks a `1ms` timeout after a `5ms` sleep in a `select` with a `default` case. On a loaded runner the timer fires after the sleep, and the test fails. It failed four `Test Retina Image` runs between Aug 6 and Aug 24: [Aug 24, merge queue](https://github.com/microsoft/retina/actions/runs/32750347796/attempts/1), [Aug 21, push to `main`](https://github.com/microsoft/retina/actions/runs/32432278821/attempts/1), [Aug 7, PR run](https://github.com/microsoft/retina/actions/runs/31185534764/attempts/1), [Aug 6, PR run](https://github.com/microsoft/retina/actions/runs/31108523658/attempts/1). The run list hides three of the four failures in earlier attempts of re-runs.

This PR removes the six tests and their unused imports. The real tests stay: the capability list, the trace pod manifest, the debug pod manifests (`manifests_test.go`), and the bpftrace script generation (`tracescript_test.go`). A real exec test needs an injectable `remotecommand.Executor` seam, which is a separate change.

## Related Issue

N/A — found while deflaking the `Test Retina Image` workflow (#2686).

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

```bash
go vet ./shell/
go test -tags=unit,dashboard ./shell/
```

Both pass. The change removes tests only.
