### PR TITLE
fix(ci): post the required e2e check on PR builds

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -355,79 +355,93 @@ extends:
         displayName: Run
         dependsOn: build
         jobs:
-          # The multi-arch manifests are created at the start of the e2e job.
-          # A separate job would add several minutes of OneBranch job setup
-          # and scans to the critical path.
-          - job: e2e
-            displayName: E2E Tests
-            condition: and(succeeded(), eq(variables['publishImagesAndRunE2E'], 'True'))
-            timeoutInMinutes: 90
-            pool:
-              type: linux
-            variables:
-              ob_outputDirectory: $(Build.SourcesDirectory)/out
-              CLUSTER_NAME: retina-e2e-$(Build.BuildId)-$(System.JobAttempt)
-            steps:
-              # `make manifest` creates the multi-arch indexes from the
-              # per-platform tags that the image jobs pushed. The OneBranch
-              # Linux container has no docker CLI, so the oras script replaces
-              # `docker buildx imagetools create` as the backend.
-              - task: AzureCLI@2
-                displayName: Create multi-arch manifests
-                inputs:
-                  azureSubscription: $(azureServiceConnection)
-                  scriptType: bash
-                  scriptLocation: inlineScript
-                  inlineScript: |
-                    set -euo pipefail
-                    registry="$(ACR_NAME)"
-                    ns="$(imageNamespace)"
-                    tag="$(TAG)"
-                    az acr login --name "$registry" --expose-token --query accessToken -o tsv \
-                      | oras login "$registry" --username 00000000-0000-0000-0000-000000000000 --password-stdin
-                    for component in retina operator shell kubectl-retina; do
-                      make manifest COMPONENT="$component" IMAGE_REGISTRY="$registry" \
-                        IMAGE_NAMESPACE="$ns" TAG="$tag" MANIFEST_CREATE=hack/scripts/oras-index.sh
-                    done
-                    # The e2e tests pull the event writer at the run tag. Its image
-                    # job tags by attempt, so publish the newest attempt under the
-                    # run tag as a one-entry index.
-                    hack/scripts/oras-index.sh "$registry/$ns/test/e2e-test-event-writer:$tag" \
-                      "$registry/$ns/test/e2e-test-event-writer:$tag"
-              # The capture scenario shells out to kubectl, which the OneBranch
-              # Linux container does not ship.
-              - bash: tdnf install -y kubernetes-client && kubectl version --client
-                displayName: Install kubectl
-              - task: AzureCLI@2
-                displayName: Run E2E Tests
-                env:
-                  AZURE_LOCATION: $(AZURE_LOCATION)
-                  AZURE_AGENT_LINUX_SKU: $(AZURE_AGENT_LINUX_SKU)
-                  AZURE_AGENT_WINDOWS_SKU: $(AZURE_AGENT_WINDOWS_SKU)
-                  AZURE_AGENT_LINUX_ARM_SKU: $(AZURE_AGENT_LINUX_ARM_SKU)
-                inputs:
-                  azureSubscription: $(azureServiceConnection)
-                  scriptType: bash
-                  scriptLocation: inlineScript
-                  inlineScript: |
-                    set -euo pipefail
-                    export AZURE_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
-                    go test -v ./test/e2e/. -timeout 60m -tags=e2e -count=1 -args \
-                      -image-tag=$(TAG) \
-                      -image-registry=$(ACR_NAME) \
-                      -image-namespace=$(imageNamespace)
-              - task: AzureCLI@2
-                displayName: Cleanup resource group
-                condition: always()
-                inputs:
-                  azureSubscription: $(azureServiceConnection)
-                  scriptType: bash
-                  scriptLocation: inlineScript
-                  inlineScript: |
-                    if az group exists --name "$(CLUSTER_NAME)" 2>/dev/null | grep -q true; then
-                      echo "Deleting resource group $(CLUSTER_NAME)..."
-                      az group delete --name "$(CLUSTER_NAME)" --yes --no-wait || true
-                    fi
+          # PR builds publish no images, so there is nothing to test. Main
+          # requires the check "CI (Build Images) (Run E2E Tests)" on every
+          # pull request, and Azure DevOps posts no check for a skipped job.
+          # A server job with the same name posts the check in seconds.
+          - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+            - job: e2e
+              displayName: E2E Tests
+              pool:
+                type: agentless
+              steps:
+                - task: Delay@1
+                  inputs:
+                    delayForMinutes: '0'
+          - ${{ else }}:
+            # The multi-arch manifests are created at the start of the e2e job.
+            # A separate job would add several minutes of OneBranch job setup
+            # and scans to the critical path.
+            - job: e2e
+              displayName: E2E Tests
+              condition: and(succeeded(), eq(variables['publishImagesAndRunE2E'], 'True'))
+              timeoutInMinutes: 90
+              pool:
+                type: linux
+              variables:
+                ob_outputDirectory: $(Build.SourcesDirectory)/out
+                CLUSTER_NAME: retina-e2e-$(Build.BuildId)-$(System.JobAttempt)
+              steps:
+                # `make manifest` creates the multi-arch indexes from the
+                # per-platform tags that the image jobs pushed. The OneBranch
+                # Linux container has no docker CLI, so the oras script replaces
+                # `docker buildx imagetools create` as the backend.
+                - task: AzureCLI@2
+                  displayName: Create multi-arch manifests
+                  inputs:
+                    azureSubscription: $(azureServiceConnection)
+                    scriptType: bash
+                    scriptLocation: inlineScript
+                    inlineScript: |
+                      set -euo pipefail
+                      registry="$(ACR_NAME)"
+                      ns="$(imageNamespace)"
+                      tag="$(TAG)"
+                      az acr login --name "$registry" --expose-token --query accessToken -o tsv \
+                        | oras login "$registry" --username 00000000-0000-0000-0000-000000000000 --password-stdin
+                      for component in retina operator shell kubectl-retina; do
+                        make manifest COMPONENT="$component" IMAGE_REGISTRY="$registry" \
+                          IMAGE_NAMESPACE="$ns" TAG="$tag" MANIFEST_CREATE=hack/scripts/oras-index.sh
+                      done
+                      # The e2e tests pull the event writer at the run tag. Its image
+                      # job tags by attempt, so publish the newest attempt under the
+                      # run tag as a one-entry index.
+                      hack/scripts/oras-index.sh "$registry/$ns/test/e2e-test-event-writer:$tag" \
+                        "$registry/$ns/test/e2e-test-event-writer:$tag"
+                # The capture scenario shells out to kubectl, which the OneBranch
+                # Linux container does not ship.
+                - bash: tdnf install -y kubernetes-client && kubectl version --client
+                  displayName: Install kubectl
+                - task: AzureCLI@2
+                  displayName: Run E2E Tests
+                  env:
+                    AZURE_LOCATION: $(AZURE_LOCATION)
+                    AZURE_AGENT_LINUX_SKU: $(AZURE_AGENT_LINUX_SKU)
+                    AZURE_AGENT_WINDOWS_SKU: $(AZURE_AGENT_WINDOWS_SKU)
+                    AZURE_AGENT_LINUX_ARM_SKU: $(AZURE_AGENT_LINUX_ARM_SKU)
+                  inputs:
+                    azureSubscription: $(azureServiceConnection)
+                    scriptType: bash
+                    scriptLocation: inlineScript
+                    inlineScript: |
+                      set -euo pipefail
+                      export AZURE_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+                      go test -v ./test/e2e/. -timeout 60m -tags=e2e -count=1 -args \
+                        -image-tag=$(TAG) \
+                        -image-registry=$(ACR_NAME) \
+                        -image-namespace=$(imageNamespace)
+                - task: AzureCLI@2
+                  displayName: Cleanup resource group
+                  condition: always()
+                  inputs:
+                    azureSubscription: $(azureServiceConnection)
+                    scriptType: bash
+                    scriptLocation: inlineScript
+                    inlineScript: |
+                      if az group exists --name "$(CLUSTER_NAME)" 2>/dev/null | grep -q true; then
+                        echo "Deleting resource group $(CLUSTER_NAME)..."
+                        az group delete --name "$(CLUSTER_NAME)" --yes --no-wait || true
+                      fi
 
           - ${{ each mode in split('basic,advanced', ',') }}:
             - job: perf_${{ mode }}


