### PR TITLE
fix(ci): skip manifests and test jobs when dependencies fail

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -325,7 +325,7 @@ jobs:
 
   - job: manifests
     displayName: Generate Manifests
-    condition: eq(variables['isMergeGroup'], 'True')
+    condition: and(succeeded(), eq(variables['isMergeGroup'], 'True'))
     dependsOn:
       - retina_images
       - retina_image_win
@@ -363,7 +363,7 @@ jobs:
 
   - job: e2e
     displayName: Run E2E Tests
-    condition: eq(variables['isMergeGroup'], 'True')
+    condition: and(succeeded(), eq(variables['isMergeGroup'], 'True'))
     dependsOn: manifests
     timeoutInMinutes: 90
     pool:
@@ -406,7 +406,7 @@ jobs:
 
   - job: perf_basic
     displayName: Retina basic Performance Test
-    condition: eq(variables['isMergeGroup'], 'True')
+    condition: and(succeeded(), eq(variables['isMergeGroup'], 'True'))
     dependsOn:
       - manifests
       - e2e
@@ -456,7 +456,7 @@ jobs:
 
   - job: perf_advanced
     displayName: Retina advanced Performance Test
-    condition: eq(variables['isMergeGroup'], 'True')
+    condition: and(succeeded(), eq(variables['isMergeGroup'], 'True'))
     dependsOn:
       - manifests
       - e2e


### PR DESCRIPTION
# Description

Currently manifests and test jobs continue running in case of failure or canceling pipeline. This PR will make the pipeline skip manifests and test jobs when dependencies fail.

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
