### PR TITLE
fix(ci): grant packages write to the event-writer workflow call

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -32,6 +32,12 @@ jobs:
   event-writer-image:
     name: Build E2E Event Writer Image
     if: ${{ github.event_name == 'merge_group' }}
+    # The called workflow declares packages: write. A called workflow cannot
+    # hold more permissions than the calling job, so the job has to grant it.
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
     uses: ./.github/workflows/e2e-test-event-writer.yml
     secrets: inherit
 


### PR DESCRIPTION
# Description

The `Build Images` workflow (`images.yaml`) has failed at startup on every run since 2026-09-03, for pull requests and merge-queue runs alike. GitHub reports "This run likely failed because of a workflow file issue" and starts no jobs, so the merge queue has had no Build Images or e2e signal since then.

#2625 added the `event-writer-image` job, which calls the reusable workflow `e2e-test-event-writer.yml`. That workflow declares `packages: write`. `images.yaml` grants only `contents: read` and `id-token: write`. A called workflow cannot hold more permissions than the calling job, so GitHub rejects the call while it parses the workflow, before any job or `if:` condition runs. The last successful run of `images.yaml` finished at 17:20 UTC on 2026-09-03; #2625 merged at 17:30 UTC the same day, and the first startup failure was the run on #2625 itself.

This PR grants the three permissions the called workflow declares on the `event-writer-image` job. The workflow-level block is unchanged, so no other job gains `packages: write`.

## Related Issue

N/A — found while moving the ADO CI pipeline to OneBranch (#2746).

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally. (N/A — workflow-only change; the workflow run on this PR is the test.)
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary. (N/A)
- [ ] I have added tests, if applicable. (N/A — workflow-only change)

## Screenshots (if applicable) or Testing Completed

The `Build Images` run on this PR started and completed with every job green, the first run of this workflow to get past startup since 2026-09-03. Before the fix, the same PR-mode run failed at startup with no jobs. The `event-writer-image` job itself runs only in merge-queue runs and shows as skipped here, but GitHub validates the permission grant for every run regardless of the `if:` condition.

## Additional Notes

N/A.