### PR DESCRIPTION
# Description

Main requires the check `CI (Build Images) (Run E2E Tests)` on every pull request. PR builds skip the e2e job, because they publish no images, and Azure DevOps posts no check for a skipped job. So the check never reports on a PR head. GitHub shows it as "Expected", the PR stays blocked, and it cannot enter the merge queue. Every open PR is in this state.

This PR makes PR builds post that check. In a PR build, the `e2e` job is a server job with the same display name: `pool.type: agentless` and one `Delay@1` step of 0 minutes. It needs no agent, completes in seconds, and Azure DevOps posts its check as success. Merge-queue runs and manual runs keep the real e2e job, so the check gates the merge in the queue. The switch is a compile-time condition on `Build.Reason`.

The real e2e job did not change. It moved under the `else` branch, so the diff re-indents it. Hide whitespace changes to review it.

## Related Issue

N/A — found on #2755, which shows the e2e check as expected and required after #2746 merged.

## Checklist

- [x] I have read the [contributing documentation](https://retina.sh/docs/Contributing/overview).
- [x] I signed and signed-off the commits (`git commit -S -s ...`). See [this documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) on signing commits.
- [x] I have correctly attributed the author(s) of the code.
- [ ] I have tested the changes locally. (N/A — pipeline-only change; the PR build of this PR is the test.)
- [x] I have followed the project's style guidelines.
- [ ] I have updated the documentation, if necessary. (N/A)
- [ ] I have added tests, if applicable. (N/A — pipeline-only change)

## Screenshots (if applicable) or Testing Completed

Both branches of the switch compile in the Azure DevOps preview API. The PR-build branch resolves the `e2e` job to `pool: server` with the display name `E2E Tests`; the other branch resolves it to the unchanged Linux job.

The PR build of this PR is the end-to-end test. On its head, GitHub lists `CI (Build Images) (Run E2E Tests)` as required and passed. The placeholder job took one second. The two failing checks are the govulncheck jobs, which fail on every PR since 2026-09-10 on a cilium advisory and are not required.

## Additional Notes

- Azure DevOps posts checks only for jobs that run. GitHub counts a skipped check as a pass, but a skipped job never produces one.
- Other open PRs stay blocked until this merges and their PR builds run again. A rebase triggers that; for dependabot PRs, comment `@dependabot rebase`.
- A PR build gains about one minute, because the placeholder job runs after the build stage.
