### PR TITLE
fix(perf-test): remove ebpfwindows from advanced test profile, add dedicated profile for advanced with ebpfwindows

### DIFF
--- a/test/e2e/common/common.go
+++ b/test/e2e/common/common.go
@@ -53,6 +53,9 @@ var (
 	RetinaAdvancedProfilePath = func(rootDir string) string {
 		return filepath.Join(rootDir, "test", "profiles", "advanced", "values.yaml")
 	}
+	RetinaAdvancedWithEbpfWindowsProfilePath = func(rootDir string) string {
+		return filepath.Join(rootDir, "test", "profiles", "advanced", "ebpfwindows-values.yaml")
+	}
 	KubeConfigFilePath = func(rootDir string) string {
 		return filepath.Join(rootDir, "test", "e2e", "test.pem")
 	}

--- a/test/e2e/retina_e2e_test.go
+++ b/test/e2e/retina_e2e_test.go
@@ -63,7 +63,7 @@ func TestE2ERetina(t *testing.T) {
 		jobs.UpgradeAndTestRetinaAdvancedMetrics(
 			common.KubeConfigFilePath(rootDir),
 			common.RetinaChartPath(rootDir),
-			common.RetinaAdvancedProfilePath(rootDir),
+			common.RetinaAdvancedWithEbpfWindowsProfilePath(rootDir),
 			common.TestPodNamespace),
 	)
 	advanceMetricsE2E.Run(ctx)

--- a/test/profiles/advanced/ebpfwindows-values.yaml
+++ b/test/profiles/advanced/ebpfwindows-values.yaml
@@ -1,6 +1,6 @@
 enablePodLevel: true
 enableAnnotations: true
-enabledPlugin_win: '["hnsstats"]'
+enabledPlugin_win: '["hnsstats", "ebpfwindows"]'
 packetParserRingBuffer: "enabled"
 operator:
   enabled: true


### PR DESCRIPTION
# Description

The advanced perf test (`TestE2EPerfRetina`, mode=advanced) was failing due to the `ebpfwindows` plugin, which was should be enabled only for E2E test.

This PR reverts original advanced profile for perf tests to be kept as before and adds a new profile for e2e test with ebpfwindows.

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
