### PR TITLE
fix(operator): set Pod owner reference on RetinaEndpoints for garbage collection

### DIFF
--- a/operator/cmd/standard/deployment.go
+++ b/operator/cmd/standard/deployment.go
@@ -209,6 +209,11 @@ func (o *Operator) Start() error {
 			// start reconcile the cached Pod before manager starts to not miss any events
 			go ke.ReconcilePod(ctrlCtx)
 
+			// Clean up RetinaEndpoints orphaned before owner references were set on them.
+			if err = mgr.Add(ke); err != nil {
+				return errors.Wrap(err, "unable to add retinaendpoint cleanup")
+			}
+
 			pc := podcontroller.New(mgr.GetClient(), mgr.GetScheme(), retinaendpointchannel)
 			if err = (pc).SetupWithManager(mgr); err != nil {
 				return errors.Wrap(err, "unable to create controller - podcontroller")

--- a/pkg/controllers/operator/retinaendpoint/retinaendpoint_controller.go
+++ b/pkg/controllers/operator/retinaendpoint/retinaendpoint_controller.go
@@ -15,6 +15,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	retinav1alpha1 "github.com/microsoft/retina/crd/api/v1alpha1"
 	"github.com/microsoft/retina/operator/cache"
@@ -44,8 +45,6 @@ func New(client client.Client, podchannel chan cache.PodCacheObject) *RetinaEndp
 	}
 }
 
-// NOTE(mainrerd): Chances are that pod cache channel lost pods events during controller manager restart, we need to
-// have full-set reconciliation to make sure all RetinaEndpoints are reconciled to Pods.
 // when a pod reaches here, it indicates that there is a metricsconfiguration that references it,
 // or doesn't and a RetinaEndpoint needs to be created or updated.
 // This is a blocking function, and will wait on the pod channel until a pod is received.
@@ -72,6 +71,67 @@ func (r *RetinaEndpointReconciler) ReconcilePod(pctx context.Context) {
 			return
 		}
 	}
+}
+
+// setPodOwner adds an owner reference to pod so the API server garbage collects the
+// RetinaEndpoint when the Pod is deleted.
+//
+// A plain owner reference is enough for garbage collection. The controller reference is
+// deliberately not claimed, which would also block Pod deletion on this RetinaEndpoint.
+//
+// This is metadata.ownerReferences, distinct from the RetinaEndpoint's informational
+// spec.ownerReferences, which mirrors the Pod's own owners (ReplicaSet, DaemonSet, ...)
+// and is not consulted by garbage collection.
+func (r *RetinaEndpointReconciler) setPodOwner(endpoint *retinav1alpha1.RetinaEndpoint, pod *corev1.Pod) error {
+	if err := controllerutil.SetOwnerReference(pod, endpoint, r.Scheme()); err != nil {
+		return fmt.Errorf("setting Pod owner reference: %w", err)
+	}
+	return nil
+}
+
+// Start deletes RetinaEndpoints whose Pod no longer exists, once, when the operator
+// starts. Owner references make the API server garbage collect RetinaEndpoints from then
+// on, but ones already orphaned carry no reference and would never receive a Pod event, so
+// nothing else would reclaim them.
+//
+// Start implements manager.Runnable so the manager runs it after its caches have synced.
+func (r *RetinaEndpointReconciler) Start(ctx context.Context) error {
+	endpoints := &retinav1alpha1.RetinaEndpointList{}
+	if err := r.List(ctx, endpoints); err != nil {
+		return fmt.Errorf("listing RetinaEndpoints: %w", err)
+	}
+
+	deleted := 0
+	for i := range endpoints.Items {
+		endpoint := &endpoints.Items[i]
+		if len(endpoint.OwnerReferences) > 0 {
+			continue
+		}
+		key := types.NamespacedName{Namespace: endpoint.Namespace, Name: endpoint.Name}
+
+		pod := &corev1.Pod{}
+		err := r.Get(ctx, key, pod, &client.GetOptions{})
+		if err == nil {
+			// The Pod is still around, so its next event adopts the RetinaEndpoint.
+			continue
+		}
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("getting Pod %s: %w", key.String(), err)
+		}
+
+		r.l.Info("deleting orphaned RetinaEndpoint", zap.String("name", key.String()))
+		// Refuse the delete if the RetinaEndpoint changed since it was listed.
+		if err := r.Delete(ctx, endpoint, client.Preconditions{UID: &endpoint.UID}); err != nil {
+			if errors.IsNotFound(err) || errors.IsConflict(err) {
+				continue
+			}
+			return fmt.Errorf("deleting orphaned RetinaEndpoint %s: %w", key.String(), err)
+		}
+		deleted++
+	}
+
+	r.l.Info("deleted orphaned RetinaEndpoints", zap.Int("count", deleted))
+	return nil
 }
 
 // requeuePodToRetinaEndpoint is called when a pod is received from the pod channel, and it will writeback to the
