### PR TITLE
fix: optimize install-ebpf-xdp

### DIFF
--- a/.github/workflows/e2e-test-event-writer.yml
+++ b/.github/workflows/e2e-test-event-writer.yml
@@ -18,6 +18,8 @@ env:
   EVENT_WRITER_PATH: "${{ github.workspace }}/test/e2e/tools/event-writer/"
   EBPF_VERSION: "1.1.0"
   XDP_SDK_VERSION: "1.3.0"
+  XDP_RUNTIME_VERSION: "1.3.0"
+  RETINA_EBPF_API_VERSION: "1.6.0"
 
 jobs:
   retina-win-e2e-bpf-images:
@@ -139,7 +141,7 @@ jobs:
           }
 
           $tag = "${{ steps.tag.outputs.tag }}"
-          docker build -f "./Dockerfile" -t "${image}:${tag}" -t "${image}:latest" .
+          docker build -f "./Dockerfile" --build-arg EBPF_VERSION="${{ env.EBPF_VERSION }}" --build-arg XDP_RUNTIME_VERSION="${{ env.XDP_RUNTIME_VERSION }}" --build-arg RETINA_EBPF_API_VERSION="${{ env.RETINA_EBPF_API_VERSION }}" -t "${image}:${tag}" -t "${image}:latest" .
 
           if ("${{ github.event_name }}" -ne "pull_request") {
               docker push "${image}:${tag}"

--- a/test/e2e/tools/event-writer/Dockerfile
+++ b/test/e2e/tools/event-writer/Dockerfile
@@ -1,5 +1,22 @@
 FROM mcr.microsoft.com/windows/servercore:ltsc2022 As base
 
+ARG EBPF_VERSION=1.1.0
+ARG RETINA_EBPF_API_VERSION=1.6.0
+ARG XDP_RUNTIME_VERSION=1.3.0
+ENV EBPF_VERSION=${EBPF_VERSION} \
+    RETINA_EBPF_API_VERSION=${RETINA_EBPF_API_VERSION} \
+    XDP_RUNTIME_VERSION=${XDP_RUNTIME_VERSION}
+
+SHELL ["powershell", "-NoLogo", "-Command"]
+
+# Fetch install artifacts consumed by install-ebpf-xdp.ps1 from C:\install-artifacts.
+RUN $ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue'; \
+    New-Item -ItemType Directory -Path C:\install-artifacts | Out-Null; \
+    Invoke-WebRequest -Uri "https://github.com/microsoft/ebpf-for-windows/releases/download/Release-v$env:EBPF_VERSION/ebpf-for-windows.x64.$env:EBPF_VERSION.msi" -OutFile 'C:\install-artifacts\ebpf-for-windows.x64.msi'; \
+    Invoke-WebRequest -Uri 'https://aka.ms/vs/17/release/vc_redist.x64.exe' -OutFile 'C:\install-artifacts\vc_redist.x64.exe'; \
+    Invoke-WebRequest -Uri "https://www.nuget.org/api/v2/package/Microsoft.Wcn.Observability.eBPF.Retina.x64/$env:RETINA_EBPF_API_VERSION" -OutFile 'C:\install-artifacts\retinaebpfapi.zip'; \
+    Invoke-WebRequest -Uri "https://www.nuget.org/api/v2/package/Microsoft.XDP-for-Windows.Runtime.x64/$env:XDP_RUNTIME_VERSION" -OutFile 'C:\install-artifacts\xdp-runtime.zip'
+
 COPY ./install-ebpf-xdp.ps1 ./install-ebpf-xdp.ps1
 COPY ./x64/Release/bpf_event_writer.sys ./bpf_event_writer.sys
 COPY ./x64/Release/event_writer.exe ./event_writer.exe

--- a/test/e2e/tools/event-writer/Dockerfile
+++ b/test/e2e/tools/event-writer/Dockerfile
@@ -10,12 +10,19 @@ ENV EBPF_VERSION=${EBPF_VERSION} \
 SHELL ["powershell", "-NoLogo", "-Command"]
 
 # Fetch install artifacts consumed by install-ebpf-xdp.ps1 from C:\install-artifacts.
+# Each download is checked to be non-empty so a failed/blocked request fails the
+# build instead of being baked silently into the image.
 RUN $ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue'; \
+    function Get-ValidatedFile { \
+        param([string] $Uri, [string] $OutFile) \
+        Invoke-WebRequest -Uri $Uri -OutFile $OutFile -UseBasicParsing; \
+        if ((Get-Item $OutFile).Length -eq 0) { throw "Downloaded file '$OutFile' is empty" } \
+    }; \
     New-Item -ItemType Directory -Path C:\install-artifacts | Out-Null; \
-    Invoke-WebRequest -Uri "https://github.com/microsoft/ebpf-for-windows/releases/download/Release-v$env:EBPF_VERSION/ebpf-for-windows.x64.$env:EBPF_VERSION.msi" -OutFile 'C:\install-artifacts\ebpf-for-windows.x64.msi'; \
-    Invoke-WebRequest -Uri 'https://aka.ms/vs/17/release/vc_redist.x64.exe' -OutFile 'C:\install-artifacts\vc_redist.x64.exe'; \
-    Invoke-WebRequest -Uri "https://www.nuget.org/api/v2/package/Microsoft.Wcn.Observability.eBPF.Retina.x64/$env:RETINA_EBPF_API_VERSION" -OutFile 'C:\install-artifacts\retinaebpfapi.zip'; \
-    Invoke-WebRequest -Uri "https://www.nuget.org/api/v2/package/Microsoft.XDP-for-Windows.Runtime.x64/$env:XDP_RUNTIME_VERSION" -OutFile 'C:\install-artifacts\xdp-runtime.zip'
+    Get-ValidatedFile -Uri "https://github.com/microsoft/ebpf-for-windows/releases/download/Release-v$env:EBPF_VERSION/ebpf-for-windows.x64.$env:EBPF_VERSION.msi" -OutFile 'C:\install-artifacts\ebpf-for-windows.x64.msi'; \
+    Get-ValidatedFile -Uri 'https://aka.ms/vs/17/release/vc_redist.x64.exe' -OutFile 'C:\install-artifacts\vc_redist.x64.exe'; \
+    Get-ValidatedFile -Uri "https://www.nuget.org/api/v2/package/Microsoft.Wcn.Observability.eBPF.Retina.x64/$env:RETINA_EBPF_API_VERSION" -OutFile 'C:\install-artifacts\retinaebpfapi.zip'; \
+    Get-ValidatedFile -Uri "https://www.nuget.org/api/v2/package/Microsoft.XDP-for-Windows.Runtime.x64/$env:XDP_RUNTIME_VERSION" -OutFile 'C:\install-artifacts\xdp-runtime.zip'
 
 COPY ./install-ebpf-xdp.ps1 ./install-ebpf-xdp.ps1
 COPY ./x64/Release/bpf_event_writer.sys ./bpf_event_writer.sys

--- a/test/e2e/tools/event-writer/install-ebpf-xdp.ps1
+++ b/test/e2e/tools/event-writer/install-ebpf-xdp.ps1
@@ -51,12 +51,18 @@ Function Assert-SoftwareInstalled
    {
       If($SoftwareName)
       {
-         $software = Get-WmiObject -Class:'Win32_Product' | Where-Object -Property:'Name' -like "*$($SoftwareName)*"
+         $uninstallKeyPaths = @(
+            'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*',
+            'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*'
+         )
+
+         $software = Get-ItemProperty -Path:$uninstallKeyPaths -ErrorAction:'SilentlyContinue' |
+            Where-Object -Property:'DisplayName' -like "*$($SoftwareName)*"
 
          If($software -And
             (-Not [String]::IsNullOrWhiteSpace($SoftwareVersion)))
          {
-            $software = $software | Where-Object -Property:'Version' -like "*$($SoftwareVersion)*"
+            $software = $software | Where-Object -Property:'DisplayVersion' -like "*$($SoftwareVersion)*"
          }
 
          If($software)

--- a/test/e2e/tools/event-writer/install-ebpf-xdp.ps1
+++ b/test/e2e/tools/event-writer/install-ebpf-xdp.ps1
@@ -3,9 +3,14 @@
 # This script performs Windows node setup required for Retina e2e tests.
 
 # Version configuration
+# These must match the ARG defaults in ./Dockerfile.
 $Script:eBPFVersion = "1.1.0"
 $Script:RetinaEbpfAPIVersion = "1.6.0"
 $Script:XDPRuntimeVersion = "1.3.0"
+
+# Directory where the Dockerfile places install artifacts (eBPF MSI, VC++ redist,
+# retinaebpfapi and XDP runtime packages).
+$Script:InstallArtifactsPath = "C:\install-artifacts"
 
 Function Assert-SoftwareInstalled
 {
@@ -438,11 +443,14 @@ Function Install-eBPF
       }
 
       Write-Host 'Installing extended Berkley Packet Filter for Windows'
-      # Download eBPF-for-Windows.
-      $packageEbpfUrl  = "https://github.com/microsoft/ebpf-for-windows/releases/download/Release-v$Script:eBPFVersion/ebpf-for-windows.x64.$Script:eBPFVersion.msi"
-      Invoke-WebRequest -Uri $packageEbpfUrl -OutFile "$LocalPath\ebpf-for-windows.x64.$Script:eBPFVersion.msi"
+      $ebpfMsiPath = "$Script:InstallArtifactsPath\ebpf-for-windows.x64.msi"
+      If(-Not (Test-Path $ebpfMsiPath))
+      {
+         Write-Error -Message:"eBPF MSI not found at $ebpfMsiPath"
+         Throw
+      }
 
-      Start-Process -FilePath "$($env:WinDir)\System32\MSIExec.exe" -ArgumentList @("/i", "$LocalPath\ebpf-for-windows.x64.$Script:eBPFVersion.msi", "/qn", "INSTALLFOLDER=`"$($env:ProgramFiles)\ebpf-for-windows`"", "ADDLOCAL=eBPF_Runtime_Components") -PassThru | Wait-Process
+      Start-Process -FilePath "$($env:WinDir)\System32\MSIExec.exe" -ArgumentList @("/i", "$ebpfMsiPath", "/qn", "INSTALLFOLDER=`"$($env:ProgramFiles)\ebpf-for-windows`"", "ADDLOCAL=eBPF_Runtime_Components") -PassThru | Wait-Process
       If(-Not (Assert-SoftwareInstalled -ServiceName:'eBPFCore' -Silent) -Or
          -Not (Assert-SoftwareInstalled -ServiceName:'NetEbpfExt' -Silent))
       {
@@ -510,10 +518,13 @@ Function Install-VCRuntime
 
       Write-Host 'Installing Visual C++ Redistributable (x64)'
 
-      $vcRedistUrl = "https://aka.ms/vs/17/release/vc_redist.x64.exe"
-      $vcRedistPath = "$env:TEMP\vc_redist.x64.exe"
+      $vcRedistPath = "$Script:InstallArtifactsPath\vc_redist.x64.exe"
+      If(-Not (Test-Path $vcRedistPath))
+      {
+         Write-Error "VC++ Redistributable installer not found at $vcRedistPath"
+         Throw
+      }
 
-      Invoke-WebRequest -Uri $vcRedistUrl -OutFile $vcRedistPath
       Start-Process -FilePath $vcRedistPath -ArgumentList @("/install", "/quiet", "/norestart") -Wait
 
       # Verify installation
@@ -532,10 +543,6 @@ Function Install-VCRuntime
    {
       $isSuccess = $false
       Write-Host "Visual C++ Runtime install failed: $_"
-   }
-   Finally
-   {
-      Remove-Item -Path "$env:TEMP\vc_redist.x64.exe" -Force -ErrorAction SilentlyContinue
    }
 
    Return $isSuccess
@@ -567,13 +574,17 @@ Function Install-RetinaEbpfAPI
          return $isSuccess
       }
 
-      Write-Host 'Installing retinaebpfapi.dll from NuGet'
+      Write-Host 'Installing retinaebpfapi.dll'
 
-      $nugetUrl = "https://www.nuget.org/api/v2/package/Microsoft.Wcn.Observability.eBPF.Retina.x64/$Script:RetinaEbpfAPIVersion"
-      $zipPath = "$env:TEMP\eBPFRetina.zip"
+      $zipPath = "$Script:InstallArtifactsPath\retinaebpfapi.zip"
       $extractPath = "$env:TEMP\eBPFRetina"
 
-      Invoke-WebRequest -Uri $nugetUrl -OutFile $zipPath
+      If(-Not (Test-Path $zipPath))
+      {
+         Write-Error "retinaebpfapi NuGet package not found at $zipPath"
+         Throw
+      }
+
       Expand-Archive -Path $zipPath -DestinationPath $extractPath -Force
 
       $dllSource = "$extractPath\build\native\bin\retinaebpfapi.dll"
@@ -593,8 +604,7 @@ Function Install-RetinaEbpfAPI
    }
    Finally
    {
-      # Cleanup
-      Remove-Item -Path "$env:TEMP\eBPFRetina.zip" -Force -ErrorAction SilentlyContinue
+      # Cleanup extracted contents; the source zip stays in $Script:InstallArtifactsPath.
       Remove-Item -Path "$env:TEMP\eBPFRetina" -Recurse -Force -ErrorAction SilentlyContinue
    }
 
@@ -640,16 +650,17 @@ Function Install-XDP
          return $isSuccess
       }
 
-      # Download and extract the XDP runtime NuGet package.
       Write-Host 'Installing eXpress Data Path for Windows'
-      $xdpRuntimeVersion = $Script:XDPRuntimeVersion
-      $xdpNupkgUrl = "https://www.nuget.org/api/v2/package/Microsoft.XDP-for-Windows.Runtime.x64/$xdpRuntimeVersion"
-      $xdpZipPath = "$LocalPath\Microsoft.XDP-for-Windows.Runtime.x64.$xdpRuntimeVersion.zip"
+      $xdpZipPath = "$Script:InstallArtifactsPath\xdp-runtime.zip"
       $xdpExtractPath = "$LocalPath\xdp-runtime"
 
-      Invoke-WebRequest -Uri $xdpNupkgUrl -OutFile $xdpZipPath
+      If(-Not (Test-Path $xdpZipPath))
+      {
+         Write-Error -Message:"XDP runtime NuGet package not found at $xdpZipPath"
+         Throw
+      }
+
       Expand-Archive -Path $xdpZipPath -DestinationPath $xdpExtractPath -Force
-      Remove-Item -Path $xdpZipPath -Force
 
       # Install XDP using xdp-setup.ps1 from the runtime package
       $xdpSetupScript = Get-ChildItem -Path $xdpExtractPath -Recurse -Filter "xdp-setup.ps1" | Select-Object -First 1
@@ -842,7 +853,7 @@ Function Uninstall-eBPF
             }
          }
 
-         Start-Process -FilePath:"$($env:WinDir)\System32\MSIExec.exe" -ArgumentList @("/x $($LocalPath)\ebpf-for-windows.x64.$Script:eBPFVersion.msi", '/qn') -PassThru | Wait-Process
+         Start-Process -FilePath:"$($env:WinDir)\System32\MSIExec.exe" -ArgumentList @("/x $($Script:InstallArtifactsPath)\ebpf-for-windows.x64.msi", '/qn') -PassThru | Wait-Process
       }
 
       If((Assert-SoftwareInstalled -ServiceName:'eBPFCore' -Silent) -or

--- a/test/e2e/yaml/windows/install-ebpf-xdp.yaml
+++ b/test/e2e/yaml/windows/install-ebpf-xdp.yaml
@@ -15,7 +15,7 @@ spec:
       containers:
       - name: install-ebpf-xdp-container
         image: "{{CONTAINER_IMAGE}}"
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         command:
           - powershell.exe
           - -command


### PR DESCRIPTION
# Description

install-ebpf-xdp daemonset is frequently timing out in E2E tests. This PR makes some changes to reduce the DaemonSet execution time.

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
