### PR TITLE
fix(capture): scope podSelector/podNames targets to the Capture's own namespace

### DIFF
--- a/pkg/capture/crd_to_job.go
+++ b/pkg/capture/crd_to_job.go
@@ -734,7 +734,7 @@ func (translator *CaptureToPodTranslator) getCaptureTargetsOnNode(ctx context.Co
 		}
 	}
 	if captureTarget.PodSelector != nil {
-		if captureTargetsOnNode, err = translator.calculateCaptureTargetsByPodSelector(ctx, captureTarget); err != nil {
+		if captureTargetsOnNode, err = translator.calculateCaptureTargetsByPodSelector(ctx, captureTarget, namespace); err != nil {
 			return nil, err
 		}
 	}
@@ -820,12 +820,13 @@ func (translator *CaptureToPodTranslator) calculateCaptureTargetsByNodeSelector(
 	return captureTargetOnNode, nil
 }
 
-func (translator *CaptureToPodTranslator) calculateCaptureTargetsByPodSelector(ctx context.Context, captureTarget retinav1alpha1.CaptureTarget) (*CaptureTargetsOnNode, error) {
+func (translator *CaptureToPodTranslator) calculateCaptureTargetsByPodSelector(ctx context.Context, captureTarget retinav1alpha1.CaptureTarget, namespace string) (*CaptureTargetsOnNode, error) {
 	captureTargetOnNode := &CaptureTargetsOnNode{}
+	// Without an explicit NamespaceSelector, the lookup is scoped to the Capture's own namespace only.
 	nsList := &corev1.NamespaceList{Items: []corev1.Namespace{
 		{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: corev1.NamespaceDefault,
+				Name: namespace,
 			},
 		},
 	}}

--- a/pkg/capture/crd_to_job.go
+++ b/pkg/capture/crd_to_job.go
@@ -44,6 +44,7 @@ var (
 	errPodNamesIncompat         = errors.New("PodNames is not compatible with NamespaceSelector or PodSelector, please use one or the other")
 	errFileCountRequiresMaxSize = errors.New("fileCount requires maxCaptureSize to be set as per-file size limit")
 	errInvalidIPAddress         = errors.New("is not a valid IP address")
+	errEmptyCaptureNamespace    = errors.New("capture namespace must not be empty when resolving pod selector or pod names targets")
 	// errTcpdumpFilterIncompatibleWithSourceDestIPs: obtainAndValidateUserFilter gives the generated pcapFilter
 	// precedence over the deprecated tcpdumpFilter, so combining them would silently drop the tcpdumpFilter.
 	errTcpdumpFilterIncompatibleWithSourceDestIPs = errors.New("tcpdumpFilter (deprecated) cannot be combined with sourceIPs/destinationIPs; use pcapFilter instead")
@@ -822,6 +823,10 @@ func (translator *CaptureToPodTranslator) calculateCaptureTargetsByNodeSelector(
 
 func (translator *CaptureToPodTranslator) calculateCaptureTargetsByPodSelector(ctx context.Context, captureTarget retinav1alpha1.CaptureTarget, namespace string) (*CaptureTargetsOnNode, error) {
 	captureTargetOnNode := &CaptureTargetsOnNode{}
+
+	if captureTarget.NamespaceSelector == nil && namespace == "" {
+		return nil, errEmptyCaptureNamespace
+	}
 	// Without an explicit NamespaceSelector, the lookup is scoped to the Capture's own namespace only.
 	nsList := &corev1.NamespaceList{Items: []corev1.Namespace{
 		{
@@ -835,7 +840,7 @@ func (translator *CaptureToPodTranslator) calculateCaptureTargetsByPodSelector(c
 		var err error
 		labelSelector, err := labels.Parse(metav1.FormatLabelSelector(captureTarget.NamespaceSelector))
 		if err != nil {
-			translator.l.Error("PersistentVolumeClaim is not empty", zap.String("namespaceSelector", captureTarget.NamespaceSelector.String()), zap.Error(err))
+			translator.l.Error("Failed to parse namespace selector to label", zap.String("namespaceSelector", captureTarget.NamespaceSelector.String()), zap.Error(err))
 			return nil, err
 		}
 		nsListOpt := metav1.ListOptions{
@@ -876,6 +881,10 @@ func (translator *CaptureToPodTranslator) calculateCaptureTargetsByPodSelector(c
 
 func (translator *CaptureToPodTranslator) calculateCaptureTargetsByPodNames(ctx context.Context, captureTarget retinav1alpha1.CaptureTarget, namespace string) (*CaptureTargetsOnNode, error) {
 	captureTargetOnNode := &CaptureTargetsOnNode{}
+
+	if namespace == "" {
+		return nil, errEmptyCaptureNamespace
+	}
 
 	// Get the pods by their names from the specified namespace
 	for _, podName := range captureTarget.PodNames {

--- a/pkg/capture/crd_to_job_test.go
+++ b/pkg/capture/crd_to_job_test.go
@@ -142,8 +142,10 @@ func Test_CaptureToPodTranslator_GetCaptureTargetsOnNode(t *testing.T) {
 
 	cases := []struct {
 		name string
-		// namespace is the Capture's own namespace passed to getCaptureTargetsOnNode. Defaults to "default" when empty.
-		namespace                string
+		// namespace is the Capture's own namespace passed to getCaptureTargetsOnNode. Defaults to "default" when empty, unless emptyNamespace is set.
+		namespace string
+		// emptyNamespace passes namespace as-is (skipping the "default" fallback above) to test the empty-namespace guard.
+		emptyNamespace           bool
 		captureTarget            retinav1alpha1.CaptureTarget
 		nodeList                 *corev1.NodeList
 		namespaceList            *corev1.NamespaceList
@@ -420,6 +422,62 @@ func Test_CaptureToPodTranslator_GetCaptureTargetsOnNode(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			// NamespaceSelector must take precedence over the Capture's own namespace, not be merged/OR'd with it.
+			name:      "NamespaceSelector takes precedence over the Capture's own namespace",
+			namespace: "tenant-a",
+			captureTarget: retinav1alpha1.CaptureTarget{
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"name": "other-ns"},
+				},
+				PodSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "target"},
+				},
+			},
+			namespaceList: &corev1.NamespaceList{
+				Items: []corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: "other-ns", Labels: map[string]string{"name": "other-ns"}}}},
+			},
+			podList: &corev1.PodList{
+				Items: []corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "target-tenant", Namespace: "tenant-a", Labels: map[string]string{"app": "target"}},
+						Spec:       corev1.PodSpec{NodeName: "node1"},
+						Status: corev1.PodStatus{
+							PodIP:  "10.244.0.9",
+							PodIPs: []corev1.PodIP{{IP: "10.244.0.9"}},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "target-other", Namespace: "other-ns", Labels: map[string]string{"app": "target"}},
+						Spec:       corev1.PodSpec{NodeName: "node1"},
+						Status: corev1.PodStatus{
+							PodIP:  "10.244.0.10",
+							PodIPs: []corev1.PodIP{{IP: "10.244.0.10"}},
+						},
+					},
+				},
+			},
+			wantCaptureTargetsOnNode: &CaptureTargetsOnNode{
+				"node1": CaptureTarget{
+					PodIpAddresses: []string{"10.244.0.10"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			// Guards against the self-namespace fallback silently becoming an all-namespaces list, since
+			// client-go treats Pods("").List(...) as "all namespaces".
+			name:           "PodSelector without NamespaceSelector and an empty namespace is rejected",
+			namespace:      "",
+			emptyNamespace: true,
+			captureTarget: retinav1alpha1.CaptureTarget{
+				PodSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "target"},
+				},
+			},
+			wantCaptureTargetsOnNode: nil,
+			wantErr:                  true,
+		},
 	}
 
 	for _, tt := range cases {
@@ -438,7 +496,7 @@ func Test_CaptureToPodTranslator_GetCaptureTargetsOnNode(t *testing.T) {
 			k8sClient := fakeclientset.NewSimpleClientset(objects...)
 			captureToPodTranslator := NewCaptureToPodTranslatorForTest(k8sClient)
 			ns := tt.namespace
-			if ns == "" {
+			if ns == "" && !tt.emptyNamespace {
 				ns = "default"
 			}
 			gotCaptureTargetsOnNode, err := captureToPodTranslator.getCaptureTargetsOnNode(ctx, tt.captureTarget, ns)
@@ -1875,7 +1933,8 @@ func Test_CaptureToPodTranslator_TranslateCaptureToJobs(t *testing.T) {
 			name: "tcpdumpfilter: pod ip address and tcpdumpfilter coexist",
 			capture: retinav1alpha1.Capture{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: captureName,
+					Name:      captureName,
+					Namespace: "default",
 				},
 				Status: retinav1alpha1.CaptureStatus{
 					StartTime: timestamp,
@@ -1956,7 +2015,8 @@ func Test_CaptureToPodTranslator_TranslateCaptureToJobs(t *testing.T) {
 			name: "tcpdumpfilter: pod ip adddress exits",
 			capture: retinav1alpha1.Capture{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: captureName,
+					Name:      captureName,
+					Namespace: "default",
 				},
 				Status: retinav1alpha1.CaptureStatus{
 					StartTime: timestamp,
@@ -2035,7 +2095,8 @@ func Test_CaptureToPodTranslator_TranslateCaptureToJobs(t *testing.T) {
 			name: "tcpdumpfilter: dual-stack Pod",
 			capture: retinav1alpha1.Capture{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: captureName,
+					Name:      captureName,
+					Namespace: "default",
 				},
 				Status: retinav1alpha1.CaptureStatus{
 					StartTime: timestamp,
@@ -2117,7 +2178,8 @@ func Test_CaptureToPodTranslator_TranslateCaptureToJobs(t *testing.T) {
 			name: "netshfilter: dual-stack Pod",
 			capture: retinav1alpha1.Capture{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: captureName,
+					Name:      captureName,
+					Namespace: "default",
 				},
 				Status: retinav1alpha1.CaptureStatus{
 					StartTime: timestamp,
@@ -2200,7 +2262,8 @@ func Test_CaptureToPodTranslator_TranslateCaptureToJobs(t *testing.T) {
 			name: "netshfilter: pod ip address and tcpdumpfilter coexist",
 			capture: retinav1alpha1.Capture{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: captureName,
+					Name:      captureName,
+					Namespace: "default",
 				},
 				Status: retinav1alpha1.CaptureStatus{
 					StartTime: timestamp,
@@ -2302,6 +2365,8 @@ func Test_CaptureToPodTranslator_TranslateCaptureToJobs(t *testing.T) {
 				return
 			}
 			job := commonJob.DeepCopy()
+			job.Namespace = tt.capture.Namespace
+			job.Spec.Template.Namespace = tt.capture.Namespace
 			job.Spec.Template.Spec.Containers[0].Env = tt.podEnv
 			job.Spec.Template.Spec.Containers[0].VolumeMounts = tt.volumeMounts
 			job.Spec.Template.Spec.Volumes = tt.volumes
@@ -3574,6 +3639,29 @@ func TestGetCaptureTargetsOnNode_WithPodNames(t *testing.T) {
 			},
 			wantErr:     false,
 			wantNodeLen: 1,
+		},
+		{
+			name:      "empty namespace is rejected",
+			podNames:  []string{"test-pod-1"},
+			namespace: "",
+			pods: []*corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod-1",
+						Namespace: "default",
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "node1",
+					},
+					Status: corev1.PodStatus{
+						PodIPs: []corev1.PodIP{
+							{IP: "10.0.0.1"},
+						},
+					},
+				},
+			},
+			wantErr:     true,
+			wantNodeLen: 0,
 		},
 		{
 			name:        "empty pod names list",

--- a/pkg/capture/crd_to_job_test.go
+++ b/pkg/capture/crd_to_job_test.go
@@ -141,7 +141,9 @@ func Test_CaptureToPodTranslator_GetCaptureTargetsOnNode(t *testing.T) {
 	defer cancel()
 
 	cases := []struct {
-		name                     string
+		name string
+		// namespace is the Capture's own namespace passed to getCaptureTargetsOnNode. Defaults to "default" when empty.
+		namespace                string
 		captureTarget            retinav1alpha1.CaptureTarget
 		nodeList                 *corev1.NodeList
 		namespaceList            *corev1.NamespaceList
@@ -381,6 +383,43 @@ func Test_CaptureToPodTranslator_GetCaptureTargetsOnNode(t *testing.T) {
 			wantCaptureTargetsOnNode: nil,
 			wantErr:                  true,
 		},
+		{
+			// Regression test for RETINA-001: a PodSelector-only CaptureTarget (no NamespaceSelector) must be
+			// scoped to the Capture's own namespace, not fall back to a hardcoded "default" namespace.
+			name:      "PodSelector without NamespaceSelector is scoped to the Capture's own namespace",
+			namespace: "tenant-a",
+			captureTarget: retinav1alpha1.CaptureTarget{
+				PodSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "target"},
+				},
+			},
+			podList: &corev1.PodList{
+				Items: []corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "target-default", Namespace: "default", Labels: map[string]string{"app": "target"}},
+						Spec:       corev1.PodSpec{NodeName: "node1"},
+						Status: corev1.PodStatus{
+							PodIP:  "10.244.0.7",
+							PodIPs: []corev1.PodIP{{IP: "10.244.0.7"}},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "target-tenant", Namespace: "tenant-a", Labels: map[string]string{"app": "target"}},
+						Spec:       corev1.PodSpec{NodeName: "node1"},
+						Status: corev1.PodStatus{
+							PodIP:  "10.244.0.8",
+							PodIPs: []corev1.PodIP{{IP: "10.244.0.8"}},
+						},
+					},
+				},
+			},
+			wantCaptureTargetsOnNode: &CaptureTargetsOnNode{
+				"node1": CaptureTarget{
+					PodIpAddresses: []string{"10.244.0.8"},
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range cases {
@@ -398,7 +437,11 @@ func Test_CaptureToPodTranslator_GetCaptureTargetsOnNode(t *testing.T) {
 
 			k8sClient := fakeclientset.NewSimpleClientset(objects...)
 			captureToPodTranslator := NewCaptureToPodTranslatorForTest(k8sClient)
-			gotCaptureTargetsOnNode, err := captureToPodTranslator.getCaptureTargetsOnNode(ctx, tt.captureTarget, "default")
+			ns := tt.namespace
+			if ns == "" {
+				ns = "default"
+			}
+			gotCaptureTargetsOnNode, err := captureToPodTranslator.getCaptureTargetsOnNode(ctx, tt.captureTarget, ns)
 			if tt.wantErr != (err != nil) {
 				t.Errorf("getCaptureTargetsOnNode() want(%t) error, got error %s", tt.wantErr, err)
 			}


### PR DESCRIPTION
# Fix: scope Capture `podSelector`/`podNames` targets to the Capture's own namespace

## Description

`Capture` resources that target Pods via `podSelector` (without an explicit `namespaceSelector`) were resolved against a hardcoded `default` namespace instead of the Capture's own namespace. A `Capture` created in namespace `tenant-a` with only `spec.captureConfiguration.captureTarget.podSelector` set would silently capture traffic from Pods in `default`, and any namespace whose name resolved to an empty string could fall through to matching Pods across **all** namespaces (via `Pods("").List(...)`), since client-go treats an empty namespace as "all namespaces" for list operations. This allowed a user with permission to create `Capture` CRs in their own namespace to target Pods outside of it.

This PR:
- Threads the Capture's own `namespace` through `getCaptureTargetsOnNode` → `calculateCaptureTargetsByPodSelector`, seeding the namespace lookup with the Capture's own namespace instead of the hardcoded `corev1.NamespaceDefault`. A `namespaceSelector`, when explicitly set, still takes precedence and can expand the search to other namespaces.
- Adds a defensive guard (`errEmptyCaptureNamespace`) in both `calculateCaptureTargetsByPodSelector` and `calculateCaptureTargetsByPodNames` that fails loudly instead of silently falling back to an all-namespaces list when the namespace is empty and no `namespaceSelector` is set.
- Fixes a copy-pasted log message (`"PersistentVolumeClaim is not empty"` → `"Failed to parse namespace selector to label"`) encountered while reviewing this code path.

## Related Issue

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`).
- [x] I have correctly attributed the author(s) of the code.
- [x] I have tested the changes locally.
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary.
- [x] I have added tests, if applicable.

## Screenshots (if applicable) or Testing Completed

- `go build ./pkg/... ./cli/... ./operator/... ./controller/...` — passes.
- `go test ./pkg/capture/... ./pkg/controllers/operator/capture/...` — all tests pass, including new regression tests:
  - `PodSelector without NamespaceSelector is scoped to the Capture's own namespace`
  - `NamespaceSelector takes precedence over the Capture's own namespace`
  - `PodSelector without NamespaceSelector and an empty namespace is rejected`
  - `empty namespace is rejected` (PodNames path)
- Live-verified against a real `kind` cluster running the built `retina-operator` image: created Pods in `default` and `tenant-a`, then a `Capture` in `tenant-a` with only a `podSelector` matching both Pods' labels. Before the fix, `TCPDUMP_FILTER` resolved to the `default` Pod's IP; after the fix, it correctly resolves only to the `tenant-a` Pod's IP.

## Additional Notes

- `gofmt` clean on both modified files.
- Five pre-existing test fixtures in `Test_CaptureToPodTranslator_TranslateCaptureToJobs` implicitly relied on the old vulnerable "empty namespace = all namespaces" behavior (they never set `Capture.ObjectMeta.Namespace`). These were updated to set an explicit namespace matching their Pod fixtures, and the expected Job comparison now propagates `capture.Namespace` onto the expected Job/PodTemplate, matching real behavior.
