### PR TITLE
fix(ci): always run e2e job so required PR check reports a status

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -467,7 +467,7 @@ jobs:
 
   - job: e2e
     displayName: Run E2E Tests
-    condition: and(succeeded(), eq(variables['publishImagesAndRunE2E'], 'True'))
+    condition: succeeded()
     dependsOn:
       - manifests
       - event_writer_image
@@ -479,9 +479,13 @@ jobs:
     steps:
       - checkout: self
         fetchDepth: 0
+      - bash: echo "Skipping E2E - not a merge-queue run (publishImagesAndRunE2E=$(publishImagesAndRunE2E))."
+        displayName: Skip E2E (PR build)
+        condition: ne(variables['publishImagesAndRunE2E'], 'True')
       - template: steps/setup-go.yml
       - task: AzureCLI@2
         displayName: Run E2E Tests
+        condition: eq(variables['publishImagesAndRunE2E'], 'True')
         env:
           AZURE_LOCATION: $(AZURE_LOCATION)
           AZURE_AGENT_LINUX_SKU: $(AZURE_AGENT_LINUX_SKU)


### PR DESCRIPTION
# Description

Azure Pipelines reports GH does not report status for skipped jobs. So when PR is raised or changed, E2E does not run and required check never gets green, blocking PR merge. 

This change will make the job always execute and gate the actual e2e execution only for merge queue. This way the required check for PR will be satisfied both in PR validation and on merge queue (if e2e runs successfully).

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
