### PR TITLE
feat(shell): add nano and crictl to the shell image

### DIFF
--- a/docs/06-Troubleshooting/shell.md
+++ b/docs/06-Troubleshooting/shell.md
@@ -4,7 +4,7 @@
 
 The `retina shell` command allows you to start an interactive shell on a Kubernetes node or pod for adhoc debugging.
 
-This runs a container image built from the Dockerfile in the `/shell` directory, with many common networking tools installed (`ping`, `curl`, etc.), as well as specialized tools such as [bpftool](#bpftool), [bpftrace](#bpftrace) [pwru](#pwru) or [Inspektor Gadget](#inspektor-gadget-ig).
+This runs a container image built from the Dockerfile in the `/shell` directory, with many common networking tools installed (`ping`, `curl`, etc.), a text editor (`nano`), as well as specialized tools such as [bpftool](#bpftool), [bpftrace](#bpftrace), [crictl](#crictl), [pwru](#pwru) or [Inspektor Gadget](#inspektor-gadget-ig).
 
 Currently the Retina Shell only works in Linux environments. Windows support will be added in the future.
 
@@ -120,6 +120,8 @@ NOTICE.txt  bin  boot  dev  etc  home  lib  lib64  libx32  lost+found  media  mn
 
 The host filesystem is mounted read-only by default. If you need write access, use the `--allow-host-filesystem-write` flag.
 
+>NOTE: The host's `/run` is mounted separately and is always read-write, because tools such as [crictl](#crictl) need to write to the container runtime socket. `--allow-host-filesystem-write` controls only the `/host` mount.
+
 Symlinks between files on the host filesystem may not resolve correctly. If you see "No such file or directory" errors for symlinks, try following the instructions below to `chroot` to the host filesystem.
 
 ## Chroot to the host filesystem
@@ -164,6 +166,35 @@ root [ / ]# chroot /host systemctl status | head -n 2
 ```
 
 >NOTE: If `systemctl` shows an error "Failed to connect to bus: No data available", check that the `retina shell` command has `--host-pid` set and that you have chroot'd to /host.
+
+## [crictl](https://github.com/kubernetes-sigs/cri-tools)
+
+CLI for CRI-compatible container runtimes. Useful for inspecting the node's containers and pods from the runtime's point of view: which container owns a network namespace, why a container keeps restarting, or what it logged before it died.
+
+`crictl` talks to the container runtime socket under `/run`, which is mounted into the shell by `--mount-host-filesystem`. No extra capabilities are required.
+
+```shell
+kubectl retina shell <node-name> --mount-host-filesystem
+```
+
+You can then run, for example:
+
+```shell
+crictl ps
+crictl pods --namespace kube-system
+crictl inspect <container-id>
+crictl logs <container-id>
+```
+
+>NOTE: `crictl logs` reads the kubelet's log files at `/var/log/pods`, which exist only on the host filesystem. The image ships a symlink from `/var/log/pods` to `/host/var/log/pods`, so the command works when `--mount-host-filesystem` is set. The read-only `/host` mount is enough.
+
+The image ships an `/etc/crictl.yaml` pointing at the containerd socket. On clusters running a different CRI implementation, override the endpoint:
+
+```shell
+crictl --runtime-endpoint unix:///run/crio/crio.sock ps
+```
+
+>NOTE: Write access to the container runtime socket is equivalent to root on the node. `crictl` is inert without `--mount-host-filesystem`, which is the flag that exposes the socket.
 
 ## [pwru](https://github.com/cilium/pwru)
 

--- a/shell/Dockerfile
+++ b/shell/Dockerfile
@@ -31,6 +31,7 @@ FROM mcr.microsoft.com/azurelinux/base/core:3.0.20260825@sha256:daa1142fc6b44e27
 RUN tdnf install -y \
 	bind-utils \
 	conntrack \
+	cri-tools \
 	curl \
 	ebtables-legacy \
 	ethtool \
@@ -42,6 +43,7 @@ RUN tdnf install -y \
 	jq \
 	ldns-utils \
 	less \
+	nano \
 	net-tools \
 	nftables \
 	nmap \
@@ -57,7 +59,11 @@ RUN tdnf install -y \
 	bpftool \
 	bpftrace \
 	ig \
-	&& tdnf clean all
+	&& tdnf clean all \
+	# cri-tools also installs critest, a CRI conformance suite binary as large
+	# as crictl itself and with no use in a debug shell. Remove it in the same
+	# layer so the image does not store it.
+	&& rm /usr/bin/critest
 
 # Create the entrypoint script to mount debugfs and tracefs
 SHELL ["/bin/bash", "-c"]
@@ -75,6 +81,19 @@ exec "$@"' > /usr/local/bin/entrypoint.sh;
 ENV HOST_ROOT=/host
 
 RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Point crictl at the containerd socket, which is exposed under /run when the
+# shell is started with --mount-host-filesystem. Override with
+# `crictl --runtime-endpoint` on clusters running a different CRI implementation.
+RUN echo $'runtime-endpoint: unix:///run/containerd/containerd.sock\n\
+image-endpoint: unix:///run/containerd/containerd.sock\n\
+timeout: 10' > /etc/crictl.yaml
+
+# crictl logs opens the kubelet's log files at /var/log/pods itself; the CRI
+# API does not stream log content. The files exist only on the host, so
+# resolve the path through the read-only /host mount. The link dangles
+# harmlessly when --mount-host-filesystem is not set.
+RUN ln -s /host/var/log/pods /var/log/pods
 
 # Set the entrypoint
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
# Description

`retina shell` ships no text editor and no tool to inspect the node's containers from the runtime's point of view. This PR adds two packages from the Azure Linux 3.0 base repo, the same tier every other package in the image comes from. Both are published for `amd64` and `aarch64`.

- **`cri-tools`**: provides `crictl`. It needs no extra capabilities — `--mount-host-filesystem` already mounts the host's `/run`, so the containerd socket is present in the container. The image ships an `/etc/crictl.yaml` that points at the containerd socket. Clusters on another CRI implementation override it with `crictl --runtime-endpoint`. Without `--mount-host-filesystem` the socket is absent and `crictl` is inert, so the package grants nothing the flag did not already grant. The install layer removes `critest`, a CRI conformance suite binary as large as `crictl` itself and with no use in a debug shell. The image also ships a symlink from `/var/log/pods` to `/host/var/log/pods` — `crictl logs` opens the kubelet's log files itself, and they exist only on the host. The read-only `/host` mount covers the read, and the link dangles harmlessly when the flag is not set.
- **`nano`**: lets you edit a config or scratch file inside the shell.
- **Docs**: `docs/06-Troubleshooting/shell.md` gets a `crictl` section and names `nano` in the tool list. It documents that the host's `/run` mount is always read-write — pre-existing behavior from `shell/manifests.go`, only documented here.

`nano` over `vim` is deliberate. `trivy.yaml` scans `retina-shell` weekly on `CRITICAL,HIGH`. `nano` has 4 CVEs since 2010, none rated HIGH or CRITICAL. `vim` has 250, and Azure Linux bumps it for a CVE roughly every 12 days. Between releases, that parks HIGH findings in the scan that nobody can close without a release.

## Related Issue

Supersedes #2705 — same change, reopened from an in-repo branch.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable. (N/A — package addition, no test surface.)

## Screenshots (if applicable) or Testing Completed

Image built locally for `amd64` and tested on a kind cluster (containerd v2.3.1). The test pod mirrors the `--mount-host-filesystem` spec from `shell/manifests.go`: host `/` read-only at `/host`, host `/run` at `/run`, and no added capabilities.

- `crictl version`, `crictl pods`, `crictl ps`, and `crictl inspect` work against the live runtime with only the shipped `/etc/crictl.yaml` — no endpoint flags.
- `crictl logs` returns the container's log lines out of the box, through the baked-in symlink and the read-only `/host` mount.
- `nano` 6.4 and `crictl` 1.32.0 run in the built image; `critest` is absent.
- Image size: 1.43GB → 1.48GB unpacked (+50MB). `markdownlint-cli2` reports 0 issues on the changed doc.

## Additional Notes

Two stale entries in the doc's Limitations section (`bpftrace`, `nsenter`) are left alone to keep this PR focused.