@@ -191,6 +251,11 @@ func (r *RetinaEndpointReconciler) reconcileRetinaEndpointFromPod(ctx context.Co
 			},
 		}
 
+		if err = r.setPodOwner(new, pod.Pod); err != nil {
+			r.l.Error("failed to set Pod owner reference", zap.Error(err), zap.String("name", pod.Key.String()))
+			return err
+		}
+
 		r.l.Info("creating RetinaEndpoint", zap.String("name", pod.Key.String()))
 		if err := r.Client.Create(ctx, new); err != nil {
 			r.l.Error(err.Error(), zap.String("name", pod.Key.String()))
@@ -211,6 +276,11 @@ func (r *RetinaEndpointReconciler) reconcileRetinaEndpointFromPod(ctx context.Co
 		Labels:          pod.Pod.Labels,
 		Annotations:     pod.Pod.Annotations,
 		OwnerReferences: refs,
+	}
+	// Set the Pod owner reference on existing RetinaEndpoints as well.
+	if err = r.setPodOwner(new, pod.Pod); err != nil {
+		r.l.Error("failed to set Pod owner reference", zap.Error(err), zap.String("name", pod.Key.String()))
+		return err
 	}
 
 	r.l.Info("updating RetinaEndpoint", zap.String("name", pod.Key.String()))

--- a/pkg/controllers/operator/retinaendpoint/retinaendpoint_controller_test.go
+++ b/pkg/controllers/operator/retinaendpoint/retinaendpoint_controller_test.go
@@ -247,6 +247,152 @@ func TestRetinaEndpointReconciler_ReconcilePod(t *testing.T) {
 	}
 }
 
