### PR TITLE
fix(server): restrict pprof endpoints to loopback

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4,8 +4,10 @@ package server
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"net/http/pprof"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -18,6 +20,9 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// pprofPathPrefix is the URL prefix used by net/http/pprof handlers.
+const pprofPathPrefix = "/debug/pprof/"
+
 type Server struct {
 	l   *log.ZapLogger
 	mux *chi.Mux
@@ -26,6 +31,10 @@ type Server struct {
 func New(logger *log.ZapLogger) *Server {
 	r := chi.NewRouter()
 	r.Use(
+		// pprofLoopbackOnly MUST run before middleware.RealIP so it inspects
+		// the raw TCP peer address rather than a value derived from
+		// X-Forwarded-For / X-Real-IP headers (which are attacker-controlled).
+		pprofLoopbackOnly,
 		middleware.RequestID,
 		middleware.RealIP,
 		middleware.Recoverer,
@@ -36,6 +45,46 @@ func New(logger *log.ZapLogger) *Server {
 		l:   logger,
 		mux: r,
 	}
+}
+
+// pprofLoopbackOnly restricts /debug/pprof/* endpoints so they only respond
+// to requests arriving on the loopback interface. Any request whose raw TCP
+// remote address is not loopback (127.0.0.0/8 or ::1) receives a 404 — the
+// same status an unregistered path would return, so external scanners cannot
+// fingerprint the presence of pprof.
+//
+// This preserves the existing profiling workflow (`kubectl exec <pod> --
+// curl localhost:10093/debug/pprof/...` and `kubectl port-forward`), both of
+// which terminate on the pod's loopback interface, while blocking access
+// from other pods, other nodes, and off-cluster peers.
+//
+// IMPORTANT: this middleware must be registered before middleware.RealIP;
+// otherwise r.RemoteAddr would be rewritten from X-Forwarded-For and the
+// loopback check would be trivially bypassable via a spoofed header.
+func pprofLoopbackOnly(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, pprofPathPrefix) && !isLoopbackRemoteAddr(r.RemoteAddr) {
+			http.NotFound(w, r)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// isLoopbackRemoteAddr returns true iff addr (in host:port form as provided
+// by http.Request.RemoteAddr) is on the loopback interface.
+func isLoopbackRemoteAddr(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		// Fall back to treating the whole string as the host — some transports
+		// (e.g. unix sockets) leave RemoteAddr without a port.
+		host = addr
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback()
 }
 
 func (rt *Server) SetupHandlers() {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -55,8 +55,10 @@ func New(logger *log.ZapLogger) *Server {
 //
 // This preserves the existing profiling workflow (`kubectl exec <pod> --
 // curl localhost:10093/debug/pprof/...` and `kubectl port-forward`), both of
-// which terminate on the pod's loopback interface, while blocking access
-// from other pods, other nodes, and off-cluster peers.
+// which terminate on the pod's loopback interface, while blocking requests
+// whose TCP peer address is not loopback. Since Retina runs with
+// `hostNetwork: true`, node-local processes and other host-networked pods on
+// the same node can still access these endpoints through loopback.
 //
 // IMPORTANT: this middleware must be registered before middleware.RealIP;
 // otherwise r.RemoteAddr would be rewritten from X-Forwarded-For and the

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -12,7 +14,8 @@ import (
 )
 
 func TestServerShutdown(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, err := log.SetupZapLogger(log.GetDefaultLogOpts())
+	require.NoError(t, err)
 	s := New(log.Logger().Named("http-server"))
 	s.SetupHandlers()
 
@@ -33,7 +36,8 @@ func TestServerShutdown(t *testing.T) {
 }
 
 func TestServerStartOnUsedPort(t *testing.T) {
-	log.SetupZapLogger(log.GetDefaultLogOpts())
+	_, err := log.SetupZapLogger(log.GetDefaultLogOpts())
+	require.NoError(t, err)
 	s := New(log.Logger().Named("http-server"))
 	s.SetupHandlers()
 
@@ -50,7 +54,131 @@ func TestServerStartOnUsedPort(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 	cancel()
-	err := g.Wait()
+	err = g.Wait()
 
 	require.Error(t, err)
+}
+
+// TestPprofRejectsNonLoopback ensures /debug/pprof/* returns 404 when the
+// request's TCP remote address is not on the loopback interface. This is
+// the security guarantee added to close MSRC/CVE for unauthenticated pprof
+// exposure — external peers must not be able to trigger CPU profiling
+// (denial of service) or dump heap/goroutine state (information disclosure).
+func TestPprofRejectsNonLoopback(t *testing.T) {
+	_, err := log.SetupZapLogger(log.GetDefaultLogOpts())
+	require.NoError(t, err)
+	s := New(log.Logger().Named("http-server"))
+	s.SetupHandlers()
+
+	nonLoopbackPeers := []string{
+		"10.0.0.5:54321",     // typical pod IP
+		"192.168.1.10:12345", // typical LAN
+		"203.0.113.7:443",    // typical public
+		"[2001:db8::1]:9999", // typical IPv6
+	}
+	pprofPaths := []string{
+		"/debug/pprof/",
+		"/debug/pprof/cmdline",
+		"/debug/pprof/profile",
+		"/debug/pprof/symbol",
+		"/debug/pprof/trace",
+		"/debug/pprof/heap",
+		"/debug/pprof/goroutine",
+		"/debug/pprof/allocs",
+		"/debug/pprof/block",
+		"/debug/pprof/threadcreate",
+	}
+
+	for _, peer := range nonLoopbackPeers {
+		for _, path := range pprofPaths {
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, path, http.NoBody)
+			req.RemoteAddr = peer
+			rw := httptest.NewRecorder()
+			s.mux.ServeHTTP(rw, req)
+			require.Equalf(t, http.StatusNotFound, rw.Code,
+				"pprof path %s from non-loopback %s must be 404, got %d",
+				path, peer, rw.Code)
+		}
+	}
+}
+
+// TestPprofSpoofedXForwardedForDoesNotBypass verifies that a caller cannot
+// bypass the loopback guard by setting X-Forwarded-For / X-Real-IP to
+// 127.0.0.1. The middleware chain is deliberately ordered so pprof's
+// loopback check runs before chi's RealIP middleware.
+func TestPprofSpoofedXForwardedForDoesNotBypass(t *testing.T) {
+	_, err := log.SetupZapLogger(log.GetDefaultLogOpts())
+	require.NoError(t, err)
+	s := New(log.Logger().Named("http-server"))
+	s.SetupHandlers()
+
+	for _, hdr := range []string{"X-Forwarded-For", "X-Real-IP", "True-Client-IP"} {
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/debug/pprof/heap", http.NoBody)
+		req.RemoteAddr = "10.0.0.5:54321"
+		req.Header.Set(hdr, "127.0.0.1")
+		rw := httptest.NewRecorder()
+		s.mux.ServeHTTP(rw, req)
+		require.Equalf(t, http.StatusNotFound, rw.Code,
+			"spoofed %s: 127.0.0.1 must not bypass pprof loopback guard", hdr)
+	}
+}
+
+// TestPprofAllowsLoopback confirms the guard permits genuine loopback
+// callers (kubectl exec + curl localhost, or kubectl port-forward).
+func TestPprofAllowsLoopback(t *testing.T) {
+	_, err := log.SetupZapLogger(log.GetDefaultLogOpts())
+	require.NoError(t, err)
+	s := New(log.Logger().Named("http-server"))
+	s.SetupHandlers()
+
+	for _, peer := range []string{"127.0.0.1:33333", "127.10.20.30:44444", "[::1]:55555"} {
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/debug/pprof/", http.NoBody)
+		req.RemoteAddr = peer
+		rw := httptest.NewRecorder()
+		s.mux.ServeHTTP(rw, req)
+		require.NotEqualf(t, http.StatusNotFound, rw.Code,
+			"pprof from loopback %s must NOT be 404, got %d", peer, rw.Code)
+	}
+}
+
+// TestMetricsReachableFromAnyPeer confirms /metrics is unaffected by the
+// pprof loopback guard — it must remain reachable from any source.
+func TestMetricsReachableFromAnyPeer(t *testing.T) {
+	_, err := log.SetupZapLogger(log.GetDefaultLogOpts())
+	require.NoError(t, err)
+	s := New(log.Logger().Named("http-server"))
+	s.SetupHandlers()
+
+	for _, peer := range []string{"10.0.0.5:54321", "127.0.0.1:12345"} {
+		req := httptest.NewRequestWithContext(context.Background(), http.MethodGet, "/metrics", http.NoBody)
+		req.RemoteAddr = peer
+		rw := httptest.NewRecorder()
+		s.mux.ServeHTTP(rw, req)
+		require.NotEqualf(t, http.StatusNotFound, rw.Code,
+			"/metrics from %s must not 404, got %d", peer, rw.Code)
+	}
+}
+
+func TestIsLoopbackRemoteAddr(t *testing.T) {
+	cases := []struct {
+		addr string
+		want bool
+	}{
+		{"127.0.0.1:12345", true},
+		{"127.10.20.30:1", true},
+		{"[::1]:80", true},
+		{"10.0.0.1:80", false},
+		{"192.168.1.1:80", false},
+		{"[2001:db8::1]:80", false},
+		{"not-an-address", false},
+		{"", false},
+		// hostless variants
+		{"127.0.0.1", true},
+		{"::1", true},
+		{"10.0.0.1", false},
+	}
+	for _, c := range cases {
+		require.Equalf(t, c.want, isLoopbackRemoteAddr(c.addr),
+			"isLoopbackRemoteAddr(%q)", c.addr)
+	}
 }


### PR DESCRIPTION
# Description

/debug/pprof/* was served on the same public mux as /metrics (0.0.0.0:10093), letting any peer with L3 reach to the pod trigger CPU
profiles or dump heap/goroutine state.

- Add a chi middleware, registered before middleware.RealIP, that returns 404 for pprof requests whose raw TCP RemoteAddr is not loopback. Placing
the check before RealIP ensures X-Forwarded-For / X-Real-IP spoofing cannot bypass it.
- `kubectl exec` + curl localhost and `kubectl port-forward` continue to work unchanged — both terminate on the pod's loopback interface.
/metrics is unaffected.
- Adds regression tests covering non-loopback peers (IPv4 + IPv6), header spoofing, loopback allow-list, and /metrics passthrough.

## Related Issue

n/a

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [x] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Prove that external block works (security-relevant test)

<img width="1703" height="418" alt="image" src="https://github.com/user-attachments/assets/940a3e85-32bd-4230-a9c8-6311af7c79d7" />

Prove loopback works and Pod IP doesn't (even within pod's netns)

<img width="1770" height="488" alt="image" src="https://github.com/user-attachments/assets/dd16e4d9-d0d1-4720-b9f0-310e00b6f05d" />


## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
