### PR TITLE
fix: increase readinessProbe timeoutSeconds to avoid false negatives on Windows

### DIFF
--- a/test/e2e/retina_e2e_test.go
+++ b/test/e2e/retina_e2e_test.go
@@ -41,7 +41,7 @@ func TestE2ERetina(t *testing.T) {
 	installEbpfAndXDP.Run(ctx)
 
 	// Wait for the HPC pod to be ready. Maximum wait time is 15 minutes in case the Pods are very slow to come up.
-	err = kubernetes.WaitForPodReadyWithTimeOut(context.TODO(), common.KubeConfigFilePath(rootDir), "install-ebpf-xdp", "name=install-ebpf-xdp", 20*time.Minute)
+	err = kubernetes.WaitForPodReadyWithTimeOut(context.TODO(), common.KubeConfigFilePath(rootDir), "install-ebpf-xdp", "name=install-ebpf-xdp", 15*time.Minute)
 	require.NoError(t, err)
 
 	// Load and pin BPF Maps

--- a/test/e2e/yaml/windows/install-ebpf-xdp.yaml
+++ b/test/e2e/yaml/windows/install-ebpf-xdp.yaml
@@ -28,6 +28,7 @@ spec:
               - if (!(Test-Path C:\install-ebpf-xdp-probe-ready)) { exit 1 }
           initialDelaySeconds: 10
           periodSeconds: 5
+          timeoutSeconds: 10
       hostNetwork: true
       nodeSelector:
         kubernetes.io/os: windows


### PR DESCRIPTION
# Description

This PR increases readinessProbe timeoutSeconds to avoid false negatives on Windows

Successful E2E execution: https://github-private.visualstudio.com/microsoft/_build/results?buildId=125716&view=results

## Related Issue

If this pull request is related to any issue, please mention it here. Additionally, make sure that the issue is assigned to you before submitting this pull request.

## Checklist

- [ ] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [ ] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [ ] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally.
- [ ] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [ ] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

Please add any relevant screenshots or GIFs to showcase the changes made.

## Additional Notes

Add any additional notes or context about the pull request here.

---

Please refer to the [CONTRIBUTING.md](../CONTRIBUTING.md) file for more information on how to contribute to this project.