+// podUID is the owning Pod's UID in the owner reference tests.
+const (
+	podUID     = types.UID("pod-uid-1")
+	orphanName = "orphan"
+	podKind    = "Pod"
+)
+
+func newOwnerRefTestReconciler(t *testing.T, objects ...client.Object) (*RetinaEndpointReconciler, client.Client) {
+	t.Helper()
+	if _, err := log.SetupZapLogger(log.GetDefaultLogOpts()); err != nil {
+		t.Fatalf("Error setting up logger: %s", err)
+	}
+	utilruntime.Must(clientgoscheme.AddToScheme(fakescheme))
+	utilruntime.Must(retinav1alpha1.AddToScheme(fakescheme))
+
+	c := fake.NewClientBuilder().WithScheme(fakescheme).WithObjects(objects...).Build()
+	return New(c, make(chan cache.PodCacheObject, 10)), c
+}
+
+func runningPodWithUID(name, namespace, podIP string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, UID: podUID},
+		Status: corev1.PodStatus{
+			Phase:  corev1.PodRunning,
+			PodIP:  podIP,
+			PodIPs: []corev1.PodIP{{IP: podIP}},
+			HostIP: "10.10.10.10",
+		},
+	}
+}
+
+// requireOwnedByPod asserts the endpoint is garbage collectable via exactly one owner
+// reference to the given Pod, without claiming the controller slot or blocking Pod
+// deletion. Exactly one guards against references accumulating across reconciles.
+func requireOwnedByPod(t *testing.T, endpoint *retinav1alpha1.RetinaEndpoint, name string, uid types.UID) {
+	t.Helper()
+	podRefs := []metav1.OwnerReference{}
+	for _, ref := range endpoint.OwnerReferences {
+		if ref.Kind == podKind {
+			podRefs = append(podRefs, ref)
+		}
+	}
+	require.Len(t, podRefs, 1, "expected exactly one Pod owner reference, got %v", endpoint.OwnerReferences)
+
+	require.Equal(t, "v1", podRefs[0].APIVersion)
+	require.Equal(t, name, podRefs[0].Name)
+	require.Equal(t, uid, podRefs[0].UID)
+	require.Nil(t, podRefs[0].Controller, "should not claim the controller reference")
+	require.Nil(t, podRefs[0].BlockOwnerDeletion, "should not block Pod deletion")
+}
+
+func TestRetinaEndpointReconciler_CreateSetsPodOwnerReference(t *testing.T) {
+	key := types.NamespacedName{Namespace: "default", Name: "pod"}
+	pod := runningPodWithUID(key.Name, key.Namespace, "10.0.0.1")
+	r, c := newOwnerRefTestReconciler(t, pod)
+
+	require.NoError(t, r.reconcileRetinaEndpointFromPod(context.Background(), cache.PodCacheObject{Key: key, Pod: pod}))
+
+	got := &retinav1alpha1.RetinaEndpoint{}
+	require.NoError(t, c.Get(context.Background(), key, got))
+	requireOwnedByPod(t, got, key.Name, podUID)
+
+	// The informational spec field still mirrors the Pod's own owners, not the Pod.
+	require.Empty(t, got.Spec.OwnerReferences)
+}
+
+func TestRetinaEndpointReconciler_UpdateAdoptsExistingEndpoint(t *testing.T) {
+	key := types.NamespacedName{Namespace: "default", Name: "pod"}
+	// An endpoint created before owner references were set carries none.
+	existing := &retinav1alpha1.RetinaEndpoint{
+		ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace},
+		Spec:       retinav1alpha1.RetinaEndpointSpec{PodIP: "10.0.0.1"},
+	}
+	pod := runningPodWithUID(key.Name, key.Namespace, "10.0.0.2")
+	r, c := newOwnerRefTestReconciler(t, existing, pod)
+
+	require.NoError(t, r.reconcileRetinaEndpointFromPod(context.Background(), cache.PodCacheObject{Key: key, Pod: pod}))
+
+	got := &retinav1alpha1.RetinaEndpoint{}
+	require.NoError(t, c.Get(context.Background(), key, got))
+	requireOwnedByPod(t, got, key.Name, podUID)
+	require.Equal(t, "10.0.0.2", got.Spec.PodIP, "spec should still be updated")
+}
+
+func TestRetinaEndpointReconciler_UpdateReplacesStalePodOwnerReference(t *testing.T) {
+	key := types.NamespacedName{Namespace: "default", Name: "pod"}
+	// A Pod of the same name was recreated, so the endpoint points at a dead UID.
+	staleUID := types.UID("pod-uid-old")
+	existing := &retinav1alpha1.RetinaEndpoint{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      key.Name,
+			Namespace: key.Namespace,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "v1",
+				Kind:       podKind,
+				Name:       key.Name,
+				UID:        staleUID,
+			}},
+		},
+	}
+	pod := runningPodWithUID(key.Name, key.Namespace, "10.0.0.3")
+	r, c := newOwnerRefTestReconciler(t, existing, pod)
+
+	require.NoError(t, r.reconcileRetinaEndpointFromPod(context.Background(), cache.PodCacheObject{Key: key, Pod: pod}))
+
+	got := &retinav1alpha1.RetinaEndpoint{}
+	require.NoError(t, c.Get(context.Background(), key, got))
+	// requireOwnedByPod asserts exactly one Pod reference, so the stale UID is gone.
+	requireOwnedByPod(t, got, key.Name, podUID)
+}
+
+func TestRetinaEndpointReconciler_StartDeletesOrphans(t *testing.T) {
+	endpoint := func(name string, refs []metav1.OwnerReference) *retinav1alpha1.RetinaEndpoint {
+		return &retinav1alpha1.RetinaEndpoint{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", OwnerReferences: refs},
+		}
+	}
+	podRef := []metav1.OwnerReference{{APIVersion: "v1", Kind: podKind, Name: "owned", UID: podUID}}
+
+	r, c := newOwnerRefTestReconciler(t,
+		// No owner reference and no Pod: orphaned before this shipped, so delete it.
+		endpoint(orphanName, nil),
+		// No owner reference but the Pod exists: its next event adopts it.
+		endpoint("live", nil),
+		runningPodWithUID("live", "default", "10.0.0.1"),
+		// Already has an owner reference: garbage collection handles it.
+		endpoint("owned", podRef),
+	)
+
+	require.NoError(t, r.Start(context.Background()))
+
+	got := &retinav1alpha1.RetinaEndpoint{}
+	err := c.Get(context.Background(), types.NamespacedName{Namespace: "default", Name: orphanName}, got)
+	require.True(t, apierrors.IsNotFound(err), "orphaned RetinaEndpoint should be deleted, got %v", err)
+
+	for _, name := range []string{"live", "owned"} {
+		require.NoErrorf(t, c.Get(context.Background(),
+			types.NamespacedName{Namespace: "default", Name: name}, got), "%s should be kept", name)
+	}
+}
+
+func TestRetinaEndpointReconciler_StartNoEndpoints(t *testing.T) {
+	r, _ := newOwnerRefTestReconciler(t)
+	require.NoError(t, r.Start(context.Background()))
+}
+
 func TestRetinaEndpointReconciler_reqeuePodToRetinaEndpoint(t *testing.T) {
 	type args struct {
 		pod cache.PodCacheObject


### PR DESCRIPTION
# Description

`RetinaEndpoint` objects can be leaked across operator restarts or missed events right now.  This sets up owner references so they are automatically GCed when the pods they track are deleted.

## Related Issue

Solves the TODO referenced here https://github.com/microsoft/retina/blob/0a8044757e75e4104a0ca4c6ea25821854505320/pkg/controllers/operator/retinaendpoint/retinaendpoint_controller.go#L47

## Checklist

- [X] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [X] I have correctly attributed the author(s) of the code.
- [X] I have tested the changes locally.
- [X] I have followed the project's style guidelines.
- [X] I have updated the documentation, if necessary.
- [X] I have added tests, if applicable.

## Additional Notes

Alternatively, explored a periodic reconciliation loop that would also help create RetinaEndpoints that were missed.  This is much more expensive, and we already do that on operator restarts so this approach is far superior.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
