### PR TITLE
fix(e2e): enable eBPF Windows plugin for advanced metrics tests

### DIFF
--- a/test/profiles/advanced/values.yaml
+++ b/test/profiles/advanced/values.yaml
@@ -1,5 +1,6 @@
 enablePodLevel: true
 enableAnnotations: true
+enabledPlugin_win: '["hnsstats", "ebpfwindows"]'
 packetParserRingBuffer: "enabled"
 operator:
   enabled: true


### PR DESCRIPTION
# Description

Enable the `ebpfwindows` plugin in the advanced E2E profile while preserving the production-safe Windows chart default.

The Windows advanced-metrics test installs and generates eBPF events, but the advanced Helm upgrade previously retained the default `enabledPlugin_win: ["hnsstats"]`. As a result, `ebpfwindows` did not start and expected metrics such as `networkobservability_forward_bytes` and drop metrics were never produced.

This change configures the advanced E2E profile with:

```yaml
enabledPlugin_win: '["hnsstats", "ebpfwindows"]'
```


## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [X] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
