### PR TITLE
fix(scale-test): add unique runID to scale test telemetry

### DIFF
--- a/.azure-pipelines/scale.yml
+++ b/.azure-pipelines/scale.yml
@@ -87,6 +87,7 @@ jobs:
           TAG: ${{ parameters.image_tag }}
           NODES: ${{ parameters.num_nodes }}
           AZURE_APP_INSIGHTS_KEY: $(AZURE_APP_INSIGHTS_KEY)
+          RUN_ID: $(Build.BuildId)
         inputs:
           azureSubscription: $(azureServiceConnection)
           scriptType: bash

--- a/test/e2e/scale_test.go
+++ b/test/e2e/scale_test.go
@@ -3,10 +3,12 @@
 package retina
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/microsoft/retina/test/e2e/common"
 	"github.com/microsoft/retina/test/e2e/framework/azure"
@@ -70,6 +72,12 @@ func TestE2ERetina_Scale(t *testing.T) {
 	require.NotEmpty(t, RetinaVersion)
 	opt.AdditionalTelemetryProperty["retinaVersion"] = RetinaVersion
 	opt.AdditionalTelemetryProperty["clusterName"] = clusterName
+
+	runID := os.Getenv("RUN_ID")
+	if runID == "" {
+		runID = fmt.Sprintf("local-%d", time.Now().UnixNano())
+	}
+	opt.AdditionalTelemetryProperty["runId"] = runID
 
 	// AppInsightsKey is required for telemetry
 	require.NotEmpty(t, os.Getenv(common.AzureAppInsightsKeyEnv))


### PR DESCRIPTION
# Description

Tags each scale test execution with a `runId` telemetry property propagated through telemetry events for the run. This gives each execution a distinct, traceable identifier in the collected data, improving how individual runs can be distinguished and correlated back to their CI pipeline run.

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
