### PR TITLE
feat(shell): add nano and crictl to the shell image

### DIFF
--- a/docs/06-Troubleshooting/shell.md
+++ b/docs/06-Troubleshooting/shell.md
@@ -4,7 +4,7 @@
 
 The `retina shell` command allows you to start an interactive shell on a Kubernetes node or pod for adhoc debugging.
 
-This runs a container image built from the Dockerfile in the `/shell` directory, with many common networking tools installed (`ping`, `curl`, etc.), as well as specialized tools such as [bpftool](#bpftool), [bpftrace](#bpftrace) [pwru](#pwru) or [Inspektor Gadget](#inspektor-gadget-ig).
+This runs a container image built from the Dockerfile in the `/shell` directory, with many common networking tools installed (`ping`, `curl`, etc.), a text editor (`nano`), as well as specialized tools such as [bpftool](#bpftool), [bpftrace](#bpftrace), [crictl](#crictl), [pwru](#pwru) or [Inspektor Gadget](#inspektor-gadget-ig).
 
 Currently the Retina Shell only works in Linux environments. Windows support will be added in the future.
 
@@ -120,6 +120,8 @@ NOTICE.txt  bin  boot  dev  etc  home  lib  lib64  libx32  lost+found  media  mn
 
 The host filesystem is mounted read-only by default. If you need write access, use the `--allow-host-filesystem-write` flag.
 
+>NOTE: The host's `/run` is mounted separately and is always read-write, because tools such as [crictl](#crictl) need to write to the container runtime socket. `--allow-host-filesystem-write` controls only the `/host` mount.
+
 Symlinks between files on the host filesystem may not resolve correctly. If you see "No such file or directory" errors for symlinks, try following the instructions below to `chroot` to the host filesystem.
 
 ## Chroot to the host filesystem
@@ -164,6 +166,33 @@ root [ / ]# chroot /host systemctl status | head -n 2
 ```
 
 >NOTE: If `systemctl` shows an error "Failed to connect to bus: No data available", check that the `retina shell` command has `--host-pid` set and that you have chroot'd to /host.
+
+## [crictl](https://github.com/kubernetes-sigs/cri-tools)
+
+CLI for CRI-compatible container runtimes. Useful for inspecting the node's containers and pods from the runtime's point of view: which container owns a network namespace, why a container keeps restarting, or what it logged before it died.
+
+`crictl` talks to the container runtime socket under `/run`, which is mounted into the shell by `--mount-host-filesystem`. No extra capabilities are required.
+
+```shell
+kubectl retina shell <node-name> --mount-host-filesystem
+```
+
+You can then run, for example:
+
+```shell
+crictl ps
+crictl pods --namespace kube-system
+crictl inspect <container-id>
+crictl logs <container-id>
+```
+
+The image ships an `/etc/crictl.yaml` pointing at the containerd socket. On clusters running a different CRI implementation, override the endpoint:
+
+```shell
+crictl --runtime-endpoint unix:///run/crio/crio.sock ps
+```
+
+>NOTE: Write access to the container runtime socket is equivalent to root on the node. `crictl` is inert without `--mount-host-filesystem`, which is the flag that exposes the socket.
 
 ## [pwru](https://github.com/cilium/pwru)
 

--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -31,6 +31,7 @@ FROM mcr.microsoft.com/azurelinux/base/core:3.0.20260825@sha256:daa1142fc6b44e27
 RUN tdnf install -y \
 	bind-utils \
 	conntrack \
+	cri-tools \
 	curl \
 	ebtables-legacy \
 	ethtool \
@@ -42,6 +43,7 @@ RUN tdnf install -y \
 	jq \
 	ldns-utils \
 	less \
+	nano \
 	net-tools \
 	nftables \
 	nmap \
@@ -75,6 +77,13 @@ exec "$@"' > /usr/local/bin/entrypoint.sh;
 ENV HOST_ROOT=/host
 
 RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Point crictl at the containerd socket, which is exposed under /run when the
+# shell is started with --mount-host-filesystem. Override with
+# `crictl --runtime-endpoint` on clusters running a different CRI implementation.
+RUN echo $'runtime-endpoint: unix:///run/containerd/containerd.sock\n\
+image-endpoint: unix:///run/containerd/containerd.sock\n\
+timeout: 10' > /etc/crictl.yaml
 
 # Set the entrypoint
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
# Description

`retina shell` ships no text editor and no way to inspect the node's containers from the runtime's point of view. Editing a scratch file means a `cat > file` heredoc, and answering "which container owns this netns" or "what did this container log before it died" means `chroot /host` and hoping the node has tooling installed.

This adds two packages from the Azure Linux 3.0 base repo — the same tier every other package in the image already comes from — both published for `amd64` and `aarch64`.

- **`cri-tools`** provides `crictl`. It requires no extra capabilities: `--mount-host-filesystem` already mounts the host's `/run` (`shell/manifests.go`), so the containerd socket is present in the container. The image ships an `/etc/crictl.yaml` pointing at `unix:///run/containerd/containerd.sock`; clusters on another CRI implementation override it with `crictl --runtime-endpoint`. Without `--mount-host-filesystem` the socket is absent and `crictl` is inert, so this grants nothing that flag did not already grant.
- **`nano`** covers editing a config or scratch file without leaving the shell.
- **Docs**: `docs/06-Troubleshooting/shell.md` gains a `crictl` section, names `nano` in the intro tool list, and documents that the host's `/run` is mounted read-write even without `--allow-host-filesystem-write` — the behavior `crictl` depends on, and worth stating next to the existing "mounted read-only by default" line.

`nano` over `vim` is deliberate. `retina-shell` is scanned weekly by `trivy.yaml` on `CRITICAL,HIGH`, and the two have very different profiles:

| | CVEs (NVD) | HIGH + CRITICAL | Azure Linux CVE bumps |
|---|---|---|---|
| `nano` | 4 since 2010 | 0 | 2 since 2020, still on `6.4` |
| `vim` | 250 | 153 of 233 scored | 13 in 2026 alone, roughly 1 per 12 days |

The shell image is rebuilt on release cadence (4–6 weeks) while Azure Linux bumps `vim` about every 12 days, so `vim` would park HIGH findings in the weekly scan that nobody can close without cutting a release. `nano` has never produced a finding matching that filter.

## Related Issue

N/A.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally. (Image not built locally — no container runtime in the authoring environment. Package availability and config rendering verified as below; the image build in CI is the real check.)
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable. (N/A — package addition, no test surface.)

## Screenshots (if applicable) or Testing Completed

Both packages resolve in the Azure Linux 3.0 base repo on both build architectures:

```
nano-6.4-3.azl3.x86_64.rpm         cri-tools-1.32.0-7.azl3.x86_64.rpm
nano-6.4-3.azl3.aarch64.rpm        cri-tools-1.32.0-7.azl3.aarch64.rpm
```

`/etc/crictl.yaml` renders as valid YAML — simulating the Dockerfile line-join and the `$'...'` expansion the existing `entrypoint.sh` block already uses:

```console
$ cat crictl.yaml
runtime-endpoint: unix:///run/containerd/containerd.sock
image-endpoint: unix:///run/containerd/containerd.sock
timeout: 10

$ python3 -c "import yaml; print(yaml.safe_load(open('crictl.yaml')))"
{'runtime-endpoint': 'unix:///run/containerd/containerd.sock', 'image-endpoint': 'unix:///run/containerd/containerd.sock', 'timeout': 10}
```

`markdownlint-cli2` clean on the changed doc, using the repo config:

```console
$ npx markdownlint-cli2 --config .github/.markdownlint.json docs/06-Troubleshooting/shell.md
Summary: 0 issues in 0 files
```

## Additional Notes

The read-write `/run` mount is pre-existing behavior from `shell/manifests.go`, not introduced here — this PR only documents it, because `crictl` makes it reachable in one command rather than latent.

Two stale entries in the doc's Limitations section are left alone here to keep this focused: `bpftrace` is listed as unsupported despite having its own section and shipping in the image, and `nsenter` is listed as unavailable when the constraint is that it needs `--host-pid` to be useful.
